### PR TITLE
tmf: Fix for times requested before start time

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
@@ -119,11 +119,14 @@ public class TmfStateStatistics implements ITmfStatistics {
         }
         List<Long> times = new ArrayList<>();
         for (int i = 0; i < timeRequested.length; i++) {
-            if (timeRequested[i] > fTotalsStats.getCurrentEndTime()) {
+            if (timeRequested[i] < fTotalsStats.getStartTime()) {
+                times.add(fTotalsStats.getStartTime());
+            } else if (timeRequested[i] < fTotalsStats.getCurrentEndTime()) {
+                times.add(timeRequested[i]);
+            } else {
                 times.add(fTotalsStats.getCurrentEndTime());
                 break;
             }
-            times.add(timeRequested[i]);
         }
         try (FlowScopeLog log = new FlowScopeLogBuilder(LOGGER, Level.FINE, "StateStatistics:histogramQuery").build()) { //$NON-NLS-1$
             Iterable<@NonNull ITmfStateInterval> intervals = fTotalsStats.query2D(Collections.singletonList(quark), times);


### PR DESCRIPTION
When requested times are below the start time of the state system when doing a query2d, it throws an error. This patch fixes that issue by replace with the start time when doing the query2d.

[Fixes] #18