### PR TITLE
statesysten: add processSpanStateChange function to statesystem

### DIFF
--- a/statesystem/org.eclipse.tracecompass.statesystem.core/META-INF/MANIFEST.MF
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 5.3.1.qualifier
+Bundle-Version: 5.4.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.statesystem.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.statesystem.core.Activator

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/StateSystem.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/StateSystem.java
@@ -681,4 +681,19 @@ public class StateSystem implements ITmfStateSystemBuilder {
                 attribute + " at time " + timestamp + //$NON-NLS-1$
                 ", returning dummy interval"); //$NON-NLS-1$
     }
+
+    /**
+     * @param t
+     * @param value
+     * @param attributeQuark
+     * @param spanQuark
+     * @throws TimeRangeException
+     * @throws StateValueTypeException
+     */
+    @Override
+    public void modifySpanAttribute(long t, Object value, int attributeQuark, int spanQuark)
+            throws TimeRangeException, StateValueTypeException {
+        transState.processSpanStateChange(t, value, attributeQuark,spanQuark);
+    }
+
 }

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/statesystem/core/ITmfStateSystem.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/statesystem/core/ITmfStateSystem.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateValueTypeException;
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
 import org.eclipse.tracecompass.statesystem.core.statevalue.ITmfStateValue;
@@ -540,4 +541,15 @@ public interface ITmfStateSystem {
      */
     Iterable<@NonNull ITmfStateInterval> query2D(@NonNull Collection<Integer> quarks,
             long start, long end) throws StateSystemDisposedException, IndexOutOfBoundsException, TimeRangeException;
+
+    /**
+     * @param t
+     * @param value
+     * @param attributeQuark
+     * @param spanQuark
+     * @throws TimeRangeException
+     * @throws StateValueTypeException
+     * @since 5.4
+     */
+    void modifySpanAttribute(long t, Object value, int attributeQuark, int spanQuark) throws TimeRangeException, StateValueTypeException;
 }


### PR DESCRIPTION
* A new function (processSpanStateChange) is added to the TransientState class. Because in async traces unlike sync traces, the position of  the event in fOngoingInfo is not the same as the quark of the event in the call stack. So we should pass two integer, quark and callstack quark to the function.

* The Statesystem and ItmfStateSystem classes are changed relayed to this function.
this changes is for adding flamgraph analysis for opentracing