### PR TITLE
tmf: Add interface to clear persistent data of analysis modules

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/statesystem/StateSystemAnalysisModuleTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/statesystem/StateSystemAnalysisModuleTest.java
@@ -516,4 +516,56 @@ public class StateSystemAnalysisModuleTest {
             TestStateSystemProvider.setEventHandler(null);
         }
     }
+
+    /**
+     * Test clearing persistent data
+     *
+     * @throws TmfAnalysisException
+     *             An exception when setting the trace
+     */
+    @Test
+    public void testClearSsModule() throws TmfAnalysisException {
+        TestStateSystemModule module = new TestStateSystemModule(true);
+        TestStateSystemModule module2 = new TestStateSystemModule(true);
+        try {
+            ITmfTrace trace = fTrace;
+            assertNotNull(trace);
+            module.setTrace(trace);
+            module2.setTrace(trace);
+
+            // Execute the first module
+            module.schedule();
+            assertTrue(module.waitForCompletion());
+
+            // Check if state system file exists
+            File ssFile = module.getSsFile();
+            assertNotNull(ssFile);
+            assertTrue(ssFile.exists());
+
+            // Delete state system file while open
+            module.clearPersistentData();
+
+            // The state system file should be deleted
+            ssFile = module.getSsFile();
+            assertNotNull(ssFile);
+            assertFalse(ssFile.exists());
+
+            // Re-schedule
+            module.schedule();
+            assertTrue(module.waitForCompletion());
+            // Dispose module (close file)
+            module.dispose();
+
+            module2.clearPersistentData();
+
+            // Delete state system file while closed
+            ssFile = module.getSsFile();
+            assertNotNull(ssFile);
+            assertFalse(ssFile.exists());
+        } finally {
+            module.dispose();
+            module2.dispose();
+        }
+    }
+
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 9.3.0.qualifier
+Bundle-Version: 9.4.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tmf.core.Activator

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/IAnalysisModule.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/IAnalysisModule.java
@@ -295,4 +295,17 @@ public interface IAnalysisModule extends ITmfComponent, IAnalysisRequirementProv
      *            The of the parameter that changed
      */
     void notifyParameterChanged(@NonNull String name);
+
+    /**
+     * Clear persistent data that an analysis module may create. This can be
+     * used to re-execute the analysis without having to close the trace.
+     *
+     * Callers of this method are responsible to notify users of the analysis
+     * module and schedule the analysis again.
+     *
+     * @since 9.4
+     */
+    default void clearPersistentData() {
+        cancel();
+    }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/TmfStateSystemAnalysisModule.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/TmfStateSystemAnalysisModule.java
@@ -896,4 +896,35 @@ public abstract class TmfStateSystemAnalysisModule extends TmfAbstractAnalysisMo
         }
         return properties;
     }
+
+
+    /**
+     * @since 9.4
+     */
+    @Override
+    public void clearPersistentData() {
+        super.clearPersistentData();
+        if (fStateSystem != null) {
+            // State system is open
+            fStateSystem.removeFiles();
+        } else {
+            // State system is closed... delete directly
+            StateSystemBackendType backend = getBackendType();
+            switch (backend) {
+            case FULL:
+            case PARTIAL:
+                File htFile = getSsFile();
+                if ((htFile != null) && (htFile.exists())) {
+                    htFile.delete();
+                }
+                break;
+                //$CASES-OMITTED$
+            default:
+                break;
+            }
+        }
+
+        // Reset analysis so that it can be scheduled again
+        resetAnalysis();
+    }
 }


### PR DESCRIPTION
- Implement method for TmfStateSystemAnalysisModule
- This allows to delete state systems from the analysis module.
If state system is open, it will close the state system files first
before deleting the file. Otherwise delete the file directly.
- Calling methods are responsible to re-trigger the analysis execution

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>