### PR TITLE
releng: Add Jenkins files and pod template configuration

### DIFF
--- a/releng/jenkins/pod-templates/tracecompass-pod.yaml
+++ b/releng/jenkins/pod-templates/tracecompass-pod.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: tracecompass
+    image: eclipse/tracecompass-build-env:18.04
+    imagePullPolicy: Always
+    tty: true
+    command: [ "/bin/sh" ]
+    args: ["-c", "/home/tracecompass/.vnc/xstartup.sh && cat"]
+    resources:
+      requests:
+        memory: "2.6Gi"
+        cpu: "1.3"
+      limits:
+        memory: "2.6Gi"
+        cpu: "1.3"
+    volumeMounts:
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    - name: tools
+      mountPath: /opt/tools
+  - name: jnlp
+    image: 'eclipsecbi/jenkins-jnlp-agent'
+    volumeMounts:
+    - mountPath: /home/jenkins/.ssh
+      name: volume-known-hosts
+  volumes:
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts
+  - name: settings-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: m2-repo
+    emptyDir: {}
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-tracecompass

--- a/releng/jenkins/tracecompass-jdk17-core-only.Jenkinsfile
+++ b/releng/jenkins/tracecompass-jdk17-core-only.Jenkinsfile
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+pipeline {
+    agent {
+        kubernetes {
+            label 'tracecompass-build'
+            yamlFile 'releng/jenkins/pod-templates/tracecompass-pod.yaml'
+        }
+    }
+    options {
+        timestamps()
+        timeout(time: 4, unit: 'HOURS')
+        disableConcurrentBuilds()
+    }
+    tools {
+        maven 'apache-maven-3.9.5'
+        jdk 'openjdk-jdk17-latest'
+    }
+    environment {
+        MAVEN_OPTS="-Xms768m -Xmx4096m -XX:+UseSerialGC"
+        TEST_OPTS="-Dskip-short-tc-ui-tests=true -Dskip-long-tc-ui-tests=true -Djdk.version=17 -Djdk.release=17"
+    }
+    stages {
+        stage('Build') {
+            steps {
+                container('tracecompass') {
+                    sh 'mvn clean install -B -Pctf-grammar -Pbuild-rcp -Dmaven.repo.local=/home/jenkins/.m2/repository --settings /home/jenkins/.m2/settings.xml ${MAVEN_ARGS} ${TEST_OPTS}'
+                }
+            }
+            post {
+                always {
+                    container('tracecompass') {
+                        junit '*/*/target/surefire-reports/*.xml'
+                        archiveArtifacts artifacts: '*/*tests/screenshots/*.jpeg,*/*tests/target/work/data/.metadata/.log', excludes: '**/org.eclipse.tracecompass.common.core.log', allowEmptyArchive: true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/releng/jenkins/tracecompass-jdk17-long-ui-only.Jenkinsfile
+++ b/releng/jenkins/tracecompass-jdk17-long-ui-only.Jenkinsfile
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+pipeline {
+    agent {
+        kubernetes {
+            label 'tracecompass-build'
+            yamlFile 'releng/jenkins/pod-templates/tracecompass-pod.yaml'
+        }
+    }
+    options {
+        timestamps()
+        timeout(time: 4, unit: 'HOURS')
+        disableConcurrentBuilds()
+    }
+    tools {
+        maven 'apache-maven-3.9.5'
+        jdk 'openjdk-jdk17-latest'
+    }
+    environment {
+        MAVEN_OPTS="-Xms768m -Xmx4096m -XX:+UseSerialGC"
+        TEST_OPTS="-Dskip-tc-core-tests=true -Dskip-short-tc-ui-tests=true  -Dskip-rcp=true -Djdk.version=17 -Djdk.release=17"
+    }
+    stages {
+        stage('Build') {
+            steps {
+                container('tracecompass') {
+                    sh 'mvn clean install -B -Pctf-grammar -Pbuild-rcp -Dmaven.repo.local=/home/jenkins/.m2/repository --settings /home/jenkins/.m2/settings.xml ${MAVEN_ARGS} ${TEST_OPTS}'
+                }
+            }
+            post {
+                always {
+                    container('tracecompass') {
+                        junit '*/*/target/surefire-reports/*.xml'
+                        archiveArtifacts artifacts: '*/*tests/screenshots/*.jpeg,*/*tests/target/work/data/.metadata/.log', excludes: '**/org.eclipse.tracecompass.common.core.log', allowEmptyArchive: true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/releng/jenkins/tracecompass-jdk17-short-ui-only.Jenkinsfile
+++ b/releng/jenkins/tracecompass-jdk17-short-ui-only.Jenkinsfile
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+pipeline {
+    agent {
+        kubernetes {
+            label 'tracecompass-build'
+            yamlFile 'releng/jenkins/pod-templates/tracecompass-pod.yaml'
+        }
+    }
+    options {
+        timestamps()
+        timeout(time: 4, unit: 'HOURS')
+        disableConcurrentBuilds()
+    }
+    tools {
+        maven 'apache-maven-3.9.5'
+        jdk 'openjdk-jdk17-latest'
+    }
+    environment {
+        MAVEN_OPTS="-Xms768m -Xmx4096m -XX:+UseSerialGC"
+        TEST_OPTS="-Dskip-tc-core-tests=true -Dskip-long-tc-ui-tests=true  -Dskip-rcp=true -Djdk.version=17 -Djdk.release=17"
+    }
+    stages {
+        stage('Build') {
+            steps {
+                container('tracecompass') {
+                    sh 'mvn clean install -B -Pctf-grammar -Pbuild-rcp -Dmaven.repo.local=/home/jenkins/.m2/repository --settings /home/jenkins/.m2/settings.xml ${MAVEN_ARGS} ${TEST_OPTS}'
+                }
+            }
+            post {
+                always {
+                    container('tracecompass') {
+                        junit '*/*/target/surefire-reports/*.xml'
+                        archiveArtifacts artifacts: '*/*tests/screenshots/*.jpeg,*/*tests/target/work/data/.metadata/.log', excludes: '**/org.eclipse.tracecompass.common.core.log', allowEmptyArchive: true
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
These files are supposed to be used to verify GitHub pull requests.

Add 3 Jenkins file for different Jenkins job configuration to allow to execute 3 builds with different test focus in parallel:

- tracecompass-jdk17-core-only.Jenkinsfile
- tracecompass-jdk17-long-ui-only.Jenkinsfile
- tracecompass-jdk17-short-ui-only.Jenkinsfile

Add pod-template
- tracecompass-pod.yaml

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>