### PR TITLE
profiling.core: add weighted tree tests from incubator

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/META-INF/MANIFEST.MF
@@ -32,5 +32,6 @@ Export-Package: org.eclipse.tracecompass.analysis.profiling.core.tests,
  org.eclipse.tracecompass.analysis.profiling.core.tests.flamegraph,
  org.eclipse.tracecompass.analysis.profiling.core.tests.perf;x-friends:="org.eclipse.tracecompass.lttng2.ust.core.tests",
  org.eclipse.tracecompass.analysis.profiling.core.tests.stubs,
+ org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted,
  org.eclipse.tracecompass.analysis.profiling.core.tests.stubs2
 Import-Package: com.google.common.collect

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/weighted/WeightedTreeGroupByTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/weighted/WeightedTreeGroupByTest.java
@@ -1,0 +1,386 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.analysis.profiling.core.tests.weighted;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted.SimpleTree;
+import org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted.SimpleWeightedTreeProvider;
+import org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted.WeightedTreeTestData;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.ITree;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeGroupDescriptor;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTreeGroupBy;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTreeSet;
+import org.eclipse.tracecompass.internal.analysis.profiling.core.tree.AllGroupDescriptor;
+import org.eclipse.tracecompass.internal.analysis.profiling.core.tree.DepthGroupDescriptor;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Test the {@link WeightedTreeGroupBy} class
+ *
+ * @author Geneviève Bastien
+ */
+@NonNullByDefault
+public class WeightedTreeGroupByTest {
+
+    private class WeightedTreeExpected {
+        public long duration;
+        public Map<String, WeightedTreeExpected> children;
+
+        public WeightedTreeExpected(long dur, Map<String, WeightedTreeExpected> childMap) {
+            duration = dur;
+            children = childMap;
+        }
+    }
+
+    private Map<String, WeightedTreeExpected> getExpectedAll() {
+        return ImmutableMap.of(
+                "op1", new WeightedTreeExpected(28, ImmutableMap.of(
+                        "op2", new WeightedTreeExpected(8, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(2, Collections.emptyMap()))),
+                        "op3", new WeightedTreeExpected(5, ImmutableMap.of(
+                                "op1", new WeightedTreeExpected(2, Collections.emptyMap()))),
+                        "op4", new WeightedTreeExpected(8, Collections.emptyMap()))),
+                "op4", new WeightedTreeExpected(8, Collections.emptyMap()),
+                "op2", new WeightedTreeExpected(17, ImmutableMap.of(
+                        "op3", new WeightedTreeExpected(1, Collections.emptyMap()),
+                        "op2", new WeightedTreeExpected(6, Collections.emptyMap()))),
+                "op5", new WeightedTreeExpected(15, ImmutableMap.of(
+                        "op2", new WeightedTreeExpected(12, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(1, Collections.emptyMap()))))));
+    }
+
+    private Map<String, WeightedTreeExpected> getExpectedL11() {
+        return ImmutableMap.of(
+                "op1", new WeightedTreeExpected(9, ImmutableMap.of(
+                        "op2", new WeightedTreeExpected(5, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(1, Collections.emptyMap()))))),
+                "op4", new WeightedTreeExpected(8, Collections.emptyMap()),
+                "op2", new WeightedTreeExpected(17, ImmutableMap.of(
+                        "op3", new WeightedTreeExpected(1, Collections.emptyMap()),
+                        "op2", new WeightedTreeExpected(6, Collections.emptyMap()))));
+    }
+
+    private Map<String, WeightedTreeExpected> getExpectedL12() {
+        return ImmutableMap.of(
+                "op1", new WeightedTreeExpected(19, ImmutableMap.of(
+                        "op3", new WeightedTreeExpected(5, ImmutableMap.of(
+                                "op1", new WeightedTreeExpected(2, Collections.emptyMap()))),
+                        "op2", new WeightedTreeExpected(3, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(1, Collections.emptyMap()))),
+                        "op4", new WeightedTreeExpected(8, Collections.emptyMap()))),
+                "op5", new WeightedTreeExpected(15, ImmutableMap.of(
+                        "op2", new WeightedTreeExpected(12, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(1, Collections.emptyMap()))))));
+    }
+
+    private Map<String, WeightedTreeExpected> getExpectedL21() {
+        return ImmutableMap.of(
+                "op1", new WeightedTreeExpected(9, ImmutableMap.of(
+                        "op2", new WeightedTreeExpected(5, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(1, Collections.emptyMap()))))),
+                "op4", new WeightedTreeExpected(8, Collections.emptyMap()));
+    }
+
+    private Map<String, WeightedTreeExpected> getExpectedL22() {
+        return ImmutableMap.of(
+                "op2", new WeightedTreeExpected(17, ImmutableMap.of(
+                        "op3", new WeightedTreeExpected(1, Collections.emptyMap()),
+                        "op2", new WeightedTreeExpected(6, Collections.emptyMap()))));
+    }
+
+    private Map<String, WeightedTreeExpected> getExpectedL23() {
+        return ImmutableMap.of(
+                "op1", new WeightedTreeExpected(19, ImmutableMap.of(
+                        "op2", new WeightedTreeExpected(3, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(1, Collections.emptyMap()))),
+                        "op3", new WeightedTreeExpected(5, ImmutableMap.of(
+                                "op1", new WeightedTreeExpected(2, Collections.emptyMap()))),
+                        "op4", new WeightedTreeExpected(8, Collections.emptyMap()))));
+    }
+
+    private Map<String, WeightedTreeExpected> getExpectedL24() {
+        return ImmutableMap.of(
+                "op5", new WeightedTreeExpected(15, ImmutableMap.of(
+                        "op2", new WeightedTreeExpected(12, ImmutableMap.of(
+                                "op3", new WeightedTreeExpected(1, Collections.emptyMap()))))));
+    }
+
+    private static SimpleWeightedTreeProvider getProvider(boolean withDescriptor) {
+        SimpleWeightedTreeProvider provider = new SimpleWeightedTreeProvider();
+        provider.setSpecificGroupDescriptor(withDescriptor);
+        return provider;
+    }
+
+    /**
+     * Test the group by all level for a weighted tree, with a tree that
+     * provides groups
+     */
+    @Test
+    public void testGroupByAll() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(true);
+
+        groupByAll(wtProvider);
+    }
+
+    /**
+     * Test the group by intermediate level for a weighted tree, with a tree
+     * that provides groups
+     */
+    @Test
+    public void testGroupByLevel1() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(true);
+        IWeightedTreeGroupDescriptor groupDescriptor = wtProvider.getGroupDescriptor();
+        assertNotNull(groupDescriptor);
+
+        groupByLevel1(wtProvider, groupDescriptor);
+    }
+
+    /**
+     * Test the group by leaf level of the weighted tree, with a tree that
+     * provides groups
+     */
+    @Test
+    public void testGroupByLevel2() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(true);
+        IWeightedTreeGroupDescriptor groupDescriptor = wtProvider.getGroupDescriptor();
+        assertNotNull(groupDescriptor);
+        groupDescriptor = groupDescriptor.getNextGroup();
+        assertNotNull(groupDescriptor);
+
+        groupByLevel2(wtProvider, groupDescriptor);
+    }
+
+    /**
+     * Test changing the grouping for an analysis, with a tree that provides
+     * groups
+     */
+    @Test
+    public void testMultiGroupBys() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(true);
+        IWeightedTreeGroupDescriptor groupDescriptor1 = wtProvider.getGroupDescriptor();
+        assertNotNull(groupDescriptor1);
+        IWeightedTreeGroupDescriptor groupDescriptor2 = groupDescriptor1.getNextGroup();
+        assertNotNull(groupDescriptor2);
+
+        // First, group by process
+        groupByLevel1(wtProvider, groupDescriptor1);
+
+        // Then, regroup by thread
+        groupByLevel2(wtProvider, groupDescriptor2);
+
+        // Then, group by all
+        groupByAll(wtProvider);
+
+        // Group by process again
+        groupByLevel1(wtProvider, groupDescriptor1);
+
+        // Group by all
+        groupByAll(wtProvider);
+
+        // Finally by thread
+        groupByLevel2(wtProvider, groupDescriptor2);
+
+    }
+
+    /**
+     * Test the group by all level for a weighted tree, with a tree that does
+     * not provide groups
+     */
+    @Test
+    public void testGroupByAllNoGrouping() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(false);
+
+        groupByAll(wtProvider);
+    }
+
+    /**
+     * Test the group by intermediate level for a weighted tree, with a tree
+     * that does not provider groups
+     */
+    @Test
+    public void testGroupByLevel1NoGrouping() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(false);
+        IWeightedTreeGroupDescriptor groupDescriptor = wtProvider.getGroupDescriptor();
+        assertTrue(groupDescriptor instanceof DepthGroupDescriptor);
+
+        groupByLevel1(wtProvider, groupDescriptor);
+    }
+
+    /**
+     * Test the group by leaf level of the weighted tree, with a tree that does
+     * not provider groups
+     */
+    @Test
+    public void testGroupByLevel2NoGrouping() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(false);
+        IWeightedTreeGroupDescriptor groupDescriptor = wtProvider.getGroupDescriptor();
+        assertTrue(groupDescriptor instanceof DepthGroupDescriptor);
+        groupDescriptor = groupDescriptor.getNextGroup();
+        assertTrue(groupDescriptor instanceof DepthGroupDescriptor);
+        assertNull(groupDescriptor.getNextGroup());
+
+        groupByLevel2(wtProvider, groupDescriptor);
+    }
+
+    /**
+     * Test changing the grouping for an analysis, with a tree does not provider
+     * groups
+     */
+    @Test
+    public void testMultiGroupBysNoGrouping() {
+        SimpleWeightedTreeProvider wtProvider = getProvider(false);
+        IWeightedTreeGroupDescriptor groupDescriptor1 = wtProvider.getGroupDescriptor();
+        assertTrue(groupDescriptor1 instanceof DepthGroupDescriptor);
+        IWeightedTreeGroupDescriptor groupDescriptor2 = groupDescriptor1.getNextGroup();
+        assertTrue(groupDescriptor2 instanceof DepthGroupDescriptor);
+
+        // First, group by process
+        groupByLevel1(wtProvider, groupDescriptor1);
+
+        // Then, regroup by thread
+        groupByLevel2(wtProvider, groupDescriptor2);
+
+        // Then, group by all
+        groupByAll(wtProvider);
+
+        // Group by process again
+        groupByLevel1(wtProvider, groupDescriptor1);
+
+        // Group by all
+        groupByAll(wtProvider);
+
+        // Finally by thread
+        groupByLevel2(wtProvider, groupDescriptor2);
+
+    }
+
+    private void groupByAll(SimpleWeightedTreeProvider wtProvider) {
+        WeightedTreeSet<String, Object> wts = WeightedTreeGroupBy.groupWeightedTreeBy(AllGroupDescriptor.getInstance(), wtProvider.getTreeSet(), wtProvider);
+        Collection<@NonNull ?> elements = wts.getElements();
+        assertEquals(1, elements.size());
+
+        for (Object element : elements) {
+            Collection<WeightedTree<String>> trees = wts.getTreesFor(element);
+            compareCcts("Group By All", getExpectedAll(), trees);
+        }
+    }
+
+    /**
+     * Test the group by intermediate level for a weighted tree
+     */
+    private void groupByLevel1(SimpleWeightedTreeProvider wtProvider, IWeightedTreeGroupDescriptor descriptor) {
+
+        WeightedTreeSet<String, Object> wts = WeightedTreeGroupBy.groupWeightedTreeBy(descriptor, wtProvider.getTreeSet(), wtProvider);
+        Collection<?> elements = wts.getElements();
+        assertEquals(2, elements.size());
+
+        for (Object element : elements) {
+            assertTrue(element instanceof SimpleTree);
+            SimpleTree treeEl = (SimpleTree) element;
+            // Objects should be equal to the ones from the tree
+            if (treeEl.getName().equals(WeightedTreeTestData.OBJ_L11.getName())) {
+                assertTrue(((SimpleTree) element).getChildren().isEmpty());
+                Collection<WeightedTree<String>> trees = wts.getTreesFor(element);
+                compareCcts("obj11", getExpectedL11(), trees);
+            } else if (treeEl.getName().equals(WeightedTreeTestData.OBJ_L12.getName())) {
+                assertTrue(((SimpleTree) element).getChildren().isEmpty());
+                Collection<WeightedTree<String>> trees = wts.getTreesFor(element);
+                compareCcts("obj12", getExpectedL12(), trees);
+            } else {
+                fail("Unexpected element: " + element);
+            }
+        }
+    }
+
+    /**
+     * Test the group by leaf level of the weighted tree
+     */
+    private void groupByLevel2(SimpleWeightedTreeProvider wtProvider, IWeightedTreeGroupDescriptor descriptor) {
+
+        WeightedTreeSet<String, Object> wts = WeightedTreeGroupBy.groupWeightedTreeBy(descriptor, wtProvider.getTreeSet(), wtProvider);
+        Collection<?> elements = wts.getElements();
+        assertEquals(2, elements.size());
+
+        for (Object element : elements) {
+            assertTrue(element instanceof SimpleTree);
+            SimpleTree treeEl = (SimpleTree) element;
+            // Objects should be equal to the ones from the tree
+            if (treeEl.getName().equals(WeightedTreeTestData.OBJ_L11.getName())) {
+                Collection<WeightedTree<String>> trees = wts.getTreesFor(element);
+                assertTrue(trees.isEmpty());
+                Collection<ITree> children = ((ITree) element).getChildren();
+                assertEquals(2, children.size());
+                for (Object child : children) {
+                    assertTrue(child instanceof SimpleTree);
+                    SimpleTree childTreeEl = (SimpleTree) child;
+                    // Objects should be equal to the ones from the tree
+                    if (childTreeEl.getName().equals(WeightedTreeTestData.OBJ_L21.getName())) {
+                        trees = wts.getTreesFor(child);
+                        compareCcts("obj21", getExpectedL21(), trees);
+                    } else if (childTreeEl.getName().equals(WeightedTreeTestData.OBJ_L22.getName())) {
+                        trees = wts.getTreesFor(child);
+                        compareCcts("obj22", getExpectedL22(), trees);
+                    } else {
+                        fail("Unexpected element: " + child);
+                    }
+                }
+            } else if (treeEl.getName().equals(WeightedTreeTestData.OBJ_L12.getName())) {
+                Collection<WeightedTree<String>> trees = wts.getTreesFor(element);
+                assertTrue(trees.isEmpty());
+                Collection<ITree> children = ((ITree) element).getChildren();
+                assertEquals(2, children.size());
+                for (Object child : children) {
+                    assertTrue(child instanceof SimpleTree);
+                    SimpleTree childTreeEl = (SimpleTree) child;
+                    // Objects should be equal to the ones from the tree
+                    if (childTreeEl.getName().equals(WeightedTreeTestData.OBJ_L23.getName())) {
+                        trees = wts.getTreesFor(child);
+                        compareCcts("obj23", getExpectedL23(), trees);
+                    } else if (childTreeEl.getName().equals(WeightedTreeTestData.OBJ_L24.getName())) {
+                        trees = wts.getTreesFor(child);
+                        compareCcts("obj24", getExpectedL24(), trees);
+                    } else {
+                        fail("Unexpected element: " + child);
+                    }
+                }
+            } else {
+                fail("Unexpected element: " + element);
+            }
+        }
+
+    }
+
+    private void compareCcts(String prefix, Map<String, WeightedTreeExpected> expected, Collection<WeightedTree<String>> trees) {
+        assertEquals(prefix + " size", expected.size(), trees.size());
+        for (WeightedTree<String> tree : trees) {
+            WeightedTreeExpected wtExpected = expected.get(tree.getObject());
+            assertNotNull(wtExpected);
+            assertEquals(prefix + " object " + tree.getObject(), wtExpected.duration, tree.getWeight());
+            compareCcts(prefix + tree.getObject() + ", ", wtExpected.children, tree.getChildren());
+        }
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/weighted/WeightedTreeSetTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/weighted/WeightedTreeSetTest.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.analysis.profiling.core.tests.weighted;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted.SimpleTree;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.ITree;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTreeSet;
+import org.junit.Test;
+
+/**
+ * Test the {@link WeightedTreeSet} class
+ *
+ * @author Geneviève Bastien
+ */
+@NonNullByDefault
+public class WeightedTreeSetTest {
+
+    private static final String OBJ1 = "obj1";
+    private static final String OBJ2 = "obj2";
+
+    /**
+     * Test adding trees to non-{@link ITree} elements in the tree
+     */
+    @Test
+    public void testAddingSimpleData() {
+        int initialWeight = 10;
+        String element1 = "element1";
+        String element2 = "element2";
+
+        // Initialization
+        WeightedTreeSet<String, String> treeSet = new WeightedTreeSet<>();
+        Collection<String> elements = treeSet.getElements();
+        assertTrue(elements.isEmpty());
+        assertTrue(treeSet.getTreesFor(element1).isEmpty());
+        assertTrue(treeSet.getTreesFor(element2).isEmpty());
+
+        // Trees for element1
+
+        // Add a first tree to the set and make sure we can retrieve it
+        WeightedTree<String> wt = new WeightedTree<>(OBJ1, initialWeight);
+        treeSet.addWeightedTree(element1, wt);
+        elements = treeSet.getElements();
+        assertEquals(1, elements.size());
+        assertEquals(element1, elements.iterator().next());
+        Collection<WeightedTree<String>> trees = treeSet.getTreesFor(element1);
+        assertEquals(1, trees.size());
+        assertEquals(wt, trees.iterator().next());
+
+        // Add a second tree to the set for the same object, should be merged
+        wt = new WeightedTree<>(OBJ1, initialWeight);
+        treeSet.addWeightedTree(element1, wt);
+        elements = treeSet.getElements();
+        assertEquals(1, elements.size());
+        assertEquals(element1, elements.iterator().next());
+        trees = treeSet.getTreesFor(element1);
+        assertEquals(1, trees.size());
+        WeightedTree<String> tree = trees.iterator().next();
+        assertEquals(wt.getObject(), tree.getObject());
+        assertEquals(initialWeight * 2, tree.getWeight());
+
+        // Add a third tree for another object, added
+        wt = new WeightedTree<>(OBJ2, initialWeight);
+        treeSet.addWeightedTree(element1, wt);
+        elements = treeSet.getElements();
+        assertEquals(1, elements.size());
+        assertEquals(element1, elements.iterator().next());
+        Collection<WeightedTree<String>> el1Trees = treeSet.getTreesFor(element1);
+        assertEquals(2, el1Trees.size());
+
+        // Trees for a second element
+
+        // Add tree to second element, first element should not be affected
+        wt = new WeightedTree<>(OBJ1, initialWeight);
+        treeSet.addWeightedTree(element2, wt);
+        elements = treeSet.getElements();
+        assertEquals(2, elements.size());
+        trees = treeSet.getTreesFor(element1);
+        // Trees for element1 are identical to before
+        assertEquals(el1Trees, trees);
+        trees = treeSet.getTreesFor(element2);
+        assertEquals(1, trees.size());
+    }
+
+    /**
+     * Test adding trees to {@link ITree} elements in the tree
+     */
+    @Test
+    public void testAddingTreeData() {
+        int initialWeight = 10;
+        SimpleTree element1 = new SimpleTree("element1");
+        SimpleTree element2 = new SimpleTree("element2");
+        SimpleTree element3 = new SimpleTree("element3");
+        element1.addChild(element2);
+        element1.addChild(element3);
+        SimpleTree element4 = new SimpleTree("element3");
+
+        // Initialization
+        WeightedTreeSet<String, SimpleTree> treeSet = new WeightedTreeSet<>();
+        Collection<SimpleTree> elements = treeSet.getElements();
+        assertTrue(elements.isEmpty());
+        assertTrue(treeSet.getTreesFor(element1).isEmpty());
+        assertTrue(treeSet.getTreesFor(element2).isEmpty());
+        assertTrue(treeSet.getTreesFor(element3).isEmpty());
+        assertTrue(treeSet.getTreesFor(element4).isEmpty());
+
+        // Trees for element2, that has a parent
+
+        // Add a first tree to the set and make sure we can retrieve it
+        WeightedTree<String> wt = new WeightedTree<>(OBJ1, initialWeight);
+        treeSet.addWeightedTree(element2, wt);
+        elements = treeSet.getElements();
+        assertEquals(1, elements.size());
+        // The main element should be the parent
+        assertEquals(element1, elements.iterator().next());
+        Collection<WeightedTree<String>> trees = treeSet.getTreesFor(element2);
+        assertEquals(1, trees.size());
+        assertEquals(wt, trees.iterator().next());
+        assertTrue(treeSet.getTreesFor(element1).isEmpty());
+
+        // Add a tree to a second child
+        wt = new WeightedTree<>(OBJ1, initialWeight);
+        treeSet.addWeightedTree(element3, wt);
+        // Base element should still be only the parent
+        elements = treeSet.getElements();
+        assertEquals(1, elements.size());
+        assertEquals(element1, elements.iterator().next());
+        trees = treeSet.getTreesFor(element3);
+        assertEquals(1, trees.size());
+
+        // Add second tree to a second child, should be merged
+        wt = new WeightedTree<>(OBJ1, initialWeight);
+        treeSet.addWeightedTree(element3, wt);
+        // Base element should still be only the parent
+        elements = treeSet.getElements();
+        assertEquals(1, elements.size());
+        assertEquals(element1, elements.iterator().next());
+        trees = treeSet.getTreesFor(element3);
+        assertEquals(1, trees.size());
+        WeightedTree<String> tree = trees.iterator().next();
+        assertEquals(wt.getObject(), tree.getObject());
+        assertEquals(initialWeight * 2, tree.getWeight());
+
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/weighted/WeightedTreeTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/weighted/WeightedTreeTest.java
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.analysis.profiling.core.tests.weighted;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
+import org.junit.Test;
+
+/**
+ * Test the {@link WeightedTree} class
+ *
+ * @author Geneviève Bastien
+ */
+@NonNullByDefault
+public class WeightedTreeTest {
+
+    private static final String OBJECT_NAME1 = "obj1";
+    private static final String OBJECT_NAME2 = "obj2";
+    private static final String OBJECT_NAME3 = "obj3";
+    private static final String OBJECT_NAME4 = "obj4";
+    private static final String OBJECT_NAME5 = "obj5";
+
+    /**
+     * Test the constructors
+     */
+    @Test
+    public void testConstructors() {
+        // Test the default constructor with only object
+        WeightedTree<String> wt = new WeightedTree<>(OBJECT_NAME1);
+        assertEquals("default constructor name", OBJECT_NAME1, wt.getObject());
+        assertEquals("default constructor initial weight", 0, wt.getWeight());
+        assertTrue("default constructor no children", wt.getChildren().isEmpty());
+        assertEquals("default depth", 1, wt.getMaxDepth());
+
+        // Test the constructor with initial weight
+        int initialWeight = 150;
+        wt = new WeightedTree<>(OBJECT_NAME1, initialWeight);
+        assertEquals("constructor with weight name", OBJECT_NAME1, wt.getObject());
+        assertEquals("constructor with weight initial weight", initialWeight, wt.getWeight());
+        assertTrue("constructor with weight no children", wt.getChildren().isEmpty());
+        assertEquals("constructor with weight depth", 1, wt.getMaxDepth());
+    }
+
+    /**
+     * Test the {@link WeightedTree#merge(WeightedTree)} method
+     */
+    @Test
+    public void testSimpleMerge() {
+        int initialWeight = 150;
+        WeightedTree<String> wt = new WeightedTree<>(OBJECT_NAME1, initialWeight);
+
+        // Merge without children
+        WeightedTree<String> wt2 = new WeightedTree<>(OBJECT_NAME1, initialWeight);
+        wt.merge(wt2);
+        assertEquals("Value after merge", initialWeight * 2, wt.getWeight());
+        assertEquals("merged tree unmodified", initialWeight, wt2.getWeight());
+    }
+
+    /**
+     * Test merging trees for different objects, exception expected
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testMergeWrongObject() {
+        int initialWeight = 150;
+        WeightedTree<String> wt = new WeightedTree<>(OBJECT_NAME1, initialWeight);
+        WeightedTree<String> wt2 = new WeightedTree<>(OBJECT_NAME2, initialWeight);
+        wt.merge(wt2);
+    }
+
+    /**
+     * Test the {@link WeightedTree#addToWeight(long)} method
+     */
+    @Test
+    public void testAddToWeight() {
+        int initialWeight = 150;
+        WeightedTree<String> wt = new WeightedTree<>(OBJECT_NAME1, initialWeight);
+        assertEquals("initial weight", initialWeight, wt.getWeight());
+
+        wt.addToWeight(initialWeight);
+        assertEquals("initial weight", initialWeight * 2, wt.getWeight());
+    }
+
+    /**
+     * Test the {@link WeightedTree#copyOf()} method
+     */
+    @Test
+    public void testCopyOf() {
+        int initialWeight = 150;
+        int childWeight = 50;
+        WeightedTree<String> wt = new WeightedTree<>(OBJECT_NAME1, initialWeight);
+
+        // Test the copy without children
+        WeightedTree<String> wtCopy = wt.copyOf();
+        assertEquals("same weight", wt.getWeight(), wtCopy.getWeight());
+
+        // Make sure modifying the copy does not affect the original
+        wtCopy.addToWeight(initialWeight);
+        assertEquals("New copy weight", initialWeight * 2, wtCopy.getWeight());
+        assertEquals("Unchanged original weight", initialWeight, wt.getWeight());
+
+        // Add a child to wt and copy, children are also copied
+        WeightedTree<String> child = new WeightedTree<>(OBJECT_NAME1, childWeight);
+        wt.addChild(child);
+        wtCopy = wt.copyOf();
+        assertEquals("Same weight", wt.getWeight(), wtCopy.getWeight());
+        Collection<WeightedTree<String>> children = wtCopy.getChildren();
+        assertEquals("No children copied", 1, children.size());
+
+        // Make sure modifying the child does not affect the original child
+        WeightedTree<String> childCopy = children.iterator().next();
+        childCopy.addToWeight(childWeight);
+        assertEquals("New child copy weight", childWeight * 2, childCopy.getWeight());
+        assertEquals("Unchanged original child weight", childWeight, child.getWeight());
+
+    }
+
+    /**
+     * Test the {@link WeightedTree#addChild(WeightedTree)} method
+     */
+    @Test
+    public void testAddChild() {
+        int initialWeight = 150;
+        WeightedTree<String> wt = new WeightedTree<>(OBJECT_NAME1, initialWeight);
+
+        int childWeight = 30;
+        WeightedTree<String> child1 = new WeightedTree<>(OBJECT_NAME2, childWeight);
+
+        // Add a first child
+        wt.addChild(child1);
+        assertEquals("Unchanged parent weight", initialWeight, wt.getWeight());
+        assertEquals("Unchanged child weight", childWeight, child1.getWeight());
+        assertEquals("Children of parent", 1, wt.getChildren().size());
+        assertTrue("No child to child", child1.getChildren().isEmpty());
+        WeightedTree<String> treeChild = wt.getChildren().iterator().next();
+        assertEquals("Child of parent", child1, treeChild);
+
+        // Add a second child for different object
+        WeightedTree<String> child2 = new WeightedTree<>(OBJECT_NAME3, childWeight);
+        wt.addChild(child2);
+        assertEquals("Unchanged parent weight", initialWeight, wt.getWeight());
+        assertEquals("Unchanged child weight", childWeight, child2.getWeight());
+        assertEquals("Children of parent", 2, wt.getChildren().size());
+
+        // Add a third child to merge with child1
+        WeightedTree<String> child3 = new WeightedTree<>(OBJECT_NAME2, childWeight);
+        wt.addChild(child3);
+        assertEquals("Unchanged parent weight", initialWeight, wt.getWeight());
+        assertEquals("Unchanged child weight", childWeight, child3.getWeight());
+        assertEquals("Children of parent", 2, wt.getChildren().size());
+        assertEquals("New tree child weight", childWeight * 2, treeChild.getWeight());
+
+        assertEquals("Max depth", 2, wt.getMaxDepth());
+
+        // Add wt as a child to a new parent tree
+        WeightedTree<String> parent = new WeightedTree<>(OBJECT_NAME4, initialWeight * 2);
+        parent.addChild(wt);
+        assertFalse("Parent's child", parent.getChildren().isEmpty());
+        treeChild = parent.getChildren().iterator().next();
+        assertEquals("no children lost", 2, treeChild.getChildren().size());
+        assertEquals("Final max depth", 3, parent.getMaxDepth());
+    }
+
+    /**
+     * Test the {@link WeightedTree#merge(WeightedTree)} method for objects that
+     * have many levels of similar children
+     */
+    @Test
+    public void testDeepMerge() {
+        /**
+         * Here's the layout of the objects to merge
+         *
+         * <pre>
+         *        1                 1
+         *       / \ \             / \ \
+         *      1   2 3           1   2 5
+         *     / \  |            / \  | |
+         *    4   5 2           3   4 1 2
+         *
+         * Expected:
+         *          1*2
+         *     /     |   \  \
+         *   1*2    2*2   3  5
+         *  / | \   / \      |
+         * 3 4*2 5 1   2     2
+         * </pre>
+         */
+        int level0Weight = 150;
+        int level1Weight = 40;
+        int level2Weight = 10;
+
+        // Prepare the objects to merge
+        // First object
+        WeightedTree<String> wtParent1 = new WeightedTree<>(OBJECT_NAME1, level0Weight);
+        WeightedTree<String> wtLevel1 = new WeightedTree<>(OBJECT_NAME1, level1Weight);
+        wtLevel1.addChild(new WeightedTree<>(OBJECT_NAME4, level2Weight));
+        wtLevel1.addChild(new WeightedTree<>(OBJECT_NAME5, level2Weight));
+        wtParent1.addChild(wtLevel1);
+
+        wtLevel1 = new WeightedTree<>(OBJECT_NAME2, level1Weight);
+        wtLevel1.addChild(new WeightedTree<>(OBJECT_NAME2, level2Weight));
+        wtParent1.addChild(wtLevel1);
+
+        wtParent1.addChild(new WeightedTree<>(OBJECT_NAME3, level1Weight));
+
+        // Second object
+        WeightedTree<String> wtParent2 = new WeightedTree<>(OBJECT_NAME1, level0Weight);
+        wtLevel1 = new WeightedTree<>(OBJECT_NAME1, level1Weight);
+        wtLevel1.addChild(new WeightedTree<>(OBJECT_NAME3, level2Weight));
+        wtLevel1.addChild(new WeightedTree<>(OBJECT_NAME4, level2Weight));
+        wtParent2.addChild(wtLevel1);
+
+        wtLevel1 = new WeightedTree<>(OBJECT_NAME2, level1Weight);
+        wtLevel1.addChild(new WeightedTree<>(OBJECT_NAME1, level2Weight));
+        wtParent2.addChild(wtLevel1);
+
+        wtLevel1 = new WeightedTree<>(OBJECT_NAME5, level1Weight);
+        wtLevel1.addChild(new WeightedTree<>(OBJECT_NAME2, level2Weight));
+        wtParent2.addChild(wtLevel1);
+
+        // Merge the objects and test its content
+        wtParent1.merge(wtParent2);
+
+        assertEquals("Level 0 Weight", level0Weight * 2, wtParent1.getWeight());
+        Collection<WeightedTree<String>> level1Children = wtParent1.getChildren();
+        assertEquals("Level 0 Nb children", 4, level1Children.size());
+        assertEquals("Max depth", 3, wtParent1.getMaxDepth());
+
+        for (WeightedTree<String> level1Child : level1Children) {
+            switch (level1Child.getObject()) {
+            case OBJECT_NAME1:
+            {
+                assertEquals("Level 1 Weight 1", level1Weight * 2, level1Child.getWeight());
+                Collection<WeightedTree<String>> level2Children = level1Child.getChildren();
+                assertEquals("Level 1 Nb children 1", 3, level2Children.size());
+                for (WeightedTree<String> level2Child : level2Children) {
+                    switch (level2Child.getObject()) {
+                    case OBJECT_NAME3: // Fall-through, same weight and children
+                    case OBJECT_NAME5:
+                        assertEquals("Level 2-1 Weight", level2Weight, level2Child.getWeight());
+                        assertTrue("Empty children at last level", level2Child.getChildren().isEmpty());
+                        break;
+                    case OBJECT_NAME4:
+                        assertEquals("Level 2-1 Weight", level2Weight * 2, level2Child.getWeight());
+                        assertTrue("Empty children at last level", level2Child.getChildren().isEmpty());
+                        break;
+                    default:
+                        fail("Unknown child " + level2Child.getObject());
+                        break;
+                    }
+                }
+            }
+                break;
+            case OBJECT_NAME2:
+            {
+                assertEquals("Level 1 Weight 2", level1Weight * 2, level1Child.getWeight());
+                Collection<WeightedTree<String>> level2Children = level1Child.getChildren();
+                assertEquals("Level 1 Nb children 2", 2, level2Children.size());
+                for (WeightedTree<String> level2Child : level2Children) {
+                    switch (level2Child.getObject()) {
+                    case OBJECT_NAME1: // Fall-through, same weight and children
+                    case OBJECT_NAME2:
+                        assertEquals("Level 2-2 Weight", level2Weight, level2Child.getWeight());
+                        assertTrue("Empty children at last level", level2Child.getChildren().isEmpty());
+                        break;
+                    default:
+                        fail("Unknown child " + level2Child.getObject());
+                        break;
+                    }
+                }
+            }
+                break;
+            case OBJECT_NAME3:
+                assertEquals("Level 1 Weight 3", level1Weight, level1Child.getWeight());
+                assertTrue("Empty children at last level", level1Child.getChildren().isEmpty());
+                break;
+            case OBJECT_NAME5:
+                assertEquals("Level 1 Weight 4", level1Weight, level1Child.getWeight());
+                Collection<WeightedTree<String>> level2Children = level1Child.getChildren();
+                assertEquals("Level 1 Nb children 4", 1, level2Children.size());
+                for (WeightedTree<String> level2Child : level2Children) {
+                    switch (level2Child.getObject()) {
+                    case OBJECT_NAME2:
+                        assertEquals("Level 2-2 Weight", level2Weight, level2Child.getWeight());
+                        assertTrue("Empty children at last level", level2Child.getChildren().isEmpty());
+                        break;
+                    default:
+                        fail("Unknown child " + level2Child.getObject());
+                        break;
+                    }
+                }
+                break;
+            default:
+                fail("Unknown child " + level1Child.getObject());
+                break;
+            }
+        }
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/SimpleTree.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/SimpleTree.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.ITree;
+
+/**
+ * A simple {@link ITree} implementation for testing purposes
+ *
+ * @author Geneviève Bastien
+ */
+public class SimpleTree implements ITree {
+
+    private final String fName;
+    private @Nullable ITree fParent;
+    private List<ITree> fChildren = new ArrayList<>();
+
+    /**
+     * Constructor
+     *
+     * @param name
+     *            The object name
+     */
+    public SimpleTree(String name) {
+        fName = name;
+    }
+
+    @Override
+    public String getName() {
+        return fName;
+    }
+
+    @Override
+    public @Nullable ITree getParent() {
+        return fParent;
+    }
+
+    @Override
+    public Collection<ITree> getChildren() {
+        return new ArrayList<>(fChildren);
+    }
+
+    /**
+     * Add a child to this object
+     *
+     * @param child
+     *            The child to add
+     */
+    @Override
+    public void addChild(ITree child) {
+        fChildren.add(child);
+        child.setParent(this);
+    }
+
+    @Override
+    public String toString() {
+        return fName;
+    }
+
+    @Override
+    public ITree copyElement() {
+        return new SimpleTree(getName());
+    }
+
+    @Override
+    public void setParent(@Nullable ITree parent) {
+        fParent = parent;
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/SimpleWeightedTreeProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/SimpleWeightedTreeProvider.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeGroupDescriptor;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeProvider;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeSet;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
+
+/**
+ * Simple implementation of the {@link IWeightedTreeProvider} interface, for
+ * testing purposes.
+ *
+ * @author Geneviève Bastien
+ */
+public class SimpleWeightedTreeProvider implements IWeightedTreeProvider<String, SimpleTree, WeightedTree<String>> {
+
+    static final IWeightedTreeGroupDescriptor ROOT_DESCRIPTOR = new IWeightedTreeGroupDescriptor() {
+        @Override
+        public @Nullable IWeightedTreeGroupDescriptor getNextGroup() {
+            return SECOND_DESCRIPTOR;
+        }
+
+        @Override
+        public String getName() {
+            return "first level";
+        }
+    };
+
+    private static final IWeightedTreeGroupDescriptor SECOND_DESCRIPTOR = new IWeightedTreeGroupDescriptor() {
+        @Override
+        public @Nullable IWeightedTreeGroupDescriptor getNextGroup() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return "second level";
+        }
+    };
+
+    private boolean fWithGroupDescriptors;
+
+    /**
+     * Constructor
+     */
+    public SimpleWeightedTreeProvider() {
+
+    }
+
+    /**
+     * Sets whether to use specific group descriptor or the default ones
+     *
+     * @param withGroupDescriptors
+     *            If <code>true</code>, the specific group descriptors will be
+     *            used to describe the levels, otherwise, the returned group
+     *            descriptors will be the ones provided by the default
+     *            implementation
+     */
+    public void setSpecificGroupDescriptor(boolean withGroupDescriptors) {
+        fWithGroupDescriptors = withGroupDescriptors;
+    }
+
+    @Override
+    public IWeightedTreeSet<String, SimpleTree, WeightedTree<String>> getTreeSet() {
+        return WeightedTreeTestData.getStubData();
+    }
+
+    @Override
+    public String getTitle() {
+        return "Simple weighted tree provider for unit tests";
+    }
+
+    @Override
+    public @Nullable IWeightedTreeGroupDescriptor getGroupDescriptor() {
+        return fWithGroupDescriptors ? ROOT_DESCRIPTOR : IWeightedTreeProvider.super.getGroupDescriptor();
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/WeightedTreeProviderStub.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/WeightedTreeProviderStub.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeProvider;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeSet;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTreeSet;
+
+/**
+ * A weighted tree provider stub, without pre-defined data
+ *
+ * @author Geneviève Bastien
+ *
+ * @param <N> The type of data in the nodes
+ * @param <E> The type of elements
+ */
+public class WeightedTreeProviderStub<@NonNull N, @NonNull E> implements IWeightedTreeProvider<N, E, WeightedTree<N>> {
+
+    @Override
+    public IWeightedTreeSet<@NonNull N, E, WeightedTree<N>> getTreeSet() {
+        return new WeightedTreeSet<>();
+    }
+
+    @Override
+    public String getTitle() {
+        return "Empty weighted tree provider stub for unit tests";
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/WeightedTreeTestData.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/WeightedTreeTestData.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted;
+
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTreeSet;
+
+/**
+ * A class that encapsulates stub data for multiple tests
+ *
+ * @author Geneviève Bastien
+ */
+public class WeightedTreeTestData {
+
+    /** Level 1, first object */
+    public static final SimpleTree OBJ_L11 = new SimpleTree("l11");
+    /** Level 1, second object */
+    public static final SimpleTree OBJ_L12 = new SimpleTree("l12");
+    /** Level 2, first object */
+    public static final SimpleTree OBJ_L21 = new SimpleTree("l21");
+    /** Level 2, second object */
+    public static final SimpleTree OBJ_L22 = new SimpleTree("l22");
+    /** Level 2, third object */
+    public static final SimpleTree OBJ_L23 = new SimpleTree("l23");
+    /** Level 2, fourth object */
+    public static final SimpleTree OBJ_L24 = new SimpleTree("l24");
+
+    private static final String TREE_OBJ1 = "op1";
+    private static final String TREE_OBJ2 = "op2";
+    private static final String TREE_OBJ3 = "op3";
+    private static final String TREE_OBJ4 = "op4";
+    private static final String TREE_OBJ5 = "op5";
+
+    static {
+        OBJ_L11.addChild(OBJ_L21);
+        OBJ_L11.addChild(OBJ_L22);
+        OBJ_L12.addChild(OBJ_L23);
+        OBJ_L12.addChild(OBJ_L24);
+    }
+
+    /**
+     * This data structure was done to generalize further the original concept
+     * of callgraph. The data to test is a simplification of the original
+     * callgraph data, as follows:
+     *
+     * For the elements, there are 2 root elements with each 2 children. For
+     * weighted trees for each element, the syntax is [objec]>-[weight]
+     *
+     * <pre>
+     * l11 ___ l21     op1-9  op4-8
+     *     |              |
+     *     |            op2-5
+     *     |              |
+     *     |            op3-1
+     *     |__ l22      op2-17
+     *                  /    \
+     *                op3-1  op2-6
+     *
+     * l21 ___ l23         op1-19
+     *     |            /    |    \
+     *     |         op3-5 op2-3  op4-8
+     *     |            |    |
+     *     |         op1-2 op3-1
+     *     |__ l23         op5-15
+     *                       |
+     *                     op2-12
+     *                       |
+     *                     op3-1
+     * </pre>
+     *
+     * @return The stub tree set
+     */
+    public static WeightedTreeSet<String, SimpleTree> getStubData() {
+        WeightedTreeSet<String, SimpleTree> stub = new WeightedTreeSet<>();
+
+        // Prepare weighted trees for l21
+        WeightedTree<String> wt = new WeightedTree<>(TREE_OBJ1, 9);
+        WeightedTree<String> child = new WeightedTree<>(TREE_OBJ2, 5);
+        child.addChild(new WeightedTree<>(TREE_OBJ3, 1));
+        wt.addChild(child);
+        stub.addWeightedTree(OBJ_L21, wt);
+
+        stub.addWeightedTree(OBJ_L21, new WeightedTree<>(TREE_OBJ4, 8));
+
+        // Prepare weighted trees for l22
+        wt = new WeightedTree<>(TREE_OBJ2, 17);
+        wt.addChild(new WeightedTree<>(TREE_OBJ3, 1));
+        wt.addChild(new WeightedTree<>(TREE_OBJ2, 6));
+        stub.addWeightedTree(OBJ_L22, wt);
+
+        // Prepare weighted trees for l23
+        wt = new WeightedTree<>(TREE_OBJ1, 19);
+        child = new WeightedTree<>(TREE_OBJ3, 5);
+        child.addChild(new WeightedTree<>(TREE_OBJ1, 2));
+        wt.addChild(child);
+        child = new WeightedTree<>(TREE_OBJ2, 3);
+        child.addChild(new WeightedTree<>(TREE_OBJ3, 1));
+        wt.addChild(child);
+        wt.addChild(new WeightedTree<>(TREE_OBJ4, 8));
+        stub.addWeightedTree(OBJ_L23, wt);
+
+        // Prepare weighted trees for l24
+        wt = new WeightedTree<>(TREE_OBJ5, 15);
+        child = new WeightedTree<>(TREE_OBJ2, 12);
+        child.addChild(new WeightedTree<>(TREE_OBJ3, 1));
+        wt.addChild(child);
+        stub.addWeightedTree(OBJ_L24, wt);
+
+        return stub;
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/package-info.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs/weighted/package-info.java
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+@org.eclipse.jdt.annotation.NonNullByDefault
+package org.eclipse.tracecompass.analysis.profiling.core.tests.stubs.weighted;


### PR DESCRIPTION
Move weighted tree tests from incubator that were forgotten when porting callstack.