### PR TITLE
linux.core: Make getStatusIntervalsForThreads handle out of range queries

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernel/KernelThreadInformationProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernel/KernelThreadInformationProvider.java
@@ -548,12 +548,16 @@ public final class KernelThreadInformationProvider {
         if (ss == null) {
             return Objects.requireNonNull(Collections.emptyMap());
         }
+        List<Long> currentTimes = times.stream().filter(time -> (time > ss.getCurrentEndTime() || time < ss.getStartTime())).sorted().collect(Collectors.toList());
+        if (currentTimes.isEmpty()) {
+            return Objects.requireNonNull(Collections.emptyMap());
+        }
         Map<Integer, String> quarkToThreadIds = getQuarkToThreadIds(module, threadIds);
         TreeMultimap<String, ITmfStateInterval> intervals = TreeMultimap.create(Comparator.naturalOrder(),
                 Comparator.comparing(ITmfStateInterval::getStartTime));
         Map<Integer, List<ITmfStateInterval>> kernelStatuses = new HashMap<>();
         try {
-            for (ITmfStateInterval interval : ss.query2D(quarkToThreadIds.keySet(), times)) {
+            for (ITmfStateInterval interval : ss.query2D(quarkToThreadIds.keySet(), currentTimes)) {
                 if (monitor.isCanceled()) {
                     return Objects.requireNonNull(Collections.emptyMap());
                 }


### PR DESCRIPTION
This avoids many TimeRangeExceptions and undefined behaviour. It is visible when a kernel trace partially overlaps a userspace trace with a new callstack. The behavour is now defined rather than crashing out with an exception.