### PR TITLE
analysis: Add "Timestamp ns" column in SegmentStoreTableDataProvder

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderExperimentTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderExperimentTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Ericsson
+ * Copyright (c) 2022, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -116,6 +116,7 @@ public class SegmentStoreTableDataProviderExperimentTest {
     private static final String START_TIME_COLUMN_NAME = "Start Time";
     private static final String END_TIME_COLUMN_NAME = "End Time";
     private static final String DURATION_COLUMN_NAME = "Duration";
+    private static final String NS_TIME_COLUMN_NAME = "Timestamp ns";
     private static final String TRACE_COLUMN_NAME = "Trace";
     private static final String MAIN_TRACE_NAME = "main trace";
     private static final String SECOND_TRACE_NAME = "second trace";
@@ -179,6 +180,7 @@ public class SegmentStoreTableDataProviderExperimentTest {
         assertEquals(DURATION_COLUMN_NAME, columnEntries.get(2).getName());
         assertEquals(StubSegmentStoreProvider.STUB_COLUMN_NAME, columnEntries.get(3).getName());
         assertEquals(TRACE_COLUMN_NAME, columnEntries.get(4).getName());
+        assertEquals(NS_TIME_COLUMN_NAME, columnEntries.get(5).getName());
 
         Map<String, Long> expectedColumns = new LinkedHashMap<>();
         for (TmfTreeDataModel column : columnEntries) {
@@ -197,6 +199,7 @@ public class SegmentStoreTableDataProviderExperimentTest {
         assertEquals(END_TIME_COLUMN_NAME, columnEntries.get(1).getName());
         assertEquals(DURATION_COLUMN_NAME, columnEntries.get(2).getName());
         assertEquals(StubSegmentStoreProvider.STUB_COLUMN_NAME, columnEntries.get(3).getName());
+        assertEquals(NS_TIME_COLUMN_NAME, columnEntries.get(4).getName());
 
         Map<String, Long> expectedColumns = new LinkedHashMap<>();
         for (TmfTreeDataModel column : columnEntries) {
@@ -258,19 +261,22 @@ public class SegmentStoreTableDataProviderExperimentTest {
         Long durationColumnId = fColumns.get(DURATION_COLUMN_NAME);
         Long customColumnId = fColumns.get(StubSegmentStoreProvider.STUB_COLUMN_NAME);
         Long traceColumnId = fColumns.get(TRACE_COLUMN_NAME);
+        Long nsTimeColumnId = fColumns.get(NS_TIME_COLUMN_NAME);
 
         assertNotNull(startTimeColumnId);
         assertNotNull(endTimeColumnId);
         assertNotNull(durationColumnId);
         assertNotNull(customColumnId);
         assertNotNull(traceColumnId);
+        assertNotNull(nsTimeColumnId);
 
         List<@NonNull TmfTreeDataModel> expectedColumnEntries = Arrays.asList(
                 new TmfTreeDataModel(startTimeColumnId, -1, Collections.singletonList(START_TIME_COLUMN_NAME)),
                 new TmfTreeDataModel(endTimeColumnId, -1, Collections.singletonList(END_TIME_COLUMN_NAME)),
                 new TmfTreeDataModel(durationColumnId, -1, Collections.singletonList(DURATION_COLUMN_NAME)),
                 new TmfTreeDataModel(customColumnId, -1, Collections.singletonList(StubSegmentStoreProvider.STUB_COLUMN_NAME)),
-                new TmfTreeDataModel(traceColumnId, -1, Collections.singletonList(TRACE_COLUMN_NAME)));
+                new TmfTreeDataModel(traceColumnId, -1, Collections.singletonList(TRACE_COLUMN_NAME)),
+                new TmfTreeDataModel(nsTimeColumnId, -1, Collections.singletonList(NS_TIME_COLUMN_NAME)));
 
         TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> response = fMainDataProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 0, 1)), null);
         TmfTreeModel<@NonNull TmfTreeDataModel> currentColumnModel = response.getModel();
@@ -291,17 +297,20 @@ public class SegmentStoreTableDataProviderExperimentTest {
         Long endTimeColumnId = fSingleTraceColumns.get(END_TIME_COLUMN_NAME);
         Long durationColumnId = fSingleTraceColumns.get(DURATION_COLUMN_NAME);
         Long customColumnId = fSingleTraceColumns.get(StubSegmentStoreProvider.STUB_COLUMN_NAME);
+        Long nsTimeColumnId = fSingleTraceColumns.get(NS_TIME_COLUMN_NAME);
 
         assertNotNull(startTimeColumnId);
         assertNotNull(endTimeColumnId);
         assertNotNull(durationColumnId);
         assertNotNull(customColumnId);
+        assertNotNull(nsTimeColumnId);
 
         List<@NonNull TmfTreeDataModel> expectedColumnEntries = Arrays.asList(
                 new TmfTreeDataModel(startTimeColumnId, -1, Collections.singletonList(START_TIME_COLUMN_NAME)),
                 new TmfTreeDataModel(endTimeColumnId, -1, Collections.singletonList(END_TIME_COLUMN_NAME)),
                 new TmfTreeDataModel(durationColumnId, -1, Collections.singletonList(DURATION_COLUMN_NAME)),
-                new TmfTreeDataModel(customColumnId, -1, Collections.singletonList(StubSegmentStoreProvider.STUB_COLUMN_NAME)));
+                new TmfTreeDataModel(customColumnId, -1, Collections.singletonList(StubSegmentStoreProvider.STUB_COLUMN_NAME)),
+                new TmfTreeDataModel(nsTimeColumnId, -1, Collections.singletonList(NS_TIME_COLUMN_NAME)));
 
         TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> response = fDataProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 0, 1)), null);
         TmfTreeModel<@NonNull TmfTreeDataModel> currentColumnModel = response.getModel();
