### PR TITLE
Fix references to new Trace Compass wiki location and doc updates

### DIFF
--- a/API_POLICY.md
+++ b/API_POLICY.md
@@ -47,4 +47,4 @@ API clients should follow the Trace Compass [New&Noteworthy][nan] for each relea
 [example-patch]: https://git.eclipse.org/r/c/tracecompass/org.eclipse.tracecompass/+/193428
 [issues]: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/issues
 [mail]: https://www.eclipse.org/lists/tracecompass-dev/msg01661.html
-[nan]: https://wiki.eclipse.org/Trace_Compass/NewInTraceCompass
+[nan]: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/New_In_Trace_Compass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ information about building the application see the description in the
 [BUILDING](BUILDING.md) file.
 
 ## Source code tree
+
 This source tree contains the source code for the Trace Compass plugins for
 Eclipse.
 
@@ -151,7 +152,7 @@ Other commit information:
 * Not a hard requirement, but we normally prefix the commit titles with the name of the component to which the patch applies, in lowercase. This normally corresponds to the plugin name, so "lttng: xxxx" or "tmf: xxxx".
 * If the patch is significant enough to have a mention in the New & Noteworthy, annotate the patch with `[Fixed]`, `[Added]`, `[Changed]`, `[Deprecated]`, or `[Security]` with a short description of what the change does.
 
-# API policy
+## API policy
 
 For more information about the API policies, read the [API_POLICY](API_POLICY.md) file.
 
