### PR TITLE
Add workflows for continuous integration

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -1,0 +1,57 @@
+name: Continuous Integration (base)
+
+on:
+  workflow_call:
+    maven-opts:
+      description: maven opts to use, defaults to empty string
+      required: false
+      default: ''
+      type: string
+    maven-goals:
+        description: maven goals to use, defaults to 'clean verify'
+        required: false
+        default: 'clean install'
+        type: string
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.5
+    - name: Build with Maven
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      with:
+       run: >- 
+        mvn -B -Pctf-grammar -Pbuild-rcp ${{ inputs.maven-opts }}
+        -Djdk.version=17 
+        -Djdk.release=17
+        ${{ inputs.maven-goals }}
+    - name: Upload logs
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: build logs
+        path: |
+          */*tests/screenshots/*.jpeg
+          */*tests/target/work/data/.metadata/.log
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test results
+        path: |
+          */*/target/surefire-reports/*.xml

--- a/.github/workflows/ci-core-tests-only.yml
+++ b/.github/workflows/ci-core-tests-only.yml
@@ -1,0 +1,55 @@
+name: Continuous Integration (core tests only)
+
+on:
+  push:
+    branches:
+      - master
+      - stable-*
+  pull_request:
+    branches:
+      - master
+      - stable-*
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.5
+    - name: Build with Maven
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      with:
+       run: >- 
+        mvn -B -Pctf-grammar -Pbuild-rcp
+        -Dskip-short-tc-ui-tests=true
+        -Dskip-long-tc-ui-tests=true
+        clean install
+    - name: Upload logs
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: build logs
+        path: |
+          */*tests/screenshots/*.jpeg
+          */*tests/target/work/data/.metadata/.log
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test results
+        path: |
+          */*/target/surefire-reports/*.xml

--- a/.github/workflows/ci-long-ui-tests-only.yml
+++ b/.github/workflows/ci-long-ui-tests-only.yml
@@ -1,0 +1,56 @@
+name: Continuous Integration (long-ui tests only)
+
+on:
+  push:
+    branches:
+      - master
+      - stable-*
+  pull_request:
+    branches:
+      - master
+      - stable-*
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.5
+    - name: Build with Maven
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      with:
+       run: >- 
+        mvn -B -Pctf-grammar -Pbuild-rcp
+        -Dskip-tc-core-tests=true
+        -Dskip-short-tc-ui-tests=true
+        -Dskip-rcp=true
+        clean install
+    - name: Upload logs
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: build logs
+        path: |
+          */*tests/screenshots/*.jpeg
+          */*tests/target/work/data/.metadata/.log
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test results
+        path: |
+          */*/target/surefire-reports/*.xml

--- a/.github/workflows/ci-short-ui-tests-only.yml
+++ b/.github/workflows/ci-short-ui-tests-only.yml
@@ -1,0 +1,56 @@
+name: Continuous Integration (short-ui tests only)
+
+on:
+  push:
+    branches: 
+      - master
+      - stable-*
+  pull_request:
+    branches:
+      - master
+      - stable-*
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.5
+    - name: Build with Maven
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      with:
+       run: >- 
+        mvn -B -Pctf-grammar -Pbuild-rcp
+        -Dskip-tc-core-tests=true
+        -Dskip-long-tc-ui-tests=true
+        -Dskip-rcp=true
+        clean install
+    - name: Upload logs
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: build logs
+        path: |
+          */*tests/screenshots/*.jpeg
+          */*tests/target/work/data/.metadata/.log
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test results
+        path: |
+          */*/target/surefire-reports/*.xml

--- a/releng/org.eclipse.tracecompass.integration.swtbot.tests/src/org/eclipse/tracecompass/integration/swtbot/tests/projectexplorer/ProjectExplorerTracesFolderTest.java
+++ b/releng/org.eclipse.tracecompass.integration.swtbot.tests/src/org/eclipse/tracecompass/integration/swtbot/tests/projectexplorer/ProjectExplorerTracesFolderTest.java
@@ -1639,6 +1639,7 @@ public class ProjectExplorerTracesFolderTest {
     }
 
     private static SWTBotShell openWorkbenchMenuImport() {
+        SWTBotUtils.focusMainWindow(fBot.shells());
         fBot.menu().menu("File", "Import...").click();
 
         SWTBot shellBot = fBot.shell("Import").activate().bot();

--- a/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/src/org/eclipse/tracecompass/tmf/ui/swtbot/tests/viewers/events/TestRefreshTextTrace.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/src/org/eclipse/tracecompass/tmf/ui/swtbot/tests/viewers/events/TestRefreshTextTrace.java
@@ -111,12 +111,14 @@ public class TestRefreshTextTrace {
 
             // Force resource refresh and ignore trace change
             fBot.viewByTitle("Project Explorer").show();
+            SWTBotUtils.focusMainWindow(fBot.shells());
             fBot.menu().menu("File", "Refresh").click();
             fBot.shell("Trace Changed").activate().bot().button("No").click();
 
             // Refresh
             SWTBotEditor eventsEditor = SWTBotUtils.activeEventsEditor(fBot);
             eventsEditor.show();
+            SWTBotUtils.focusMainWindow(fBot.shells());
             fBot.menu().menu("File", "Refresh").click();
 
             // Make sure the refresh is completed


### PR DESCRIPTION
Add 3 workflows for different test focus which run in parallel:

- ci-core-test-only.yml
- ci-long-ui-test-only.yml
- ci-short-ui-test-only.yml

Add a ci-base.yml for future configuration as reusable workflows. This
file needs to be merged before configuring the other ci workflows for
it.

Updating some SwtBot tests to fix flakiness.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>