### PR TITLE
lttng2.kernel: Move CriticalPathParameterProvider to lttng2.core

### DIFF
--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.core/META-INF/MANIFEST.MF
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.core/META-INF/MANIFEST.MF
@@ -24,6 +24,7 @@ Export-Package: org.eclipse.tracecompass.internal.lttng2.kernel.core;x-friends:=
  org.eclipse.tracecompass.internal.lttng2.kernel.core.analysis.graph.building;x-friends:="org.eclipse.tracecompass.lttng2.kernel.ui,org.eclipse.tracecompass.lttng2.kernel.core.tests",
  org.eclipse.tracecompass.internal.lttng2.kernel.core.analysis.graph.handlers;x-friends:="org.eclipse.tracecompass.lttng2.kernel.ui,org.eclipse.tracecompass.lttng2.kernel.core.tests",
  org.eclipse.tracecompass.internal.lttng2.kernel.core.analysis.graph.model;x-friends:="org.eclipse.tracecompass.lttng2.kernel.ui,org.eclipse.tracecompass.lttng2.kernel.core.tests",
+ org.eclipse.tracecompass.internal.lttng2.kernel.core.criticalpath;x-internal:=true,
  org.eclipse.tracecompass.internal.lttng2.kernel.core.event.matching;x-friends:="org.eclipse.tracecompass.lttng2.kernel.core.tests",
  org.eclipse.tracecompass.internal.lttng2.kernel.core.trace.layout;x-friends:="org.eclipse.tracecompass.lttng2.kernel.core.tests,org.eclipse.tracecompass.lttng2.kernel.ui",
  org.eclipse.tracecompass.lttng2.kernel.core.trace

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.core/plugin.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.core/plugin.xml
@@ -49,4 +49,13 @@
          class="org.eclipse.tracecompass.internal.lttng2.kernel.core.analysis.graph.building.LttngGraphHandlerBuilder$HandlerBuilderExecutionGraph"
          priority="10" />
    </extension>
+   <extension
+         point="org.eclipse.linuxtools.tmf.core.analysis">
+      <parameterProvider
+            class="org.eclipse.tracecompass.internal.lttng2.kernel.core.criticalpath.CriticalPathParameterProvider">
+         <analysisId
+               id="org.eclipse.tracecompass.analysis.graph.core.criticalpath">
+         </analysisId>
+      </parameterProvider>
+   </extension>
 </plugin>

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.core/src/org/eclipse/tracecompass/internal/lttng2/kernel/core/criticalpath/CriticalPathParameterProvider.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.core/src/org/eclipse/tracecompass/internal/lttng2/kernel/core/criticalpath/CriticalPathParameterProvider.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.tracecompass.internal.lttng2.kernel.ui.criticalpath;
+package org.eclipse.tracecompass.internal.lttng2.kernel.core.criticalpath;
 
 import org.eclipse.tracecompass.analysis.graph.core.criticalpath.AbstractCriticalPathModule;
 import org.eclipse.tracecompass.analysis.graph.core.criticalpath.OSCriticalPathModule;

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.ui/META-INF/MANIFEST.MF
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.ui/META-INF/MANIFEST.MF
@@ -28,6 +28,5 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional
 Import-Package: com.google.common.collect
 Export-Package: org.eclipse.tracecompass.internal.lttng2.kernel.ui;x-internal:=true,
- org.eclipse.tracecompass.internal.lttng2.kernel.ui.criticalpath;x-internal:=true,
  org.eclipse.tracecompass.internal.lttng2.kernel.ui.views;x-friends:="org.eclipse.tracecompass.lttng2.kernel.ui.swtbot.tests"
 Automatic-Module-Name: org.eclipse.tracecompass.lttng2.kernel.ui

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.ui/plugin.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.ui/plugin.xml
@@ -46,13 +46,4 @@
          </perspective>
       </type>
    </extension>
-   <extension
-         point="org.eclipse.linuxtools.tmf.core.analysis">
-      <parameterProvider
-            class="org.eclipse.tracecompass.internal.lttng2.kernel.ui.criticalpath.CriticalPathParameterProvider">
-         <analysisId
-               id="org.eclipse.tracecompass.analysis.graph.core.criticalpath">
-         </analysisId>
-      </parameterProvider>
-   </extension>
 </plugin>


### PR DESCRIPTION
With this it's possible to re-use it in the Trace Compass trace server.

[Changed] Move CriticalPathParameterProvider to lttng2.core

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>