### PR TITLE
ctf.core: Explicitly align to support 0-length sequences

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/types/SequenceDeclaration.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/types/SequenceDeclaration.java
@@ -121,6 +121,9 @@ public class SequenceDeclaration extends CompoundDeclaration {
             throw new CTFException("Sequence length too long " + length); //$NON-NLS-1$
         }
 
+        // Explicitly align to support 0-length sequences
+        alignRead(input);
+
         if (isAlignedBytes()) {
             // Don't create "useless" definitions
             byte[] data = new byte[(int) length];


### PR DESCRIPTION
Resolves #58

For a test trace that covers this, see https://github.com/eclipse-tracecompass/tracecompass-test-traces/pull/3

This fix works for me with the above trace. It is based on the proposed babeltrace 1.5 fix (https://bugs.lttng.org/attachments/596) under the original LTTng issue (https://bugs.lttng.org/issues/1412).

I think that this fix is not needed for arrays, because the metadata parser simply rejects arrays with a length of less than 1 (i.e., throws an exception).