### PR TITLE
profiling.core: verify that the source flamechart is completed

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/callgraph2/CallGraphAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/callgraph2/CallGraphAnalysis.java
@@ -163,6 +163,9 @@ public class CallGraphAnalysis extends TmfAbstractAnalysisModule implements ICal
             return false;
         }
         IFlameChartProvider callstackModule = fCsProvider;
+        if (!callstackModule.isComplete()) {
+            return false;
+        }
         CallStackSeries callstack = callstackModule.getCallStackSeries();
         if (callstack != null) {
             long time0 = range.getStartTime().toNanos();


### PR DESCRIPTION
This patch corrects an issue where when opening a trace or experiment with the flamegraph view opened, it would schedule that call graph analysis before the call stack analysis was completed. This would result in an incorrect callgraph analysis and the flamegraph view would not work.

This issue was solved by checking that the call stack analysis is completed before calculating the callgraph.

[Fixed] Intermittent error with the flamegraph analysis