### PR TITLE
tmf: Add utility to detect directory traces from trace path

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 9.2.1.qualifier
+Bundle-Version: 9.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tmf.core.Activator

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/project/model/TmfTraceType.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/project/model/TmfTraceType.java
@@ -751,4 +751,36 @@ public final class TmfTraceType {
         }
         return (ITmfEvent) ce.createExecutableExtension(TmfTraceType.EVENT_TYPE_ATTR);
     }
+
+    /**
+     * Checks whether the parent or grandparent path of given path to a file is
+     * a valid directory trace. If it is a directory trace then return the
+     * parent or grandparent path.
+     *
+     * @param path
+     *            the path to check
+     * @return root path of trace to use (for example for trace type
+     *         validation).
+     * @since 9.3
+     */
+    public static String checkAndUpdateTracePath(String path) {
+        File file = new File(path);
+        if (file.exists() && !file.isDirectory()) {
+            // First check parent
+            File parent = file.getParentFile();
+            String pathToUse = parent.getAbsolutePath();
+            if (TmfTraceType.isDirectoryTrace(pathToUse)) {
+                return pathToUse;
+            }
+            // Second check grandparent
+            File grandParent = parent.getParentFile();
+            if (grandParent != null) {
+                pathToUse = grandParent.getAbsolutePath();
+                if (TmfTraceType.isDirectoryTrace(pathToUse)) {
+                    return pathToUse;
+                }
+            }
+        }
+        return path;
+    }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
@@ -138,7 +138,7 @@ public class TmfOpenTraceHelper {
      *             end
      */
     public static IStatus openTraceFromPath(TmfTraceFolder destinationFolder, String path, Shell shell, String tracetypeHint) throws CoreException {
-        final String pathToUse = checkTracePath(path);
+        final String pathToUse = TmfTraceType.checkAndUpdateTracePath(path);
         TraceTypeHelper traceTypeToSet = null;
         try (ScopeLog scopeLog = new ScopeLog(LOGGER, Level.FINE, "TmfOpenTraceHelper#openTraceFromPath", "Get trace type")) { //$NON-NLS-1$//$NON-NLS-2$
             traceTypeToSet = TmfTraceTypeUIUtils.selectTraceType(pathToUse, null, tracetypeHint);
@@ -174,36 +174,6 @@ public class TmfOpenTraceHelper {
             ret = openTraceFromFolder(destinationFolder, traceName);
         }
         return ret;
-    }
-
-    /**
-     * Checks whether the parent or grandparent of given path to a file is a valid
-     * directory trace. If it is a directory trace then return the parent or
-     * grandparent path.
-     *
-     * @param path
-     *            the path to check
-     * @return path to use for trace type validation.
-     */
-    private static String checkTracePath(String path) {
-        File file = new File(path);
-        if (file.exists() && !file.isDirectory()) {
-            // First check parent
-            File parent = file.getParentFile();
-            String pathToUse = parent.getAbsolutePath();
-            if (TmfTraceType.isDirectoryTrace(pathToUse)) {
-                return pathToUse;
-            }
-            // Second check grandparent
-            File grandParent = parent.getParentFile();
-            if (grandParent != null) {
-                pathToUse = grandParent.getAbsolutePath();
-                if (TmfTraceType.isDirectoryTrace(pathToUse)) {
-                    return pathToUse;
-                }
-            }
-        }
-        return path;
     }
 
     private static boolean traceExists(String path, IFolder folder) {


### PR DESCRIPTION
This utility checks whether the parent or grandparent path of given path to a file is a valid directory trace. If it is a directory trace then return the parent or grandparent path.

[Added] TmfTraceType.checkAndUpdateTracePath() to check directory traces

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>