### PR TITLE
ctf: support out of spec index files from LTTng

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFStreamInput.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFStreamInput.java
@@ -108,14 +108,13 @@ public class CTFStreamInput implements IDefinitionScope {
      *            The stream to which this StreamInput belongs to.
      * @param file
      *            Information about the trace file (for debugging purposes).
-     * @since 2.0
+     * @since 4.5
      */
-    public CTFStreamInput(ICTFStream stream, File file) {
+    public CTFStreamInput(ICTFStream stream, File file, StreamInputPacketIndex index) {
         fStream = stream;
         fFile = file;
         fFileName = fFile.getName();
-
-        fIndex = new StreamInputPacketIndex();
+        fIndex = index;
         /*
          * Create the definitions we need to read the packet headers + contexts
          */
@@ -131,6 +130,19 @@ public class CTFStreamInput implements IDefinitionScope {
         } else {
             fStreamPacketContextDecl = new StructDeclaration(1);
         }
+    }
+
+    /**
+     * Constructs a StreamInput.
+     *
+     * @param stream
+     *            The stream to which this StreamInput belongs to.
+     * @param file
+     *            Information about the trace file (for debugging purposes).
+     * @since 2.0
+     */
+    public CTFStreamInput(ICTFStream stream, File file) {
+        this(stream, file, new StreamInputPacketIndex());
     }
 
     // ------------------------------------------------------------------------

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/ICTFPacketDescriptor.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/ICTFPacketDescriptor.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.ctf.core.event.types.ICompositeDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.StructDefinition;
 
 /**
  * CTF Packet descriptor, can come from a packet context or an index file, this
@@ -102,6 +103,17 @@ public interface ICTFPacketDescriptor {
      */
     default @Nullable ICompositeDefinition getStreamPacketContextDef() {
         return null;
+    }
+
+    /**
+     * Set the packet context definition.
+     *
+     * @param streamPacketContextDef
+     *            the packet context to store in the descriptor.
+     * @since 4.5
+     */
+    default void setStreamPacketContextDef(StructDefinition streamPacketContextDef) {
+        // Do nothing
     }
 
     /**

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/trace/CTFIndexFile.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/trace/CTFIndexFile.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2024 Ericsson, École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Matthew Khouzam - Initial implementation
+ *   Arnaud Fiorini - Update to make it work with later LTTng versions
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.internal.ctf.core.trace;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.ctf.core.event.types.StructDeclaration;
+import org.eclipse.tracecompass.ctf.core.trace.CTFIOException;
+
+/**
+ * Ctf index file reader
+ *
+ * @author Matthew Khouzam
+ */
+public class CTFIndexFile {
+
+    private static final int CTF_INDEX_MAGIC = 0xC1F1DCC1;
+    private static final int CTF_INDEX_MAJOR = 1;
+    private static final int CTF_INDEX_MINOR = 1;
+    private static final int PACKET_SIZE = 9 * Long.SIZE / 8;
+
+    private final @NonNull StreamInputPacketIndex fIndex;
+
+    /**
+     * Ctf index file reader
+     *
+     * @param indexFile
+     *            The {@Link File} input
+     * @param tracePacketHeaderDecl
+     *            The struct information for the trace packet header
+     * @param packetContextDecl
+     *            The struct information for the packet context
+     * @throws CTFIOException
+     *             an error such as an {@link IOException}
+     */
+    public CTFIndexFile(File indexFile, StructDeclaration tracePacketHeaderDecl, StructDeclaration packetContextDecl) throws CTFIOException {
+        try (DataInputStream dataIn = new DataInputStream(new FileInputStream(indexFile))) {
+            CtfPacketIndexFileHeader header;
+
+            header = new CtfPacketIndexFileHeader(dataIn);
+            fIndex = new StreamInputPacketIndex();
+            long packetHeaderBits = (long) tracePacketHeaderDecl.getMaximumSize() + packetContextDecl.getMaximumSize();
+            while (dataIn.available() >= header.packetIndexLen) {
+                StreamInputPacketIndexEntry element;
+                if (header.oldMagic) {
+                    element = new StreamInputPacketIndexEntry(dataIn, packetHeaderBits, indexFile.getName().replace("\\.idx", "")); //$NON-NLS-1$ //$NON-NLS-2$
+                } else {
+                    element = new StreamInputPacketIndexEntry(dataIn, packetHeaderBits);
+                }
+                fIndex.append(element);
+            }
+        } catch (IOException e) {
+            throw new CTFIOException(e);
+        }
+    }
+
+    /**
+     * Gets the packet entries of this file
+     *
+     * @return the packet entries of this file
+     */
+    public @NonNull StreamInputPacketIndex getStreamInputPacketIndex() {
+        return fIndex;
+    }
+
+    /**
+     * Header at the beginning of each index file. All integer fields are stored
+     * in big endian.
+     */
+    class CtfPacketIndexFileHeader {
+        private final int magic;
+        private final int indexMajor;
+        private final int indexMinor;
+        /* CtfPacketIndexEntry, in bytes */
+        private final int packetIndexLen;
+        private final boolean oldMagic;
+
+        public CtfPacketIndexFileHeader(DataInputStream dataIn) throws IOException, CTFIOException {
+            magic = dataIn.readInt();
+            if (magic != CTF_INDEX_MAGIC) {
+                if (magic == 0x43544649) {
+                    oldMagic = (dataIn.readShort() == 0x4458);
+                } else {
+                    oldMagic = false;
+                }
+                if (!oldMagic) {
+                    throw new CTFIOException("Magic mismatch in index"); //$NON-NLS-1$
+                }
+            } else {
+                oldMagic = false;
+            }
+            indexMajor = dataIn.readInt();
+            if (indexMajor != CTF_INDEX_MAJOR) {
+                throw new CTFIOException("Major version mismatch in index"); //$NON-NLS-1$
+            }
+            indexMinor = dataIn.readInt();
+            if (indexMinor != CTF_INDEX_MINOR) {
+                throw new CTFIOException("Minor version mismatch in index"); //$NON-NLS-1$
+            }
+            if (!oldMagic) {
+                packetIndexLen = dataIn.readInt();
+            } else {
+                packetIndexLen = PACKET_SIZE;
+            }
+            if (packetIndexLen != PACKET_SIZE) {
+                throw new CTFIOException("Packet size wrong in index"); //$NON-NLS-1$
+            }
+        }
+    }
+}

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core.tests/src/org/eclipse/tracecompass/tmf/ctf/core/tests/trace/CtfTmfTraceTest.java
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core.tests/src/org/eclipse/tracecompass/tmf/ctf/core/tests/trace/CtfTmfTraceTest.java
@@ -67,6 +67,7 @@ public class CtfTmfTraceTest {
     @BeforeClass
     public static void setUp() {
         fixture = CtfTmfTestTraceUtils.getTrace(testTrace);
+        fixture.seekEvent(fixture.readEnd());
     }
 
     /**
@@ -213,18 +214,20 @@ public class CtfTmfTraceTest {
     public void testGetLocationRatio() {
         ITmfContext context = fixture.seekEvent(0);
         long t1 = ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp();
-        fixture.getNext(context);
+        double ratio1 = 0.4;
+        context = fixture.seekEvent(ratio1);
         long t2 = ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp();
-        fixture.getNext(context);
+        long tMid = (fixture.getEndTime().getValue() - fixture.getStartTime().getValue()) / 2 + fixture.getStartTime().getValue();
+        double ratio2 = 0.7;
+        context = fixture.seekEvent(ratio2);
         long t3 = ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp();
-        fixture.getNext(context);
         context.dispose();
-        double ratio1 = fixture.getLocationRatio(new CtfLocation(t1, 0));
-        assertEquals(0.0, ratio1, 0.01);
-        double ratio2 = fixture.getLocationRatio(new CtfLocation(t2, 0));
-        assertEquals((double) (t2 - t1) / (t3 - t1), ratio2, 0.01);
-        double ratio3 = fixture.getLocationRatio(new CtfLocation(t3, 0));
-        assertEquals(1.0, ratio3, 0.01);
+
+        assertEquals(0.0, fixture.getLocationRatio(new CtfLocation(t1, 0)), 0.01);
+        assertEquals(ratio1, fixture.getLocationRatio(new CtfLocation(t2, 0)), 0.01);
+        assertEquals(0.5, fixture.getLocationRatio(new CtfLocation(tMid, 0)), 0.01);
+        assertEquals(ratio2, fixture.getLocationRatio(new CtfLocation(t3, 0)), 0.01);
+        assertEquals(1.0, fixture.getLocationRatio(new CtfLocation(fixture.getEndTime(), 0)), 0.01);
     }
 
     /**
@@ -252,7 +255,7 @@ public class CtfTmfTraceTest {
     @Test
     public void testGetNbEvents() {
         long result = fixture.getNbEvents();
-        assertEquals(1L, result);
+        assertEquals(695319L, result);
     }
 
     /**
@@ -328,21 +331,26 @@ public class CtfTmfTraceTest {
     @Test
     public void testSeekEvent_ratio() {
         ITmfContext context = fixture.seekEvent(0);
-        long t1 = ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp();
-        fixture.getNext(context);
-        long t2 = ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp();
-        fixture.getNext(context);
-        long t3 = ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp();
-        fixture.getNext(context);
+        assertEquals(fixture.getStartTime().getValue(), ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp());
         context.dispose();
-        context = fixture.seekEvent(0.0);
-        assertEquals(t1, ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp());
+
+        double ratio1 = 0.3;
+        context = fixture.seekEvent(ratio1);
+        assertEquals(ratio1, fixture.getLocationRatio(context.getLocation()), 0.01);
         context.dispose();
+
         context = fixture.seekEvent(0.5);
-        assertEquals(t2, ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp());
+        long tMid = (fixture.getEndTime().getValue() - fixture.getStartTime().getValue()) / 2 + fixture.getStartTime().getValue();
+        assertEquals(tMid, ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp(), 1000);
         context.dispose();
+
+        double ratio2 = 0.7;
+        context = fixture.seekEvent(ratio2);
+        assertEquals(ratio2, fixture.getLocationRatio(context.getLocation()), 0.01);
+        context.dispose();
+
         context = fixture.seekEvent(1.0);
-        assertEquals(t3, ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp());
+        assertEquals(fixture.getEndTime().getValue(), ((CtfLocationInfo) context.getLocation().getLocationInfo()).getTimestamp());
         context.dispose();
     }
 

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/trace/CtfTmfTrace.java
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/trace/CtfTmfTrace.java
@@ -235,7 +235,8 @@ public class CtfTmfTrace extends TmfTrace
             } else {
                 final ITmfTimestamp curTime = event.getTimestamp();
                 this.setStartTime(curTime);
-                this.setEndTime(curTime);
+                long endTime = Math.max(curTime.getValue(), fTrace.getCurrentEndTime());
+                this.setEndTime(TmfTimestamp.fromNanos(endTime));
             }
             /*
              * Register every event type. When you call getType, it will register a trace to


### PR DESCRIPTION
IDX files were added to help speed up trace indexing. This patch will load them. This patch should not affect the system performance, but might lay down some groundwork to improve streaming performance.

The index format is not yet part of the CTF standard, but is described here:
https://git.efficios.com/?p=babeltrace.git;a=blob;f=src/plugins/ctf/fs-src/lttng-index.hpp;h=36dc7cc934d46366aa12ebf7b13f239e8699eacb;hb=HEAD