### PR TITLE
kernel.ui.swtbot.tests: Fix intermittent failing HelpMessageTest

### DIFF
--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.ui.swtbot.tests/src/org/eclipse/tracecompass/lttng2/kernel/ui/swtbot/tests/HelpMessageTest.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.ui.swtbot.tests/src/org/eclipse/tracecompass/lttng2/kernel/ui/swtbot/tests/HelpMessageTest.java
@@ -78,7 +78,8 @@ public class HelpMessageTest extends KernelTestBase {
             shell.activate();
             SWTBot helpShellBot = shell.bot();
             assertEquals("Help", helpShellBot.canvas().getText());
-            assertEquals(entry.getValue(), helpShellBot.label(1).getText());
+            String text = helpShellBot.label(entry.getValue()).getText();
+            assertEquals(entry.getValue(), text);
             helpShellBot.button().click();
             SWTBotUtils.waitUntil(shellBot -> !shellBot.isOpen(), shell, "Help Dialog did not close.");
         }


### PR DESCRIPTION
The info dialog has multiple labels where one contains the info message. Use the expected value to get the label with the expected info message.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>