### PR TITLE
tmf: Fix statistics queries when there is no intervals

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
@@ -117,40 +117,63 @@ public class TmfStateStatistics implements ITmfStatistics {
         if (quark == ITmfStateSystem.INVALID_ATTRIBUTE) {
             return Collections.emptyList();
         }
-        List<Long> times = new ArrayList<>();
+        List<@NonNull Long> times = new ArrayList<>();
         for (int i = 0; i < timeRequested.length; i++) {
+            /* create padding for every window of time before the start time */
             if (timeRequested[i] < fTotalsStats.getStartTime()) {
-                times.add(fTotalsStats.getStartTime());
-            } else if (timeRequested[i] < fTotalsStats.getCurrentEndTime()) {
-                times.add(timeRequested[i]);
+                list.add(0L);
             } else {
+                if (!list.isEmpty()) {
+                    /* replace this bucket with the [start time, next time] */
+                    times.add(fTotalsStats.getStartTime());
+                    list.remove(list.size() - 1);
+                }
+                times.add(timeRequested[i]);
+            }
+            if (timeRequested[i] > fTotalsStats.getCurrentEndTime()) {
                 times.add(fTotalsStats.getCurrentEndTime());
                 break;
             }
         }
         try (FlowScopeLog log = new FlowScopeLogBuilder(LOGGER, Level.FINE, "StateStatistics:histogramQuery").build()) { //$NON-NLS-1$
+            addHistogramValuesFromQuery2d(quark, times, list);
+            /* Padding for after trace ends */
+            for (int i = list.size(); i < timeRequested.length; i++) {
+                list.add(0L);
+            }
+            return list;
+        }
+    }
+
+    private List<@NonNull Long> addHistogramValuesFromQuery2d(int quark, List<@NonNull Long> times, List<@NonNull Long> results) {
+        try {
             Iterable<@NonNull ITmfStateInterval> intervals = fTotalsStats.query2D(Collections.singletonList(quark), times);
             List<@NonNull ITmfStateInterval> sortedIntervals = Lists.newArrayList(intervals);
+            if (sortedIntervals.isEmpty()) {
+                return results;
+            }
             sortedIntervals.sort(Comparator.comparingLong(ITmfStateInterval::getStartTime));
-            int j = 0;
             long previousTotal;
-            if (!sortedIntervals.isEmpty() && fTotalsStats.getStartTime() != sortedIntervals.get(0).getStartTime()) {
+            if (fTotalsStats.getStartTime() != sortedIntervals.get(0).getStartTime()) {
                 previousTotal = sortedIntervals.get(0).getValueInt();
             } else {
                 previousTotal = 0;
             }
-            for (int i = 0; i < timeRequested.length; i++) {
-                while (j < sortedIntervals.size() - 1 && sortedIntervals.get(j).getEndTime() < timeRequested[i]) {
+            int j = 0;
+            for (int i = 0; i < times.size(); i++) {
+                while (j < sortedIntervals.size() - 1 && sortedIntervals.get(j).getEndTime() < times.get(i)) {
                     j++;
                 }
                 long count = sortedIntervals.get(j).getValueInt() - previousTotal;
-                list.add(count);
+                results.add(count);
                 previousTotal = sortedIntervals.get(j).getValueInt();
             }
-            return list;
+            return results;
         } catch (StateSystemDisposedException e) {
-            /* Assume there is no events, nothing will be put in the histogram. */
-            return Collections.emptyList();
+            /*
+             * Assume there is no events, nothing will be put in the histogram.
+             */
+            return results;
         }
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
@@ -155,7 +155,7 @@ public class TmfStateStatistics implements ITmfStatistics {
             sortedIntervals.sort(Comparator.comparingLong(ITmfStateInterval::getStartTime));
             long previousTotal;
             if (fTotalsStats.getStartTime() != sortedIntervals.get(0).getStartTime()) {
-                previousTotal = sortedIntervals.get(0).getValueInt();
+                previousTotal = sortedIntervals.get(0).getValueLong();
             } else {
                 previousTotal = 0;
             }
@@ -164,9 +164,9 @@ public class TmfStateStatistics implements ITmfStatistics {
                 while (j < sortedIntervals.size() - 1 && sortedIntervals.get(j).getEndTime() < times.get(i)) {
                     j++;
                 }
-                long count = sortedIntervals.get(j).getValueInt() - previousTotal;
+                long count = sortedIntervals.get(j).getValueLong() - previousTotal;
                 results.add(count);
-                previousTotal = sortedIntervals.get(j).getValueInt();
+                previousTotal = sortedIntervals.get(j).getValueLong();
             }
             return results;
         } catch (StateSystemDisposedException e) {

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStatisticsEventTypesModule.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStatisticsEventTypesModule.java
@@ -101,7 +101,7 @@ public class TmfStatisticsEventTypesModule extends TmfStateSystemAnalysisModule 
          * Version number of this input handler. Please bump this if you modify the
          * contents of the generated state history in some way.
          */
-        private static final int VERSION = 3;
+        private static final int VERSION = 4;
 
         /**
          * Constructor
@@ -139,12 +139,12 @@ public class TmfStatisticsEventTypesModule extends TmfStateSystemAnalysisModule 
                 ITmfLostEvent le = (ITmfLostEvent) event;
                 quark = ss.getQuarkAbsoluteAndAdd(Attributes.EVENT_TYPES, eventName);
 
-                int curVal = ss.queryOngoingState(quark).unboxInt();
+                long curVal = ss.queryOngoingState(quark).unboxLong();
                 if (curVal == -1) {
                     curVal = 0;
                 }
 
-                ss.modifyAttribute(ts, (int) (curVal + le.getNbLostEvents()), quark);
+                ss.modifyAttribute(ts, curVal + le.getNbLostEvents(), quark);
 
                 long lostEventsStartTime = le.getTimeRange().getStartTime().toNanos();
                 long lostEventsEndTime = le.getTimeRange().getEndTime().toNanos();
@@ -160,7 +160,7 @@ public class TmfStatisticsEventTypesModule extends TmfStateSystemAnalysisModule 
 
             /* Number of events of each type, globally */
             quark = ss.getQuarkAbsoluteAndAdd(Attributes.EVENT_TYPES, eventName);
-            StateSystemBuilderUtils.incrementAttributeInt(ss, ts, quark, 1);
+            StateSystemBuilderUtils.incrementAttributeLong(ss, ts, quark, 1);
         }
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStatisticsTotalsModule.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStatisticsTotalsModule.java
@@ -85,7 +85,7 @@ public class TmfStatisticsTotalsModule extends TmfStateSystemAnalysisModule {
          * Version number of this input handler. Please bump this if you modify the
          * contents of the generated state history in some way.
          */
-        private static final int VERSION = 2;
+        private static final int VERSION = 3;
 
         /**
          * Constructor
@@ -122,7 +122,7 @@ public class TmfStatisticsTotalsModule extends TmfStateSystemAnalysisModule {
 
             /* Total number of events */
             int quark = ss.getQuarkAbsoluteAndAdd(Attributes.TOTAL);
-            StateSystemBuilderUtils.incrementAttributeInt(ss, ts, quark, 1);
+            StateSystemBuilderUtils.incrementAttributeLong(ss, ts, quark, 1);
         }
     }
 


### PR DESCRIPTION
There are still two issues with the previous implementation:

- Having the duplicates of the start time in the TimeArrayCondition will slow down the execution of the binary search.
- When the query2d returned no intervals, an exception is thrown. This situation was never encountered because the previous version would add at least the end time or the start time but that would lead to an incorrect first bucket or last bucket

This patch was the one I lost. I modified it a bit to reduce the complexity of the queryHistogram method.