@@ -318,15 +327,18 @@ public class SegmentStoreTableDataProviderExperimentTest {
         Long startTimeColumnId = fColumns.get(START_TIME_COLUMN_NAME);
         Long endTimeColumnId = fColumns.get(END_TIME_COLUMN_NAME);
         Long durationColumnId = fColumns.get(DURATION_COLUMN_NAME);
+        Long nsTimeColumnId = fColumns.get(NS_TIME_COLUMN_NAME);
 
         assertNotNull(startTimeColumnId);
         assertNotNull(endTimeColumnId);
         assertNotNull(durationColumnId);
+        assertNotNull(nsTimeColumnId);
 
         List<@NonNull TmfTreeDataModel> expectedColumnEntries = Arrays.asList(
                 new TmfTreeDataModel(startTimeColumnId, -1, Collections.singletonList(START_TIME_COLUMN_NAME)),
                 new TmfTreeDataModel(endTimeColumnId, -1, Collections.singletonList(END_TIME_COLUMN_NAME)),
-                new TmfTreeDataModel(durationColumnId, -1, Collections.singletonList(DURATION_COLUMN_NAME)));
+                new TmfTreeDataModel(durationColumnId, -1, Collections.singletonList(DURATION_COLUMN_NAME)),
+                new TmfTreeDataModel(nsTimeColumnId, -1, Collections.singletonList(NS_TIME_COLUMN_NAME)));
 
         TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> response = fInvalidDataProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 0, 1)), null);
         TmfTreeModel<@NonNull TmfTreeDataModel> currentColumnModel = response.getModel();
