### PR TITLE
tmf: fix invalid 1ns histogram span

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/histogram/HistogramView.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/histogram/HistogramView.java
@@ -610,6 +610,11 @@ public class HistogramView extends TmfView implements ITmfTimeAligned {
             realStart = fTraceStartTime;
         }
 
+        if (duration == 1) {
+            fTimeSpanControl.setValue(fWindowSpan);
+            return;
+        }
+        
         long endTime = realStart + duration;
         if (endTime > fTraceEndTime) {
             endTime = fTraceEndTime;

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/histogram/HistogramView.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/histogram/HistogramView.java
@@ -610,7 +610,7 @@ public class HistogramView extends TmfView implements ITmfTimeAligned {
             realStart = fTraceStartTime;
         }
 
-        if (duration == 1) {
+        if (duration <= 1) {
             fTimeSpanControl.setValue(fWindowSpan);
             return;
         }


### PR DESCRIPTION
Fixes: #47 

This PR fixes an issue where histograms would be allowed to have a 1ns window span, which should not be possible.

Signed-off-by: Vlad Arama <vlad.arama@ericsson.com>