### PR TITLE
releng: update alpine to have latest mvn

### DIFF
--- a/releng/dockerfiles/Dockerfile
+++ b/releng/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Polytechnique de Montréal
+# Copyright (c) 2023, 2024 Polytechnique de Montréal
 #
 # All rights reserved. This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0 which
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
-FROM alpine:3.16.0 as packager
+FROM alpine:3.18.0 as packager
 
 RUN apk --no-cache add openjdk17-jdk openjdk17-jmods maven
 
@@ -17,6 +17,7 @@ WORKDIR /app/
 
 RUN mvn clean install -DskipTests -Dskip-rcp -Pfilter-grammar -Pctf-grammar
 
-FROM alpine:3.16.0
+FROM alpine:3.18.0
 
-COPY --from=packager /root/.m2/repository/org/eclipse/tracecompass /root/.m2/repository/org/eclipse/tracecompass
+COPY --from=packager /root/.m2/ /root/.m2/
+


### PR DESCRIPTION
Update the dockerfile because mvn is not up to date to build Trace Compass.