### PR TITLE
callstack.core: Add arrows to flamechart test

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/flamegraph/AggregationTreeTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/flamegraph/AggregationTreeTest.java
@@ -91,6 +91,7 @@ public class AggregationTreeTest {
         assertNotNull(threads);
         assertEquals("Number of threads found", 0, threads.size());
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**
@@ -162,6 +163,7 @@ public class AggregationTreeTest {
         assertEquals("Test second function's nombre of calls", 1, secondFunction.getNbCalls());
         assertEquals("Test third function's nombre of calls", 1, thirdFunction.getNbCalls());
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**
@@ -236,6 +238,7 @@ public class AggregationTreeTest {
         assertEquals("Test second function's number of calls", 2, secondFunction.getNbCalls());
         assertEquals("Test third function's number of calls", 1, thirdFunction.getNbCalls());
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**
@@ -322,6 +325,7 @@ public class AggregationTreeTest {
         assertEquals("Test first leaf's number of calls", 1, leaf1.getNbCalls());
         assertEquals("Test second leaf's number of calls", 1, leaf2.getNbCalls());
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**
@@ -438,6 +442,7 @@ public class AggregationTreeTest {
         assertEquals("Test second child's number of calls", 1, function3.getNbCalls());
         assertEquals("Test leaf's number of calls", 2, function4.getNbCalls());
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**
@@ -480,6 +485,7 @@ public class AggregationTreeTest {
             parent = child;
         }
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**
@@ -553,6 +559,7 @@ public class AggregationTreeTest {
         assertEquals("Test second function's number of calls", 1, function2.getNbCalls());
         assertEquals("Test third function's number of calls", 1, function3.getNbCalls());
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**
@@ -634,6 +641,7 @@ public class AggregationTreeTest {
         assertEquals("Test third function's number of calls", 1, function3.getNbCalls());
         assertEquals("Test third function's number of calls", 1, function4.getNbCalls());
         cga.dispose();
+        fCsa.dispose();
     }
 
     /**

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs2/CallStackAnalysisStub.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs2/CallStackAnalysisStub.java
@@ -12,9 +12,15 @@
 package org.eclipse.tracecompass.analysis.profiling.core.tests.stubs2;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.analysis.os.linux.core.model.HostThread;
+import org.eclipse.tracecompass.internal.analysis.profiling.core.instrumented.EdgeStateValue;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.instrumented.InstrumentedCallStackAnalysis;
+import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.statesystem.core.tests.shared.utils.StateIntervalStub;
 import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 
@@ -42,5 +48,24 @@ public class CallStackAnalysisStub extends InstrumentedCallStackAnalysis {
     @Override
     public List<String[]> getPatterns() {
         return super.getPatterns();
+    }
+
+    @Override
+    public List<ITmfStateInterval> getLinks(long start, long end, IProgressMonitor monitor) {
+        String hostId = getHostId();
+        HostThread tid2 = new HostThread(hostId, 2);
+        HostThread tid3 = new HostThread(hostId, 3);
+        HostThread tid6 = new HostThread(hostId, 6);
+        HostThread tid7 = new HostThread(hostId, 7);
+
+        List<ITmfStateInterval> intervals = List.of(new StateIntervalStub(1, 2, new EdgeStateValue(1, tid2, tid2)),
+                new StateIntervalStub(4, 6, new EdgeStateValue(2, tid2, tid3)),
+                new StateIntervalStub(5, 8, new EdgeStateValue(3, tid3, tid6)),
+                new StateIntervalStub(5, 9, new EdgeStateValue(4, tid6, tid7)),
+                new StateIntervalStub(9, 11, new EdgeStateValue(5, tid6, tid6)));
+
+        return intervals.stream()
+                .filter(i -> (i.getStartTime() >= start && i.getStartTime() <= end) || (i.getEndTime() >= start && i.getEndTime() <= end))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
This patch adds arrow in the CallStackProviderStub to test the data provider. It also adds checks for arrows in the testFetchModel of the FlameChartDataProviderTest