@@ -344,16 +356,16 @@ public class SegmentStoreTableDataProviderExperimentTest {
     public void testFetchLinesFromDataProviderWithExperiment() {
         VirtualTableQueryFilter queryFilter = new VirtualTableQueryFilter(Collections.emptyList(), 0, 10);
         @NonNull List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(5, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(6, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(7, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(8, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(9, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(6)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))));
+                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(5, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(6, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(7, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(8, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(9, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(6)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fMainDataProvider.fetchLines(FetchParametersUtils.virtualTableQueryToMap(queryFilter), null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -384,16 +396,16 @@ public class SegmentStoreTableDataProviderExperimentTest {
         VirtualTableQueryFilter queryFilter = new VirtualTableQueryFilter(new ArrayList<>(fSingleTraceColumns.values()), 0, 10);
 
         @NonNull List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(5, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(6, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(6)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(8, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(8)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(9, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(9)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(5, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(6, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(6)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(7, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(8, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(8)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(9, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(9)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(FetchParametersUtils.virtualTableQueryToMap(queryFilter), null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -416,11 +428,11 @@ public class SegmentStoreTableDataProviderExperimentTest {
         fetchParameters.put(TABLE_SEARCH_DIRECTION_KEY, NEXT_DIR_UNDER_TEST);
 
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(42, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(43, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(44, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(45, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(46, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(23)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))));
+                new VirtualTableLine(42, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(43, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(44, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(45, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(46, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(23)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))));
 
         expectedData.forEach(sl -> sl.setActiveProperties(CoreFilterProperty.HIGHLIGHT));
 
@@ -446,11 +458,11 @@ public class SegmentStoreTableDataProviderExperimentTest {
         fetchParameters.put(TABLE_SEARCH_DIRECTION_KEY, NEXT_DIR_UNDER_TEST);
 
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(43, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(45, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(47, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(23)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))),
-                new VirtualTableLine(46, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(47, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME))));
+                new VirtualTableLine(43, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(45, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(47, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(23)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(46, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(47, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(22)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(SECOND_TRACE_NAME), new VirtualTableCell(String.valueOf(21)))));
 
         expectedData.get(0).setActiveProperties(CoreFilterProperty.HIGHLIGHT);
         expectedData.get(1).setActiveProperties(CoreFilterProperty.HIGHLIGHT);
@@ -500,16 +512,16 @@ public class SegmentStoreTableDataProviderExperimentTest {
         fetchParameters.put(TABLE_COMPARATOR_EXPRESSION_KEY, traceNameColumnID);
 
         @NonNull List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(5, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(6, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(6)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(7, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(8, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(8)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))),
-                new VirtualTableLine(9, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(9)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME))));
+                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(5, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(6, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(6)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(7, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(8, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(8)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(9, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(9)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(MAIN_TRACE_NAME), new VirtualTableCell(String.valueOf(7)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fMainDataProvider.fetchLines(fetchParameters, null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Ericsson
+ * Copyright (c) 2022, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -67,6 +67,7 @@ public class SegmentStoreTableDataProviderTest {
     private static final String START_TIME_COLUMN_NAME = "Start Time";
     private static final String END_TIME_COLUMN_NAME = "End Time";
     private static final String DURATION_COLUMN_NAME = "Duration";
+    private static final String NS_TIME_COLUMN_NAME = "Timestamp ns";
     private static final String TABLE_COMPARATOR_EXPRESSION_KEY = "table_comparator_expression"; //$NON-NLS-1$
     private static final String TABLE_SEARCH_EXPRESSION_KEY = "table_search_expressions"; //$NON-NLS-1$
     private static final String TABLE_SEARCH_DIRECTION_KEY = "table_search_direction"; //$NON-NLS-1$
@@ -113,6 +114,7 @@ public class SegmentStoreTableDataProviderTest {
         assertEquals(END_TIME_COLUMN_NAME, columnEntries.get(1).getName());
         assertEquals(DURATION_COLUMN_NAME, columnEntries.get(2).getName());
         assertEquals(StubSegmentStoreProvider.STUB_COLUMN_NAME, columnEntries.get(3).getName());
+        assertEquals(NS_TIME_COLUMN_NAME, columnEntries.get(4).getName());
 
         Map<String, Long> expectedColumns = new LinkedHashMap<>();
         for (TmfTreeDataModel column : columnEntries) {
@@ -142,17 +144,20 @@ public class SegmentStoreTableDataProviderTest {
         Long endTimeColumnId = fColumns.get(END_TIME_COLUMN_NAME);
         Long durationColumnId = fColumns.get(DURATION_COLUMN_NAME);
         Long customColumndId = fColumns.get(StubSegmentStoreProvider.STUB_COLUMN_NAME);
+        Long nsTimeColumnId = fColumns.get(NS_TIME_COLUMN_NAME);
 
         assertNotNull(startTimeColumnId);
         assertNotNull(endTimeColumnId);
         assertNotNull(durationColumnId);
         assertNotNull(customColumndId);
+        assertNotNull(nsTimeColumnId);
 
         List<@NonNull TmfTreeDataModel> expectedColumnEntries = Arrays.asList(
                 new TmfTreeDataModel(startTimeColumnId, -1, Collections.singletonList(START_TIME_COLUMN_NAME)),
                 new TmfTreeDataModel(endTimeColumnId, -1, Collections.singletonList(END_TIME_COLUMN_NAME)),
                 new TmfTreeDataModel(durationColumnId, -1, Collections.singletonList(DURATION_COLUMN_NAME)),
-                new TmfTreeDataModel(customColumndId, -1, Collections.singletonList(StubSegmentStoreProvider.STUB_COLUMN_NAME)));
+                new TmfTreeDataModel(customColumndId, -1, Collections.singletonList(StubSegmentStoreProvider.STUB_COLUMN_NAME)),
+                new TmfTreeDataModel(nsTimeColumnId, -1, Collections.singletonList(NS_TIME_COLUMN_NAME)));
 
         TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> response = fDataProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 0, 1)), null);
         TmfTreeModel<@NonNull TmfTreeDataModel> currentColumnModel = response.getModel();
@@ -169,11 +174,11 @@ public class SegmentStoreTableDataProviderTest {
     public void testDataProviderFetchLineZeroIndex() {
         VirtualTableQueryFilter queryFilter = new VirtualTableQueryFilter(Collections.emptyList(), 0, 5);
         @NonNull List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(FetchParametersUtils.virtualTableQueryToMap(queryFilter), null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -191,11 +196,11 @@ public class SegmentStoreTableDataProviderTest {
     public void testDataProviderFetchLineNonZeroIndex() {
         VirtualTableQueryFilter queryFilter = new VirtualTableQueryFilter(Collections.emptyList(), 10, 5);
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(10, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(10)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(11, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(11)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(12, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(12)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(13, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(13)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(14, Arrays.asList(new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(10, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(10)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(11, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(11)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(12, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(12)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(13, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(13)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(14, Arrays.asList(new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(14)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(FetchParametersUtils.virtualTableQueryToMap(queryFilter), null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -213,11 +218,11 @@ public class SegmentStoreTableDataProviderTest {
     public void testDataProviderFetchLineTimeOut() {
         VirtualTableQueryFilter queryFilter = new VirtualTableQueryFilter(Collections.emptyList(), 3200, 5);
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(3200, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3200)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3201, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3201)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3202, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3202)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3203, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3203)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3204, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3204)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(3200, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3200)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(3199)))),
+                new VirtualTableLine(3201, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3201)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(3199)))),
+                new VirtualTableLine(3202, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3202)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(3199)))),
+                new VirtualTableLine(3203, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3203)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(3199)))),
+                new VirtualTableLine(3204, Arrays.asList(new VirtualTableCell(lineTime(3199)), new VirtualTableCell(lineTime(3204)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(3199)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(FetchParametersUtils.virtualTableQueryToMap(queryFilter), null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -234,11 +239,11 @@ public class SegmentStoreTableDataProviderTest {
     public void testDataProviderFetchLineCornerIndex() {
         VirtualTableQueryFilter queryFilter = new VirtualTableQueryFilter(Collections.emptyList(), 1000, 5);
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(1000, Arrays.asList(new VirtualTableCell(lineTime(994)), new VirtualTableCell(lineTime(1000)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1001, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1002, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1002)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1003, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1003)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1004, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1004)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(1000, Arrays.asList(new VirtualTableCell(lineTime(994)), new VirtualTableCell(lineTime(1000)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(994)))),
+                new VirtualTableLine(1001, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(1001)))),
+                new VirtualTableLine(1002, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1002)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(1001)))),
+                new VirtualTableLine(1003, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1003)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(1001)))),
+                new VirtualTableLine(1004, Arrays.asList(new VirtualTableCell(lineTime(1001)), new VirtualTableCell(lineTime(1004)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(1001)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(FetchParametersUtils.virtualTableQueryToMap(queryFilter), null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -262,11 +267,11 @@ public class SegmentStoreTableDataProviderTest {
         fetchParameters.put(TABLE_SEARCH_DIRECTION_KEY, NEXT_DIR_UNDER_TEST);
 
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(7000, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7001, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7001)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7002, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7002)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7003, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7003)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7004, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7004)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(7000, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7001, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7001)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7002, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7002)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7003, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7003)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7004, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7004)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))));
         expectedData.forEach(sl -> sl.setActiveProperties(CoreFilterProperty.HIGHLIGHT));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(fetchParameters, null);
@@ -293,11 +298,11 @@ public class SegmentStoreTableDataProviderTest {
         fetchParameters.put(TABLE_SEARCH_DIRECTION_KEY, PREV_DIR_UNDER_TEST);
 
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(7006, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7006)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7005, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7005)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7004, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7004)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7003, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7003)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(7002, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7002)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(7006, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7006)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7005, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7005)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7004, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7004)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7003, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7003)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))),
+                new VirtualTableLine(7002, Arrays.asList(new VirtualTableCell(lineTime(7000)), new VirtualTableCell(lineTime(7002)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7000)))));
         expectedData.forEach(sl -> sl.setActiveProperties(CoreFilterProperty.HIGHLIGHT));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(fetchParameters, null);
@@ -344,7 +349,7 @@ public class SegmentStoreTableDataProviderTest {
                 previousStartTime = i;
             }
             expectedData.add(new VirtualTableLine(i,
-                    Arrays.asList(new VirtualTableCell(lineTime(previousStartTime)), new VirtualTableCell(lineTime(i)), new VirtualTableCell(lineDuration(i - previousStartTime)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                    Arrays.asList(new VirtualTableCell(lineTime(previousStartTime)), new VirtualTableCell(lineTime(i)), new VirtualTableCell(lineDuration(i - previousStartTime)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(previousStartTime)))));
         }
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(FetchParametersUtils.virtualTableQueryToMap(queryFilter), null);
@@ -368,11 +373,11 @@ public class SegmentStoreTableDataProviderTest {
         assertNotNull(endTimeColumnID);
         fetchParameters.put(TABLE_COMPARATOR_EXPRESSION_KEY, endTimeColumnID);
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(65534)), new VirtualTableCell(lineTime(65534)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65533)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65532)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65531)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65530)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(65534)), new VirtualTableCell(lineTime(65534)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65534)))),
+                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65533)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65527)))),
+                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65532)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65527)))),
+                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65531)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65527)))),
+                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(65527)), new VirtualTableCell(lineTime(65530)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65527)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(fetchParameters, null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -395,11 +400,11 @@ public class SegmentStoreTableDataProviderTest {
         fetchParameters.put(TABLE_COMPARATOR_EXPRESSION_KEY, durationColumnID);
 
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(28)), new VirtualTableCell(lineTime(28)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(0, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(1, Arrays.asList(new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineTime(7)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(7)))),
+                new VirtualTableLine(2, Arrays.asList(new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineTime(14)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(14)))),
+                new VirtualTableLine(3, Arrays.asList(new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineTime(21)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(21)))),
+                new VirtualTableLine(4, Arrays.asList(new VirtualTableCell(lineTime(28)), new VirtualTableCell(lineTime(28)), new VirtualTableCell(lineDuration(0)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(28)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(fetchParameters, null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -422,11 +427,11 @@ public class SegmentStoreTableDataProviderTest {
         fetchParameters.put(TABLE_COMPARATOR_EXPRESSION_KEY, endTimeColumnID);
 
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(65529, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65530, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65531, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65532, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65533, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(65529, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(5)), new VirtualTableCell(lineDuration(5)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(65530, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(4)), new VirtualTableCell(lineDuration(4)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(65531, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(3)), new VirtualTableCell(lineDuration(3)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(65532, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(2)), new VirtualTableCell(lineDuration(2)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))),
+                new VirtualTableLine(65533, Arrays.asList(new VirtualTableCell(lineTime(0)), new VirtualTableCell(lineTime(1)), new VirtualTableCell(lineDuration(1)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(0)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(fetchParameters, null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();
@@ -449,11 +454,11 @@ public class SegmentStoreTableDataProviderTest {
         fetchParameters.put(TABLE_COMPARATOR_EXPRESSION_KEY, durationColumnID);
 
         List<@NonNull VirtualTableLine> expectedData = Arrays.asList(
-                new VirtualTableLine(65529, Arrays.asList(new VirtualTableCell(lineTime(65492)), new VirtualTableCell(lineTime(65498)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65530, Arrays.asList(new VirtualTableCell(lineTime(65499)), new VirtualTableCell(lineTime(65505)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65531, Arrays.asList(new VirtualTableCell(lineTime(65506)), new VirtualTableCell(lineTime(65512)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65532, Arrays.asList(new VirtualTableCell(lineTime(65513)), new VirtualTableCell(lineTime(65519)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))),
-                new VirtualTableLine(65533, Arrays.asList(new VirtualTableCell(lineTime(65520)), new VirtualTableCell(lineTime(65526)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT))));
+                new VirtualTableLine(65529, Arrays.asList(new VirtualTableCell(lineTime(65492)), new VirtualTableCell(lineTime(65498)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65492)))),
+                new VirtualTableLine(65530, Arrays.asList(new VirtualTableCell(lineTime(65499)), new VirtualTableCell(lineTime(65505)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65499)))),
+                new VirtualTableLine(65531, Arrays.asList(new VirtualTableCell(lineTime(65506)), new VirtualTableCell(lineTime(65512)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65506)))),
+                new VirtualTableLine(65532, Arrays.asList(new VirtualTableCell(lineTime(65513)), new VirtualTableCell(lineTime(65519)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65513)))),
+                new VirtualTableLine(65533, Arrays.asList(new VirtualTableCell(lineTime(65520)), new VirtualTableCell(lineTime(65526)), new VirtualTableCell(lineDuration(6)), new VirtualTableCell(StubSegmentStoreProvider.STUB_COLUMN_CONTENT), new VirtualTableCell(String.valueOf(65520)))));
 
         TmfModelResponse<@NonNull ITmfVirtualTableModel<@NonNull VirtualTableLine>> response = fDataProvider.fetchLines(fetchParameters, null);
         ITmfVirtualTableModel<@NonNull VirtualTableLine> currentModel = response.getModel();

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Ericsson
+ * Copyright (c) 2022, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -65,6 +65,7 @@ import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 import org.eclipse.tracecompass.tmf.core.segment.SegmentDurationAspect;
 import org.eclipse.tracecompass.tmf.core.segment.SegmentEndTimeAspect;
+import org.eclipse.tracecompass.tmf.core.segment.SegmentStartNsTimeAspect;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 
@@ -352,6 +353,19 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
                 }
                 model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName())));
             }
+        }
+
+        ISegmentAspect aspect = SegmentStartNsTimeAspect.SEGMENT_START_NS_TIME_ASPECT;
+        synchronized (fAspectToIdMap) {
+            long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
+            Comparator<ISegment> comparator = (Comparator<ISegment>) aspect.getComparator();
+            if (comparator != null && aspect.getName().equals(SegmentEndTimeAspect.SEGMENT_END_TIME_ASPECT.getName())) {
+                comparator = comparator.reversed();
+            }
+            if (comparator != null) {
+                buildIndex(id, comparator, aspect.getName());
+            }
+            model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName())));
         }
         return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), model), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
     }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/Messages.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Ericsson
+ * Copyright (c) 2019, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -26,6 +26,8 @@ public class Messages extends NLS {
     public static String SegmentEndTimeAspect_endDescription;
     /** Segment duration */
     public static String SegmentDurationAspect_durationDescription;
+    /** Segment start time (ns timestamp)*/
+    public static String SegmentStartNsTimeAspect_startDescription;
 
     static {
         // initialize resource bundle

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/messages.properties
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Ericsson
+# Copyright (c) 2019, 2024 Ericsson
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -13,5 +13,6 @@
 ###############################################################################
 
 SegmentStartTimeAspect_startDescription=Start time of the segment
+SegmentStartNsTimeAspect_startDescription=Start time of the segment in nano seconds
 SegmentEndTimeAspect_endDescription=End time of the segment
 SegmentDurationAspect_durationDescription=Segment duration

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/TmfStrings.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/TmfStrings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 École Polytechnique de Montréal
+ * Copyright (c) 2019, 2024 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -90,4 +90,15 @@ public final class TmfStrings {
     public static String source() {
         return Objects.requireNonNull(org.eclipse.tracecompass.internal.tmf.core.aspect.Messages.TmfCallsiteAspect_name);
     }
+
+    /**
+     * Get the string for nanosecond timestamp
+     *
+     * @return the label for nanosecond timestamp
+     * @since 9.3
+     */
+    public static @NonNull String nsTime() {
+        return Objects.requireNonNull(org.eclipse.tracecompass.tmf.core.event.aspect.Messages.AspectName_Timestamp_Nanoseconds);
+    }
+
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartNsTimeAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartNsTimeAspect.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.tmf.core.segment;
+
+import java.util.Comparator;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.common.core.NonNullUtils;
+import org.eclipse.tracecompass.internal.tmf.core.segment.Messages;
+import org.eclipse.tracecompass.segmentstore.core.ISegment;
+import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
+import org.eclipse.tracecompass.tmf.core.TmfStrings;
+
+/**
+ * An aspect used to get the start time of a segment. It can be used with most
+ * segment types.
+ *
+ * @author David Piché
+ * @since 9.3
+ *
+ */
+public final class SegmentStartNsTimeAspect implements ISegmentAspect {
+
+    /**
+     * The Segment start time aspect instance
+     */
+    public static final ISegmentAspect SEGMENT_START_NS_TIME_ASPECT = new SegmentStartNsTimeAspect();
+
+    /**
+     * Constructor
+     */
+    private SegmentStartNsTimeAspect() {
+        // Do nothing
+    }
+
+    @Override
+    public @NonNull String getName() {
+        return TmfStrings.nsTime();
+    }
+
+    @Override
+    public @NonNull String getHelpText() {
+        return NonNullUtils.nullToEmptyString(Messages.SegmentStartNsTimeAspect_startDescription);
+    }
+
+    @Override
+    public @Nullable Comparator<?> getComparator() {
+        return SegmentComparators.INTERVAL_START_COMPARATOR.thenComparing(Comparator.comparingLong(ISegment::getLength));
+    }
+
+    @Override
+    public @Nullable Long resolve(@NonNull ISegment segment) {
+        return segment.getStart();
+    }
+
+    @Override
+    public @NonNull SegmentType getType() {
+        return ISegmentAspect.SegmentType.CONTINUOUS;
+    }
+}


### PR DESCRIPTION
This will allow time synchronization when selecting a row in the Theia/VsCode extension to the trace server.

Fixes #74

[Added] "Timestamp ns" column in SegmentStoreTableDataProvder

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>