### PR TITLE
tmf: Allow TmfConfiguration to be de-/serialized with GSON

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/META-INF/MANIFEST.MF
@@ -63,5 +63,8 @@ Export-Package: org.eclipse.tracecompass.tmf.core.tests,
  org.eclipse.tracecompass.tmf.tests.stubs.trace.xml
 Import-Package: com.google.common.base,
  com.google.common.collect,
- com.google.common.primitives
+ com.google.common.primitives,
+ com.google.gson,
+ com.google.gson.annotations,
+ com.google.gson.reflect
 Automatic-Module-Name: org.eclipse.tracecompass.tmf.core.tests

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/config/TmfConfigurationTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/config/TmfConfigurationTest.java
@@ -14,14 +14,28 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 /**
  * JUnit Test class to test {@link TmfConfiguration}
@@ -31,12 +45,40 @@ public class TmfConfigurationTest {
     // ------------------------------------------------------------------------
     // Test data
     // ------------------------------------------------------------------------
+    /** Temporary folder */
+    @ClassRule
+    public static TemporaryFolder fTemporaryFolder = new TemporaryFolder();
+    /** JSON file to write/read to/from */
+    public static File fJsonFile;
+
     private static final String PATH = "/tmp/my-test.xml";
     private static final String ID = "my-test.xml";
+    private static final String UUID = "c52356b5-c7c4-3b68-b834-6daf1d9f8a3b";
     private static final String DESC = "descriptor";
     private static final String SOURCE_ID = "my-source-id";
-    private static final @NonNull Map<@NonNull String, @NonNull Object> PARAM = ImmutableMap.of("path", "/tmp/home/my-test.xml");
+    private static final @NonNull Map<@NonNull String, @NonNull String> PARAM = ImmutableMap.of("path", "/tmp/home/my-test.xml");
     private static final String EXPECTED_TO_STRING = "TmfConfiguration[fName=/tmp/my-test.xml, fDescription=descriptor, fType=my-source-id, fId=my-test.xml, fParameters={path=/tmp/home/my-test.xml}]";
+
+    /**
+     * Test class setup
+     *
+     * @throws IOException
+     *             if error occurs
+     */
+    @BeforeClass
+    public static void setup() throws IOException {
+        fJsonFile = fTemporaryFolder.newFile(UUID + ".json");
+    }
+
+    /**
+     * Test class cleanup
+     */
+    @AfterClass
+    public static void cleanup() {
+        if (fJsonFile != null && fJsonFile.exists()) {
+            fJsonFile.delete();
+        }
+    }
 
     // ------------------------------------------------------------------------
     // Tests
@@ -58,6 +100,19 @@ public class TmfConfigurationTest {
             assertEquals(DESC, config.getDescription());
             assertEquals(SOURCE_ID, config.getSourceTypeId());
             assertEquals(PARAM, config.getParameters());
+
+            // Don't set ID to trigger generation of UUID
+            builder = new TmfConfiguration.Builder()
+                    .setName(PATH)
+                    .setDescription(DESC)
+                    .setSourceTypeId(SOURCE_ID)
+                    .setParameters(PARAM);
+                config = builder.build();
+                assertEquals(PATH, config.getName());
+                assertEquals(UUID, config.getId());
+                assertEquals(DESC, config.getDescription());
+                assertEquals(SOURCE_ID, config.getSourceTypeId());
+                assertEquals(PARAM, config.getParameters());
     }
 
     /**
@@ -92,32 +147,24 @@ public class TmfConfigurationTest {
             // success
         }
 
-        // Test missing ID
+        // Test missing ID, which will trigger UUID generation
         builder = new TmfConfiguration.Builder()
                 .setName(PATH)
                 .setDescription(DESC)
                 .setSourceTypeId(SOURCE_ID)
                 .setParameters(PARAM);
-        try {
-            builder.build();
-            fail("No exception created");
-        } catch (IllegalStateException e) {
-            // success
-        }
+        ITmfConfiguration config = builder.build();
+        assertEquals(UUID, config.getId());
 
-        // Test blank ID
+        // Test blank ID which triggers UUID generation
         builder = new TmfConfiguration.Builder()
                 .setName(PATH)
                 .setSourceTypeId(SOURCE_ID)
                 .setId("\n") // blank
                 .setDescription(DESC)
                 .setParameters(PARAM);
-        try {
-            builder.build();
-            fail("No exception created");
-        } catch (IllegalStateException e) {
-            // success
-        }
+        config = builder.build();
+        assertEquals(UUID, config.getId());
 
         // Test successful builder
         builder = new TmfConfiguration.Builder()
@@ -215,5 +262,40 @@ public class TmfConfigurationTest {
         assertEquals(config1.hashCode(), config1.hashCode());
         assertEquals(config2.hashCode(), config2.hashCode());
         assertNotEquals(config1.hashCode(), config2.hashCode());
+    }
+
+    /**
+     * Test GSON serialization/deserialization}
+     *
+     * @throws IOException
+     *             if error occurs
+     */
+    @Test
+    public void testJson() throws IOException {
+        TmfConfiguration.Builder builder = new TmfConfiguration.Builder()
+                .setName(PATH)
+                .setDescription(DESC)
+                .setSourceTypeId(SOURCE_ID)
+                .setParameters(PARAM);
+        ITmfConfiguration config = builder.build();
+        writeConfiguration(config);
+        ITmfConfiguration readConfig = readConfiguration();
+        assertEquals(config, readConfig);
+    }
+
+    private static @Nullable ITmfConfiguration readConfiguration() throws IOException {
+        ITmfConfiguration config = null;
+        Type listType = new TypeToken<TmfConfiguration>() {
+        }.getType();
+        try (Reader reader = new FileReader(fJsonFile)) {
+            config = new Gson().fromJson(reader, listType);
+        }
+        return config;
+    }
+
+    private static void writeConfiguration(ITmfConfiguration config) throws IOException {
+        try (Writer writer = new FileWriter(fJsonFile)) {
+            writer.append(new Gson().toJson(config));
+        }
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfiguration.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfiguration.java
@@ -43,5 +43,5 @@ public interface ITmfConfiguration {
      * @return optional informational parameters to return. Can be used to show
      *         more details to users of the configuration instance.
      */
-    Map<String, Object> getParameters();
+    Map<String, String> getParameters();
 }


### PR DESCRIPTION
Allow TmfConfiguration to be de-/serialized with GSON. 
Generate unique UUID as ID from name and parameters
Change parameter map to String->String for easy serialization.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>