### PR TITLE
tmf.ui: add support for unicode character marker symbols

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/StyleProperties.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/StyleProperties.java
@@ -283,7 +283,10 @@ public final class StyleProperties {
     /**
      * Symbol type as a string. Possible values: {@link SymbolType}.
      * <p>
-     * Default: @link {@link SymbolType#NONE}
+     * Default: {@link SymbolType#NONE}
+     * <p>
+     * If the value is not amongst {@link SymbolType}, the string value itself
+     * is drawn.
      */
     public static final String SYMBOL_TYPE = "symbol-type"; //$NON-NLS-1$
 

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
@@ -2314,7 +2314,8 @@ public class TimeGraphControl extends TimeGraphBaseControl
             } else if (VerticalAlign.TOP.equals(verticalAlign)) {
                 y -= Math.max(0, rect.height / 2 - symbolSize);
             }
-            switch (String.valueOf(symbolType)) {
+            String symbol = String.valueOf(symbolType);
+            switch (symbol) {
             case SymbolType.CROSS:
                 SymbolHelper.drawCross(gc, color, symbolSize, rect.x, y);
                 break;
@@ -2333,8 +2334,22 @@ public class TimeGraphControl extends TimeGraphBaseControl
             case SymbolType.CIRCLE:
                 SymbolHelper.drawCircle(gc, color, symbolSize, rect.x, y);
                 break;
-            default:
+            case SymbolType.DIAMOND:
                 SymbolHelper.drawDiamond(gc, color, symbolSize, rect.x, y);
+                break;
+            default:
+                Color oldColor = gc.getForeground();
+                gc.setForeground(color);
+                int height = (int) (rect.height * heightFactor);
+                TimeGraphRender.setFontForHeight(height, gc);
+                int textSize = (gc.textExtent(symbol).y + 1) / 2;
+                if (VerticalAlign.BOTTOM.equals(verticalAlign)) {
+                    y = rect.y + rect.height / 2 + Math.max(0, rect.height / 2 - textSize);
+                } else if (VerticalAlign.TOP.equals(verticalAlign)) {
+                    y = rect.y + rect.height / 2 - Math.max(0, rect.height / 2 - textSize);
+                }
+                gc.drawText(symbol, rect.x - symbolSize, y - textSize, true);
+                gc.setForeground(oldColor);
             }
             gc.setAlpha(OPAQUE);
             if (marker.getDuration() == 0) {


### PR DESCRIPTION
This is very useful to be able to identify markers by letters or more importantly by numbers to show sequences.

Successor to https://git.eclipse.org/r/c/tracecompass/org.eclipse.tracecompass/+/128504