### PR TITLE
tmf: Fix font height in TimeGraphRender.setFontForHeight()

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/widgets/timegraph/TimeGraphRender.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/widgets/timegraph/TimeGraphRender.java
@@ -81,7 +81,7 @@ public final class TimeGraphRender {
 
             /* Set the font for this item */
             int height = fBounds.height;
-            setFontForHeight(height - getMarginForHeight(height), gc);
+            setFontForHeight(height - getMarginForHeight(height) + 2, gc);
 
             for (DeferredItem item : getItems()) {
                 item.draw(provider, gc);

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2007, 2022 Intel Corporation and others
+ * Copyright (c) 2007, 2024 Intel Corporation and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2342,13 +2342,7 @@ public class TimeGraphControl extends TimeGraphBaseControl
                 gc.setForeground(color);
                 int height = (int) (rect.height * heightFactor);
                 TimeGraphRender.setFontForHeight(height, gc);
-                int textSize = (gc.textExtent(symbol).y + 1) / 2;
-                if (VerticalAlign.BOTTOM.equals(verticalAlign)) {
-                    y = rect.y + rect.height / 2 + Math.max(0, rect.height / 2 - textSize);
-                } else if (VerticalAlign.TOP.equals(verticalAlign)) {
-                    y = rect.y + rect.height / 2 - Math.max(0, rect.height / 2 - textSize);
-                }
-                gc.drawText(symbol, rect.x - symbolSize, y - textSize, true);
+                gc.drawText(symbol, rect.x - symbolSize, y - symbolSize, true);
                 gc.setForeground(oldColor);
             }
             gc.setAlpha(OPAQUE);

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
@@ -2763,7 +2763,7 @@ public class TimeGraphControl extends TimeGraphBaseControl
         }
 
         int height = bounds.height - TimeGraphRender.getMarginForHeight(bounds.height);
-        TimeGraphRender.setFontForHeight(height, Objects.requireNonNull(gc));
+        TimeGraphRender.setFontForHeight(height + 2, Objects.requireNonNull(gc));
 
         String name = fLabelProvider == null ? item.fName : fLabelProvider.getColumnText(item.fEntry, 0);
         Rectangle rect = Utils.clone(bounds);


### PR DESCRIPTION
Implement a workaround so that the font height matches the requested pixel height, as the font height in points determined by calculation results in a larger font than expected.

https://github.com/eclipse-platform/eclipse.platform.swt/issues/1193

With the font now matching the requested height, the workaround for the marker symbol text y-position can be removed.

With the font now matching the requested height, request a slightly larger (2px) font height for time graph name and labels, to improve readability. In both cases the text is centered using the actual rendered text height.