### PR TITLE
tmf: Allow TmfTrace to refresh it's analysis modules

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 9.3.0.qualifier
+Bundle-Version: 9.4.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tmf.core.Activator

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/TmfAnalysisManager.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/TmfAnalysisManager.java
@@ -82,6 +82,18 @@ public class TmfAnalysisManager {
     }
 
     /**
+     * Deregisters a source of modules
+     *
+     * @param source
+     *            A {@link IAnalysisModuleSource} instance
+     * @since 9.4
+     */
+    public static synchronized void deregisterModuleSource(IAnalysisModuleSource source) {
+        fSources.remove(source);
+        refreshModules();
+    }
+
+    /**
      * Initializes sources and new module listeners from the extension point
      */
     public static synchronized void initialize() {

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/ITmfTrace.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/ITmfTrace.java
@@ -27,6 +27,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.math.SaturatedArithmetic;
@@ -271,6 +272,17 @@ public interface ITmfTrace extends ITmfEventProvider {
      * @return An iterable view of the analysis modules
      */
     @NonNull Iterable<@NonNull IAnalysisModule> getAnalysisModules();
+
+    /**
+     * Refresh the analysis modules for this traces
+     *
+     * @return An IStatus indicating whether the analysis could be run
+     *         successfully or not
+     * @since 9.4
+     */
+    default IStatus refreshAnalysisModules() {
+        return Status.OK_STATUS;
+    }
 
     // ------------------------------------------------------------------------
     // Aspect getters


### PR DESCRIPTION
With this API analysis modules can be added or removed through the analysis framework while trace is open.

[Added] API to refresh analysis modules of an ITmfTrace.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>