### PR TITLE
releng: Downgrade org.mozilla.rhino to org.mozilla.javascript

### DIFF
--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -230,7 +230,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.mozilla.rhino"
+         id="org.mozilla.javascript"
          version="0.0.0"/>
 
    <plugin
@@ -427,6 +427,10 @@
 
    <plugin
          id="org.osgi.service.component.annotations"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.osgi.services"
          version="0.0.0"/>
 
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.30/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.30/feature.xml
@@ -380,7 +380,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.mozilla.rhino"
+         id="org.mozilla.javascript"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.30.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.30.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.30" sequenceNumber="5">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.30" sequenceNumber="6">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -36,10 +36,14 @@
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
 <unit id="org.hamcrest" version="0.0.0"/>
 <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
-<unit id="org.mozilla.rhino" version="1.7.14"/>
+<unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.30.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.mozilla.javascript" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.31.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.31.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.31" sequenceNumber="5">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.31" sequenceNumber="6">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -18,6 +18,7 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="bcpg" version="0.0.0"/>
 <unit id="bcprov" version="0.0.0"/>
+<unit id="bcutil" version="0.0.0"/>
 <unit id="ch.qos.logback.classic" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
 <unit id="com.google.guava" version="33.0.0.jre"/>
@@ -38,10 +39,14 @@
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
 <unit id="org.hamcrest" version="0.0.0"/>
 <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
-<unit id="org.mozilla.rhino" version="1.7.14"/>
+<unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.31.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.mozilla.javascript" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.32.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.32.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.32" sequenceNumber="4">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.32" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -37,10 +37,14 @@
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
 <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
-<unit id="org.mozilla.rhino" version="1.7.15"/>
+<unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.32.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.mozilla.javascript" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -63,6 +67,7 @@
 <unit id="org.eclipse.ui.views.log" version="0.0.0"/>
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
+<unit id="org.eclipse.osgi.services" version="0.0.0"/>
 <repository location="https://download.eclipse.org/eclipse/updates/4.32/R-4.32-202406010610/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="231">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="232">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -37,10 +37,14 @@
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
 <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
-<unit id="org.mozilla.rhino" version="1.7.15"/>
+<unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.32.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.mozilla.javascript" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -63,6 +67,7 @@
 <unit id="org.eclipse.ui.views.log" version="0.0.0"/>
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
+<unit id="org.eclipse.osgi.services" version="0.0.0"/>
 <repository location="https://download.eclipse.org/eclipse/updates/4.32/R-4.32-202406010610/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Use older version of org.mozilla.javascript for compatibility with incubator EASE Scripting feature.

Fixes #116