### PR TITLE
analysis: Add "Timestamp ns" column in SegmentStoreTableDataProvder

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
@@ -65,6 +65,7 @@ import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 import org.eclipse.tracecompass.tmf.core.segment.SegmentDurationAspect;
 import org.eclipse.tracecompass.tmf.core.segment.SegmentEndTimeAspect;
+import org.eclipse.tracecompass.tmf.core.segment.SegmentStartNsTimeAspect;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 
@@ -352,6 +353,19 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
                 }
                 model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName())));
             }
+        }
+
+        ISegmentAspect aspect = SegmentStartNsTimeAspect.SEGMENT_START_NS_TIME_ASPECT;
+        synchronized (fAspectToIdMap) {
+            long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
+            Comparator<ISegment> comparator = (Comparator<ISegment>) aspect.getComparator();
+            if (comparator != null && aspect.getName().equals(SegmentEndTimeAspect.SEGMENT_END_TIME_ASPECT.getName())) {
+                comparator = comparator.reversed();
+            }
+            if (comparator != null) {
+                buildIndex(id, comparator, aspect.getName());
+            }
+            model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName())));
         }
         return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), model), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
     }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/Messages.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/Messages.java
@@ -26,6 +26,8 @@ public class Messages extends NLS {
     public static String SegmentEndTimeAspect_endDescription;
     /** Segment duration */
     public static String SegmentDurationAspect_durationDescription;
+    /** Segment start time (ns timestamp)*/
+    public static String SegmentStartNsTimeAspect_startDescription;
 
     static {
         // initialize resource bundle

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/messages.properties
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/segment/messages.properties
@@ -13,5 +13,6 @@
 ###############################################################################
 
 SegmentStartTimeAspect_startDescription=Start time of the segment
+SegmentStartNsTimeAspect_startDescription=Start time of the segment in nano seconds
 SegmentEndTimeAspect_endDescription=End time of the segment
 SegmentDurationAspect_durationDescription=Segment duration

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/TmfStrings.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/TmfStrings.java
@@ -90,4 +90,15 @@ public final class TmfStrings {
     public static String source() {
         return Objects.requireNonNull(org.eclipse.tracecompass.internal.tmf.core.aspect.Messages.TmfCallsiteAspect_name);
     }
+
+    /**
+     * Get the string for nanosecond timestamp
+     *
+     * @return the label for nanosecond timestamp
+     * @since 10.1
+     */
+    public static @NonNull String nsTime() {
+        return Objects.requireNonNull(org.eclipse.tracecompass.tmf.core.event.aspect.Messages.AspectName_Timestamp_Nanoseconds);
+    }
+
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartNsTimeAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartNsTimeAspect.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.tmf.core.segment;
+
+import java.util.Comparator;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.common.core.NonNullUtils;
+import org.eclipse.tracecompass.internal.tmf.core.segment.Messages;
+import org.eclipse.tracecompass.segmentstore.core.ISegment;
+import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
+import org.eclipse.tracecompass.tmf.core.TmfStrings;
+
+/**
+ * An aspect used to get the start time of a segment. It can be used with most
+ * segment types.
+ *
+ * @author David Piché
+ * @since 9.3
+ *
+ */
+public final class SegmentStartNsTimeAspect implements ISegmentAspect {
+
+    /**
+     * The Segment start time aspect instance
+     */
+    public static final ISegmentAspect SEGMENT_START_NS_TIME_ASPECT = new SegmentStartNsTimeAspect();
+
+    /**
+     * Constructor
+     */
+    private SegmentStartNsTimeAspect() {
+        // Do nothing
+    }
+
+    @Override
+    public @NonNull String getName() {
+        return TmfStrings.nsTime();
+    }
+
+    @Override
+    public @NonNull String getHelpText() {
+        return NonNullUtils.nullToEmptyString(Messages.SegmentStartNsTimeAspect_startDescription);
+    }
+
+    @Override
+    public @Nullable Comparator<?> getComparator() {
+        return SegmentComparators.INTERVAL_START_COMPARATOR.thenComparing(Comparator.comparingLong(ISegment::getLength));
+    }
+
+    @Override
+    public @Nullable Long resolve(@NonNull ISegment segment) {
+        return segment.getStart();
+    }
+
+    @Override
+    public @NonNull SegmentType getType() {
+        return ISegmentAspect.SegmentType.CONTINUOUS;
+    }
+}


### PR DESCRIPTION
This will allow time synchronization when selecting a row in the Theia/VsCode extension to the trace server.

It uses the same mechanism than the TmfEventsTableTableProvider using a ns timestamp column

Fixes #74

[Added] "Timestamp ns" column in SegmentStoreTableDataProvider

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>