### PR TITLE
ctf2: add varints support and testing

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/IntegerDeclarationTest.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/IntegerDeclarationTest.java
@@ -72,6 +72,29 @@ public class IntegerDeclarationTest {
     }
 
     /**
+     * Run the createVarintDeclaration method test (boolean, int, String,
+     * boolean)
+     */
+    @Test
+    public void testVarintDeclaration() {
+        boolean signed = false;
+        boolean varint = true;
+        int base = 1;
+        ByteOrder byteOrder = ByteOrder.LITTLE_ENDIAN;
+
+        IntegerDeclaration result = IntegerDeclaration.createVarintDeclaration(signed, base, null, varint);
+
+        assertNotNull(result);
+        assertEquals(1, result.getBase());
+        assertEquals(true, result.isVarint());
+        String outputValue = "[declaration] integer[";
+        assertEquals(outputValue,
+                result.toString().substring(0, outputValue.length()));
+        assertEquals(byteOrder, result.getByteOrder());
+        assertEquals(false, result.isSigned());
+    }
+
+    /**
      * Test the factory part more rigorously to make sure there are no
      * regressions
      */
@@ -156,6 +179,15 @@ public class IntegerDeclarationTest {
     @Test
     public void testIsCharacter() {
         boolean result = fixture.isCharacter();
+        assertEquals(false, result);
+    }
+
+    /**
+     * Run the boolean isVarint() method test.
+     */
+    @Test
+    public void testIsVarint() {
+        boolean result = fixture.isVarint();
         assertEquals(false, result);
     }
 

--- a/ctf/org.eclipse.tracecompass.ctf.core/META-INF/MANIFEST.MF
+++ b/ctf/org.eclipse.tracecompass.ctf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 4.4.1.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.ctf.core;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/TypeAliasParser.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/TypeAliasParser.java
@@ -49,6 +49,7 @@ import com.google.gson.JsonPrimitive;
 public final class TypeAliasParser extends AbstractScopedCommonTreeParser {
 
     private static final String SIGNED = "signed"; //$NON-NLS-1$
+    private static final String VARINT = "varint"; //$NON-NLS-1$
 
     /**
      * Parameters for the typealias parser
@@ -136,9 +137,19 @@ public final class TypeAliasParser extends AbstractScopedCommonTreeParser {
             if (fieldClass != null) {
                 if (JsonMetadataStrings.FIXED_UNSIGNED_INTEGER_FIELD.equals(type)) {
                     fieldClass.addProperty(SIGNED, false);
+                    fieldClass.addProperty(VARINT, false);
                     targetDeclaration = IntegerDeclarationParser.INSTANCE.parse(typealias, new IntegerDeclarationParser.Param(trace));
                 } else if (JsonMetadataStrings.FIXED_SIGNED_INTEGER_FIELD.equals(type)) {
                     fieldClass.addProperty(SIGNED, true);
+                    fieldClass.addProperty(VARINT, false);
+                    targetDeclaration = IntegerDeclarationParser.INSTANCE.parse(typealias, new IntegerDeclarationParser.Param(trace));
+                } else if (JsonMetadataStrings.VARIABLE_UNSIGNED_INTEGER_FIELD.equals(type)) {
+                    fieldClass.addProperty(SIGNED, false);
+                    fieldClass.addProperty(VARINT, true);
+                    targetDeclaration = IntegerDeclarationParser.INSTANCE.parse(typealias, new IntegerDeclarationParser.Param(trace));
+                } else if (JsonMetadataStrings.VARIABLE_SIGNED_INTEGER_FIELD.equals(type)) {
+                    fieldClass.addProperty(SIGNED, true);
+                    fieldClass.addProperty(VARINT, true);
                     targetDeclaration = IntegerDeclarationParser.INSTANCE.parse(typealias, new IntegerDeclarationParser.Param(trace));
                 } else if (JsonMetadataStrings.STATIC_LENGTH_BLOB.equals(type)) {
                     targetDeclaration = BlobDeclarationParser.INSTANCE.parse(typealias, null);

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/utils/JsonMetadataStrings.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/utils/JsonMetadataStrings.java
@@ -123,14 +123,24 @@ public final class JsonMetadataStrings {
     public static final String ALIAS = "alias"; //$NON-NLS-1$
 
     /**
-     * Type string for an unsigned integer field class
+     * Type string for an unsigned fixed integer field class
      */
     public static final String FIXED_UNSIGNED_INTEGER_FIELD = "fixed-length-unsigned-integer"; //$NON-NLS-1$
 
     /**
-     * Type string for a signed integer field class
+     * Type string for a signed fixed integer field class
      */
     public static final String FIXED_SIGNED_INTEGER_FIELD = "fixed-length-signed-integer"; //$NON-NLS-1$
+
+    /**
+     * Type string for an unsigned variable integer field class
+     */
+    public static final String VARIABLE_UNSIGNED_INTEGER_FIELD = "variable-length-unsigned-integer"; //$NON-NLS-1$
+
+    /**
+     * Type string for a signed variable integer field class
+     */
+    public static final String VARIABLE_SIGNED_INTEGER_FIELD = "variable-length-signed-integer"; //$NON-NLS-1$
 
     /**
      * Type string for a static length blob field class

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/utils/LEB128.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/utils/LEB128.java
@@ -13,10 +13,11 @@ package org.eclipse.tracecompass.internal.ctf.core.utils;
 
 import java.io.DataInput;
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import org.eclipse.tracecompass.ctf.core.CTFException;
+import org.eclipse.tracecompass.ctf.core.event.io.BitBuffer;
 
 /**
- * LEB128 decoding utility functions. 
+ * LEB128 decoding utility functions.
  * Original implementation: https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/200680
  *
  * @author Matthew Khouzam
@@ -25,20 +26,24 @@ import java.nio.ByteBuffer;
  */
 public class LEB128 {
     /**
-     * Reads an unsigned LEB128 encoded integer from a ByteBuffer. The decoding
+     * Reads an unsigned LEB128 encoded integer from a BitBuffer. The decoding
      * stops if the shift exceeds 64 bits to prevent overflow, as a long can
      * only support up to 64 bits.
      *
      * @param in
-     *            ByteBuffer containing the LEB128 encoded integer.
+     *            BitBuffer containing the LEB128 encoded integer.
      * @return The decoded integer as a long.
+     * @throws CTFException
+     *             An error occurred reading the data. If more than 64 bits at a
+     *             time are read, or the buffer is read beyond its end, this
+     *             exception will be raised.
      */
-    public static long readUnsignedLeb(ByteBuffer in) {
+    public static long readUnsignedLeb(BitBuffer in) throws CTFException {
         long result = 0;
         long shift = 0;
         byte current = 0;
         do {
-            current = in.get();
+            current = (byte) in.get(8, false);
             result |= ((long) (current & 0x7f)) << shift;
             shift += 7;
         } while ((current & 0x80) != 0 && shift < 64);
@@ -70,20 +75,24 @@ public class LEB128 {
     }
 
     /**
-     * Reads a signed LEB128 encoded integer from a ByteBuffer. The decoding
+     * Reads a signed LEB128 encoded integer from a BitBuffer. The decoding
      * stops if the shift exceeds 64 bits to prevent overflow, as a long can
      * only support up to 64 bits.
      *
      * @param in
-     *            ByteBuffer containing the LEB128 encoded integer.
+     *            BitBuffer containing the LEB128 encoded integer.
      * @return The decoded signed integer as a long.
+     * @throws CTFException
+     *             An error occurred reading the data. If more than 64 bits at a
+     *             time are read, or the buffer is read beyond its end, this
+     *             exception will be raised.
      */
-    public static long readSignedLeb(ByteBuffer in) {
+    public static long readSignedLeb(BitBuffer in) throws CTFException {
         long result = 0;
         int shift = 0;
         byte current;
         do {
-            current = in.get();
+            current = (byte) in.get(8, false);
             result |= ((long) (current & 0x7f)) << shift;
             shift += 7;
         } while ((current & 0x80) != 0 && shift < 64);


### PR DESCRIPTION
Adding variable-length integer support according to [CTF2-SPEC-2.0]

Testing of this feature can be done using the following test-trace:
https://github.com/eclipse-tracecompass/tracecompass-test-traces/pull/8

[CTF2-SPEC-2.0]: https://diamon.org/ctf/#vl-int-fc

Signed-off-by: Vlad Arama <vlad.arama@ericsson.com>