### PR TITLE
tmf: Fix stream orElse(null) errors

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/execution/graph/OsWorker.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/execution/graph/OsWorker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 École Polytechnique de Montréal
+ * Copyright (c) 2015, 2024 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -96,8 +96,8 @@ public class OsWorker implements IGraphWorker {
             return Collections.emptyMap();
         }
         ImmutableMap.Builder<String, String> workerInfo = new Builder<>();
-        workerInfo.put(OsStrings.tid(), String.valueOf(tid)); //$NON-NLS-1$
-        Optional<@Nullable KernelAnalysisModule> kam = TmfTraceManager.getInstance().getActiveTraceSet()
+        workerInfo.put(OsStrings.tid(), String.valueOf(tid));
+        Optional<@NonNull KernelAnalysisModule> kam = TmfTraceManager.getInstance().getActiveTraceSet()
                 .stream()
                 .filter(trace -> trace.getHostId().equals(getHostId()))
                 .map(trace -> TmfTraceUtils.getAnalysisModuleOfClass(trace, KernelAnalysisModule.class, KernelAnalysisModule.ID))

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/model/CompositeHostModel.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/model/CompositeHostModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 École Polytechnique de Montréal
+ * Copyright (c) 2016, 2024 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -114,19 +114,20 @@ public class CompositeHostModel implements IHostModel {
 
     @Override
     public int getProcessId(int tid, long t) {
-        Integer pid = fKernelModules.stream()
+        Optional<Integer> pid = fKernelModules.stream()
                 .map(module -> KernelThreadInformationProvider.getProcessId(module, tid, t))
                 .filter(Objects::nonNull)
-                .findFirst().orElse(null);
-        return pid == null ? IHostModel.UNKNOWN_TID : (int) pid;
+                .findFirst();
+        return pid.isEmpty() ? IHostModel.UNKNOWN_TID : pid.get();
     }
 
     @Override
     public @Nullable String getExecName(int tid, long t) {
-        return fKernelModules.stream()
+        Optional<String> execName = fKernelModules.stream()
                 .map(module -> KernelThreadInformationProvider.getExecutableName(module, tid))
                 .filter(Objects::nonNull)
-                .findFirst().orElse(null);
+                .findFirst();
+        return execName.isPresent() ? execName.get() : null;
     }
 
     /**

--- a/tmf/org.eclipse.tracecompass.tmf.remote.core/src/org/eclipse/tracecompass/tmf/remote/core/proxy/TmfRemoteConnectionFactory.java
+++ b/tmf/org.eclipse.tracecompass.tmf.remote.core/src/org/eclipse/tracecompass/tmf/remote/core/proxy/TmfRemoteConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Ericsson
+ * Copyright (c) 2015, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -21,6 +21,7 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -228,12 +229,12 @@ public class TmfRemoteConnectionFactory {
         if (manager == null) {
             return null;
         }
-        return manager.getAllRemoteConnections().stream()
+        Optional<IRemoteConnection> remoteConnection = manager.getAllRemoteConnections().stream()
                 .filter(Objects::nonNull)
                 .filter(connection -> connection.getName().equals(name))
                 .filter(connection -> connection.getConnectionType().getId().equals(remoteServicesId))
-                .findFirst()
-                .orElse(null);
+                .findFirst();
+        return remoteConnection.isPresent() ? remoteConnection.get() : null;
     }
 
     /**

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfExperimentFolder.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfExperimentFolder.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
@@ -189,11 +190,11 @@ public class TmfExperimentFolder extends TmfProjectModelElement implements IProp
      * @since 2.0
      */
     public @Nullable TmfExperimentElement getExperiment(@NonNull String name) {
-        return getExperiments().stream()
+        Optional<@NonNull TmfExperimentElement> exp = getExperiments().stream()
                 .filter(Objects::nonNull)
                 .filter(experiment -> experiment.getName().equals(name))
-                .findFirst()
-                .orElse(null);
+                .findFirst();
+        return exp.isPresent() ? exp.get() : null;
     }
 
 


### PR DESCRIPTION
It seems that filter(Objects::nonNull) now changes the stream type to a <@NonNull E>, so that orElse(null) is no longer allowed. Change to check the optional presence before returning null.