@@ -160,7 +161,7 @@ For more information about the API policies, read the [API_POLICY](API_POLICY.md
 Contact the project developers via the [project's "dev" mailing list][mailing-list] or open an [issue tracker][issues].
 
 [bugzilla]: https://bugs.eclipse.org/bugs/buglist.cgi?product=Tracecompass
-[code-style]: https://wiki.eclipse.org/Trace_Compass/Code_Style
+[code-style]: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Coding_style
 [commit-message-message]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [commiter-handbook]: https://www.eclipse.org/projects/handbook/#resources-commit
 [creating-changes]: https://www.dataschool.io/how-to-contribute-on-github/

--- a/DEVELOPMENT_ENV_SETUP.md
+++ b/DEVELOPMENT_ENV_SETUP.md
@@ -25,10 +25,11 @@ After the Eclipse workbench is installed and launched, wait for the `Executing s
 Under [eclipse.org download packages](https://www.eclipse.org/downloads/packages/), select the `Eclipse IDE for Eclipse Committers` archive. You can start with any Eclipse pre-package, but make sure you have the `Eclipse Plug-in Development Environment` feature installed.
 
 Uncompress and start Eclipse. Example for Linux:
-```
-$ tar xzvf eclipse-committers-2023-12-R-linux-gtk-x86_64.tar.gz 
-$ cd eclipse
-$ ./eclipse
+
+```bash
+tar xzvf eclipse-committers-2023-12-R-linux-gtk-x86_64.tar.gz 
+cd eclipse
+./eclipse
 ```
 
 The first time you run it, it will ask for a workspace directory. You can use the default location.
@@ -39,8 +40,8 @@ You will then be greeted by the welcome screen, which you can dismiss by clickin
 
 `Trace Compass` uses source compatibility to Java 11. However, to run the eclipse.org download packages RCP and to develop it, Java 17 is required. Here is how to install Java 17 on recent Ubuntu:
 
-```
-$ sudo apt-get install openjdk-17-jdk
+``` bash
+sudo apt-get install openjdk-17-jdk
 ```
 
 For old versions of Ubuntu, install from the [OpenJDK PPA](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa).
@@ -55,9 +56,11 @@ Next, the JRE must be added in Eclipse.
 Note: if you migrate your environment to Java 17, existing debug and run configurations will continue to use the previous JRE. To use the new JRE, open the run configuration pannel `Run -> Run configurations...` and from the tab "Main", select the appropriate JRE under "Java Runtime Environment -> Execution environment".
 
 ### Setup Maven
+
 To be able run a Maven build from command-line, Maven version v3.9.x or later needs to be installed. Follow the [installation guide](https://maven.apache.org/install.html) for that.
 
 ### Setup Maven Plug-ins
+
 When developing for the `Trace Compass incubator` project, make sure to install the `M2E` plug-ins to your Eclipse IDE. You can omit these steps if not developing incubator features. This is a recent addition to `M2E` and requires an `Eclipse IDE 2021-06` or later.
 
 To install `M2E`, select menu `Help -> Install New Software...`. An `Install` dialog will open. Select the release update site from the `Work with` drop-down menu. For example, if your IDE is based on `Eclipse 2023-03` then select `2023-03 - http://download.eclipse.org/releases/2023-03`. Then select `M2E- Integration for Eclipse` and `M2E - PDE Integration` and select `Next` button and the `Finish`. Restart Eclipse when asked for it.
@@ -67,9 +70,9 @@ To install `M2E`, select menu `Help -> Install New Software...`. An `Install` di
 First, make sure you have a Git client installed (either the git command-line tool, or the [Eclipse Git Team Provider](http://www.eclipse.org/egit/) plugin, also available in Eclipse's `Install New Software`.
 
 Then, simply clone the following repository somewhere on your hard drive:
-* https://github.com/eclipse-tracecompass/org.eclipse.tracecompass
+* <https://github.com/eclipse-tracecompass/org.eclipse.tracecompass>
 
-```
+```bash
 git clone https://github.com/eclipse-tracecompass/org.eclipse.tracecompass.git
 ```
 
@@ -77,15 +80,15 @@ If adding tests that require an actual trace, then it should be added to the fol
 
 * https://github.com/eclipse-tracecompass/tracecompass-test-traces
 
-```
+```bash
 git clone https://github.com/eclipse-tracecompass/tracecompass-test-traces.git
-``` 
+```
 
 Extra functionalities are developed in the `Trace Compass Incubator` sub-project. If interested in any of those feature, the following repository can be cloned
 
 * https://git.eclipse.org/c/tracecompass.incubator/org.eclipse.tracecompass.incubator.git/
 
-```
+```bash
 git clone https://git.eclipse.org/r/tracecompass.incubator/org.eclipse.tracecompass.incubator.git
 ```
 
@@ -101,6 +104,7 @@ git clone https://git.eclipse.org/r/tracecompass.incubator/org.eclipse.tracecomp
 You will probably get a bunch of build errors at this point. DON'T PANIC! This is because `Trace Compass` needs additional dependencies that might not be present in your current Eclipse installation. We will install those in the following section.
 
 ### Setting the Target Platform
+
 Eclipse offers the ability to set target platforms, which will download a specific environment to run your plugins, without having to "pollute" your Eclipse install. `Trace Compass` ships target definition files, which is the recommended way of installing its dependencies.
 
 To set the target platform for the `Trace Compass` plugins:
@@ -139,9 +143,10 @@ If you imported the *.help plugins (which contain the user and developer guides)
 
 You can now build the documentation plugins using maven build from the command-line from the `Trace Compass` root directory:
 
+```bash
+mvn clean install -DskipTests=true
 ```
-$ mvn clean install -DskipTests=true
-```
+
 After it is built, the warning should disappear, and the HTML files should be present in its `doc/` subdirectory.
 
 Note that this builder does not run automatically ; Ant is not very smart at figuring out which files were changed, so it would end up constantly rebuilding the doc plugins for nothing. For this reason, if you modify the source (.mediawiki) files, you will have to rebuild the HTML manually, using the same method.
@@ -178,6 +183,7 @@ You can also consult the static analysis results at:
 * [Trace Compass Incubator at sonarcloud.io](https://sonarcloud.io/project/overview?id=org.eclipse.tracecompass.incubator)
 
 ### Setup virtual display on Ubuntu ==
+
 * Install Xephyr and Metacity: sudo apt-get install xserver-xephyr metacity
 * Start the virtual display: Xephyr :2 -screen 1024x768 &
 * Setup environment: export DISPLAY=:2

--- a/DEVELOPMENT_ENV_SETUP.md
+++ b/DEVELOPMENT_ENV_SETUP.md
@@ -92,7 +92,7 @@ Extra functionalities are developed in the `Trace Compass Incubator` sub-project
 git clone https://git.eclipse.org/r/tracecompass.incubator/org.eclipse.tracecompass.incubator.git
 ```
 
-= Import the `Trace Compass` projects into the workspace =
+### Import the `Trace Compass` projects into the workspace
 
 * Select `File -> Import...`
 * Select `General -> Existing Projects into Workspace`
@@ -151,7 +151,7 @@ After it is built, the warning should disappear, and the HTML files should be pr
 
 Note that this builder does not run automatically ; Ant is not very smart at figuring out which files were changed, so it would end up constantly rebuilding the doc plugins for nothing. For this reason, if you modify the source (.mediawiki) files, you will have to rebuild the HTML manually, using the same method.
 
-### Running (or Debugging) the plugins =
+### Running (or Debugging) the plugins
 
 To run (or debug) the code, start a nested Eclipse with the plugins loaded:
 
@@ -171,7 +171,7 @@ The next time you can just select `Eclipse Application` or `tracing.product` fro
 
 Before submitting a PR to GitHub, it may be useful to validate changes for possible regression. Running the GUI tests opens windows that will interfere with the main desktop session. On Linux, the windows can be redirected to a virtual display.
 
-### Static code verification ==
+### Static code verification
 
 In the testing phase, it is suggested to use [Findbugs](http://www.vogella.com/tutorials/Findbugs/article.html FindBugs) to check the code for common errors. Coding conventions are checked with Checkstyle. Bad practices are verified by (PMD).
 
@@ -182,7 +182,7 @@ You can also consult the static analysis results at:
 * [Trace Compass at sonarcloud.io](https://sonarcloud.io/project/overview?id=org.eclipse.tracecompass)
 * [Trace Compass Incubator at sonarcloud.io](https://sonarcloud.io/project/overview?id=org.eclipse.tracecompass.incubator)
 
-### Setup virtual display on Ubuntu ==
+### Setup virtual display on Ubuntu
 
 * Install Xephyr and Metacity: sudo apt-get install xserver-xephyr metacity
 * Start the virtual display: Xephyr :2 -screen 1024x768 &

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ domain-specific trace formats and use cases.
 
 For more information about the key features, see [Trace Compass website](https://eclipse.dev/tracecompass/).
 
-Also, check-out the [user guides and developer guides](https://wiki.eclipse.org/Trace_Compass#User_Guides).
+Also, check-out the [user guides and developer guides](https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki#user-guides).
 
 <img src="doc/images/tc-screenshot.png" width="66%">
 
 ## Releases
 
-Information about releases can be found on the [Trace Compass project](https://projects.eclipse.org/projects/tools.tracecompass) page at Eclipse.org. 
+Information about releases can be found on the [Trace Compass project](https://projects.eclipse.org/projects/tools.tracecompass) page at Eclipse.org.
 
-See [New & Noteworthy](https://wiki.eclipse.org/Trace_Compass/NewInTraceCompass)
+See [New & Noteworthy](https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/New_In_Trace_Compass)
 for release details.
 
 ## Downloads
@@ -31,13 +31,12 @@ for release details.
 `Eclipse Trace Compass` is available as plug-ins that can be installed to an
 Eclipse IDE, as well as standalone application.
 
-Check [Downloads](https://projects.eclipse.org/projects/tools.tracecompass/downloads) 
-for downloading specific versions of Trace Compass.
+Check [Downloads](https://projects.eclipse.org/projects/tools.tracecompass/downloads) for downloading specific versions of Trace Compass.
 
 ## Contributing to Trace Compass
 
 **👋 Want to help?** Read our [contributor guide](CONTRIBUTING.md) and follow the
-instructions to contribute code. 
+instructions to contribute code.
 
 You will also find there information about the `setup of the development environment`,
 `build instructions`, the `development and review process` as well as the `API policy`.

--- a/doc/org.eclipse.tracecompass.doc.dev/doc/Developer-Guide.mediawiki
+++ b/doc/org.eclipse.tracecompass.doc.dev/doc/Developer-Guide.mediawiki
@@ -2729,7 +2729,7 @@ public class OpenSDView extends AbstractHandler {
 
 === Downloading the Tutorial ===
 
-Use the following link to download the source code of the tutorial [https://wiki.eclipse.org/images/7/79/SamplePluginTC.zip Plug-in of Tutorial].
+Use the following link to download the source code of the tutorial [https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/media/SamplePluginTC.zip Plug-in of Tutorial].
 
 == Integration of Tracing and Monitoring Framework with Sequence Diagram Framework ==
 
@@ -2840,7 +2840,7 @@ The analysis looks for event type Strings containing ''SEND'' and ''RECEIVE''. I
 
 === How to use the Reference Implementation ===
 
-An example CTF (Common Trace Format) trace is provided that contains trace events with sequence diagram information. To download the reference trace, use the following link: [https://wiki.eclipse.org/images/3/35/ReferenceTrace.zip Reference Trace].
+An example CTF (Common Trace Format) trace is provided that contains trace events with sequence diagram information. To download the reference trace, use the following link: [https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/media/ReferenceTrace.zip Reference Trace].
 
 Run an Eclipse application with Trace Compass 0.1.0 or later installed. To open the Reference Sequence Diagram View, select '''Windows -> Show View -> Other... -> Tracing -> Sequence Diagram''' <br>
 [[Image:images/ShowTmfSDView.png]]<br>


### PR DESCRIPTION
- Fix references to new Trace Compass wiki location
  New location of wiki is: 
  https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki

  Fix also linter warnings in corresponding Markdown files.

- doc: remove mediawiki tags from DEVELOPMENT_SETUP.md
  Fixes #12

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>