### PR TITLE
Event aspect data type

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.counters.core/src/org/eclipse/tracecompass/analysis/counters/core/aspects/ITmfCounterAspect.java
+++ b/analysis/org.eclipse.tracecompass.analysis.counters.core/src/org/eclipse/tracecompass/analysis/counters/core/aspects/ITmfCounterAspect.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.tracecompass.analysis.counters.core.aspects;
 
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
 
 /**
@@ -31,6 +32,16 @@ public interface ITmfCounterAspect extends ITmfEventAspect<Number> {
     @Override
     default boolean isHiddenByDefault() {
         return true;
+    }
+
+     /**
+      * Return the data type of the aspect.
+      *
+      * @since 9.3
+      */
+    @Override
+    default DataType getDataType() {
+        return DataType.NUMBER;
     }
 
     /**

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/event/aspect/LinuxPidAspect.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/event/aspect/LinuxPidAspect.java
@@ -12,6 +12,7 @@
 package org.eclipse.tracecompass.analysis.os.linux.core.event.aspect;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
 
@@ -36,5 +37,10 @@ public abstract class LinuxPidAspect implements ITmfEventAspect<Integer> {
 
     @Override
     public abstract @Nullable Integer resolve(ITmfEvent event);
+
+    @Override
+    public DataType getDataType() {
+        return DataType.NUMBER;
+    }
 
 }

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/event/aspect/LinuxTidAspect.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/event/aspect/LinuxTidAspect.java
@@ -15,6 +15,7 @@
 package org.eclipse.tracecompass.analysis.os.linux.core.event.aspect;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
 
@@ -39,5 +40,10 @@ public abstract class LinuxTidAspect implements ITmfEventAspect<Integer> {
 
     @Override
     public abstract @Nullable Integer resolve(ITmfEvent event);
+
+    @Override
+    public DataType getDataType() {
+        return DataType.NUMBER;
+    }
 
 }

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/event/aspect/ThreadPriorityAspect.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/event/aspect/ThreadPriorityAspect.java
@@ -26,6 +26,7 @@ import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedE
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
 import org.eclipse.tracecompass.statesystem.core.statevalue.ITmfStateValue;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
 import org.eclipse.tracecompass.tmf.core.event.aspect.TmfCpuAspect;
@@ -91,5 +92,10 @@ public final class ThreadPriorityAspect implements ITmfEventAspect<Integer> {
         } catch (AttributeNotFoundException | StateSystemDisposedException | TimeRangeException e) {
         }
         return execPrio;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return DataType.NUMBER;
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/latency/SystemCallLatencyAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/latency/SystemCallLatencyAnalysis.java
@@ -34,6 +34,7 @@ import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
 import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.segmentstore.core.SegmentStoreFactory.SegmentStoreType;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.lookup.TmfCallsite;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
@@ -279,6 +280,11 @@ public class SystemCallLatencyAnalysis extends AbstractSegmentStoreAnalysisEvent
                 return ((SystemCall) segment).getTid();
             }
             return -1;
+        }
+
+        @Override
+        public DataType getDataType() {
+            return DataType.NUMBER;
         }
     }
 

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/swslatency/SWSLatencyAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/swslatency/SWSLatencyAnalysis.java
@@ -28,6 +28,7 @@ import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
 import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.segmentstore.core.SegmentStoreFactory.SegmentStoreType;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 
@@ -248,6 +249,11 @@ public class SWSLatencyAnalysis extends AbstractSegmentStoreAnalysisEventBasedMo
                 return ((SchedWS) segment).getTid();
             }
             return -1;
+        }
+
+        @Override
+        public DataType getDataType() {
+            return DataType.NUMBER;
         }
     }
 

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FunctionTidAspect.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FunctionTidAspect.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.os.linux.core.event.aspect.Messages;
 import org.eclipse.tracecompass.analysis.profiling.core.callgraph.ICalledFunction;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 
 /**
@@ -50,5 +51,10 @@ public class FunctionTidAspect implements ISegmentAspect {
             return ((ICalledFunction) segment).getThreadId();
         }
         return null;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return DataType.NUMBER;
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
@@ -341,7 +341,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
                 if (comparator != null) {
                     buildIndex(id, comparator, aspect.getName());
                 }
-                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getType().name()));
+                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getDataType()));
             }
         }
         for (ISegmentAspect aspect : fSegmentProvider.getSegmentAspects()) {
@@ -351,7 +351,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
                 if (comparator != null) {
                     buildIndex(id, comparator, aspect.getName());
                 }
-                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getType().name()));
+                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getDataType()));
             }
         }
 

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
@@ -341,7 +341,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
                 if (comparator != null) {
                     buildIndex(id, comparator, aspect.getName());
                 }
-                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName())));
+                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getType().name()));
             }
         }
         for (ISegmentAspect aspect : fSegmentProvider.getSegmentAspects()) {
@@ -351,7 +351,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
                 if (comparator != null) {
                     buildIndex(id, comparator, aspect.getName());
                 }
-                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName())));
+                model.add(new TmfTreeDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getType().name()));
             }
         }
 

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/memory/UstMemoryAnalysisModule.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/memory/UstMemoryAnalysisModule.java
@@ -43,6 +43,7 @@ import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
 import org.eclipse.tracecompass.segmentstore.core.SegmentStoreFactory;
 import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement;
 import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement.PriorityLevel;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAnalysisEventRequirement;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
@@ -97,6 +98,11 @@ public class UstMemoryAnalysisModule extends TmfStateSystemAnalysisModule implem
                 return ((PotentialLeakSegment) segment).getTid();
             }
             return -1;
+        }
+
+        @Override
+        public DataType getDataType() {
+            return DataType.NUMBER;
         }
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/event/TmfEventTableDataProviderTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/event/TmfEventTableDataProviderTest.java
@@ -157,10 +157,10 @@ public class TmfEventTableDataProviderTest {
         assertNotNull(contentsColumnId);
         assertNotNull(timestampNsColumnId);
         List<TmfEventTableColumnDataModel> expectedColumnEntries = Arrays.asList(
-                new TmfEventTableColumnDataModel(timestampColumnId, -1, Collections.singletonList(TIMESTAMP_COLUMN_NAME), "", false, DataType.TIMESTAMP),
-                new TmfEventTableColumnDataModel(eventTypeColumnId, -1, Collections.singletonList(EVENT_TYPE_COLUMN_NAME), "The type of this event. This normally determines the field layout.", false, DataType.STRING),
-                new TmfEventTableColumnDataModel(contentsColumnId, -1, Collections.singletonList(CONTENTS_COLUMN_NAME), "The fields (or payload) of this event", false, DataType.STRING),
-                new TmfEventTableColumnDataModel(timestampNsColumnId, -1, Collections.singletonList(TIMESTAMP_NS_COLUMN_NAME), "Timestamp in nanoseconds, normalized and useful for calculations", true, DataType.STRING));
+                new TmfEventTableColumnDataModel(timestampColumnId, -1, Collections.singletonList(TIMESTAMP_COLUMN_NAME), "", false, DataType.TIMESTAMP.name()),
+                new TmfEventTableColumnDataModel(eventTypeColumnId, -1, Collections.singletonList(EVENT_TYPE_COLUMN_NAME), "The type of this event. This normally determines the field layout.", false, DataType.STRING.name()),
+                new TmfEventTableColumnDataModel(contentsColumnId, -1, Collections.singletonList(CONTENTS_COLUMN_NAME), "The fields (or payload) of this event", false, DataType.STRING.name()),
+                new TmfEventTableColumnDataModel(timestampNsColumnId, -1, Collections.singletonList(TIMESTAMP_NS_COLUMN_NAME), "Timestamp in nanoseconds, normalized and useful for calculations", true, DataType.STRING.name()));
 
         TmfModelResponse<TmfTreeModel<TmfEventTableColumnDataModel>> response = fProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 0, 1)), null);
         TmfTreeModel<TmfEventTableColumnDataModel> currentColumnModel = response.getModel();

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/event/TmfEventTableDataProviderTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/event/TmfEventTableDataProviderTest.java
@@ -39,6 +39,7 @@ import org.eclipse.tracecompass.internal.provisional.tmf.core.model.table.ITmfVi
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.table.TmfVirtualTableModel;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.table.VirtualTableCell;
 import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfTraceException;
 import org.eclipse.tracecompass.tmf.core.model.CommonStatusMessage;
 import org.eclipse.tracecompass.tmf.core.model.CoreFilterProperty;
@@ -156,10 +157,10 @@ public class TmfEventTableDataProviderTest {
         assertNotNull(contentsColumnId);
         assertNotNull(timestampNsColumnId);
         List<TmfEventTableColumnDataModel> expectedColumnEntries = Arrays.asList(
-                new TmfEventTableColumnDataModel(timestampColumnId, -1, Collections.singletonList(TIMESTAMP_COLUMN_NAME), "", false),
-                new TmfEventTableColumnDataModel(eventTypeColumnId, -1, Collections.singletonList(EVENT_TYPE_COLUMN_NAME), "The type of this event. This normally determines the field layout.", false),
-                new TmfEventTableColumnDataModel(contentsColumnId, -1, Collections.singletonList(CONTENTS_COLUMN_NAME), "The fields (or payload) of this event", false),
-                new TmfEventTableColumnDataModel(timestampNsColumnId, -1, Collections.singletonList(TIMESTAMP_NS_COLUMN_NAME), "Timestamp in nanoseconds, normalized and useful for calculations", true));
+                new TmfEventTableColumnDataModel(timestampColumnId, -1, Collections.singletonList(TIMESTAMP_COLUMN_NAME), "", false, DataType.TIMESTAMP),
+                new TmfEventTableColumnDataModel(eventTypeColumnId, -1, Collections.singletonList(EVENT_TYPE_COLUMN_NAME), "The type of this event. This normally determines the field layout.", false, DataType.STRING),
+                new TmfEventTableColumnDataModel(contentsColumnId, -1, Collections.singletonList(CONTENTS_COLUMN_NAME), "The fields (or payload) of this event", false, DataType.STRING),
+                new TmfEventTableColumnDataModel(timestampNsColumnId, -1, Collections.singletonList(TIMESTAMP_NS_COLUMN_NAME), "Timestamp in nanoseconds, normalized and useful for calculations", true, DataType.STRING));
 
         TmfModelResponse<TmfTreeModel<TmfEventTableColumnDataModel>> response = fProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 0, 1)), null);
         TmfTreeModel<TmfEventTableColumnDataModel> currentColumnModel = response.getModel();

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/event/TmfEventTableDataProviderTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/event/TmfEventTableDataProviderTest.java
@@ -157,10 +157,10 @@ public class TmfEventTableDataProviderTest {
         assertNotNull(contentsColumnId);
         assertNotNull(timestampNsColumnId);
         List<TmfEventTableColumnDataModel> expectedColumnEntries = Arrays.asList(
-                new TmfEventTableColumnDataModel(timestampColumnId, -1, Collections.singletonList(TIMESTAMP_COLUMN_NAME), "", false, DataType.TIMESTAMP.name()),
-                new TmfEventTableColumnDataModel(eventTypeColumnId, -1, Collections.singletonList(EVENT_TYPE_COLUMN_NAME), "The type of this event. This normally determines the field layout.", false, DataType.STRING.name()),
-                new TmfEventTableColumnDataModel(contentsColumnId, -1, Collections.singletonList(CONTENTS_COLUMN_NAME), "The fields (or payload) of this event", false, DataType.STRING.name()),
-                new TmfEventTableColumnDataModel(timestampNsColumnId, -1, Collections.singletonList(TIMESTAMP_NS_COLUMN_NAME), "Timestamp in nanoseconds, normalized and useful for calculations", true, DataType.STRING.name()));
+                new TmfEventTableColumnDataModel(timestampColumnId, -1, Collections.singletonList(TIMESTAMP_COLUMN_NAME), "", false, DataType.TIMESTAMP),
+                new TmfEventTableColumnDataModel(eventTypeColumnId, -1, Collections.singletonList(EVENT_TYPE_COLUMN_NAME), "The type of this event. This normally determines the field layout.", false, DataType.STRING),
+                new TmfEventTableColumnDataModel(contentsColumnId, -1, Collections.singletonList(CONTENTS_COLUMN_NAME), "The fields (or payload) of this event", false, DataType.STRING),
+                new TmfEventTableColumnDataModel(timestampNsColumnId, -1, Collections.singletonList(TIMESTAMP_NS_COLUMN_NAME), "Timestamp in nanoseconds, normalized and useful for calculations", true, DataType.STRING));
 
         TmfModelResponse<TmfTreeModel<TmfEventTableColumnDataModel>> response = fProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 0, 1)), null);
         TmfTreeModel<TmfEventTableColumnDataModel> currentColumnModel = response.getModel();

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
@@ -37,7 +37,7 @@ public class TmfTreeModelTest {
     private static final int NB_COLUMNS = 4;
     private static final int NB_ROWS = 5;
     private static final long PARENT_ID = 100;
-    private static final DataType DATA_TYPE = DataType.STRING;
+    private static final String DATA_TYPE = DataType.STRING.name();
     private static final String HEADER_PREFIX = "header";
     private static final String TOOLTIP_PREFIX = "tooltip";
     private static final String LABEL_PREFIX = "label";

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
@@ -37,7 +37,7 @@ public class TmfTreeModelTest {
     private static final int NB_COLUMNS = 4;
     private static final int NB_ROWS = 5;
     private static final long PARENT_ID = 100;
-    private static final String DATA_TYPE = DataType.STRING.name();
+    private static final DataType DATA_TYPE = DataType.STRING;
     private static final String HEADER_PREFIX = "header";
     private static final String TOOLTIP_PREFIX = "tooltip";
     private static final String LABEL_PREFIX = "label";

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.TableColumnDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.ITableColumnDescriptor;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
@@ -36,6 +37,7 @@ public class TmfTreeModelTest {
     private static final int NB_COLUMNS = 4;
     private static final int NB_ROWS = 5;
     private static final long PARENT_ID = 100;
+    private static final DataType DATA_TYPE = DataType.STRING;
     private static final String HEADER_PREFIX = "header";
     private static final String TOOLTIP_PREFIX = "tooltip";
     private static final String LABEL_PREFIX = "label";
@@ -69,7 +71,7 @@ public class TmfTreeModelTest {
             for (int i = 0; i < NB_COLUMNS; i++) {
                 labels.add(LABEL_PREFIX + String.valueOf(i));
             }
-            ITmfTreeDataModel dataModel = new TmfTreeDataModelStub(k, PARENT_ID, labels);
+            ITmfTreeDataModel dataModel = new TmfTreeDataModelStub(k, PARENT_ID, labels, DATA_TYPE);
             fTestEntries.add(dataModel);
         }
     }

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/trace/TmfTraceUtilsTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/trace/TmfTraceUtilsTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.counters.core.aspects.CounterAspect;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
 import org.eclipse.tracecompass.tmf.core.event.aspect.TmfCpuAspect;
@@ -106,6 +107,11 @@ public class TmfTraceUtilsTest {
         @Override
         public @Nullable Integer resolve(@NonNull ITmfEvent event) {
             return RESOLVED_VALUE;
+        }
+
+        @Override
+        public DataType getDataType() {
+            return DataType.NUMBER;
         }
 
     }

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/model/tree/TmfTreeDataModelStub.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/model/tree/TmfTreeDataModelStub.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 
 /**
@@ -24,6 +25,7 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
     private final long fId;
     private final long fParentId;
     private final List<String> fLabels;
+    private final DataType fDataType;
 
     /**
      * Constructor
@@ -35,10 +37,11 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
      * @param labels
      *            the labels
      */
-    public TmfTreeDataModelStub(long id, long parentId, List<String> labels) {
+    public TmfTreeDataModelStub(long id, long parentId, List<String> labels, DataType dataType) {
         fId = id;
         fParentId = parentId;
         fLabels = labels;
+        fDataType = dataType;
 }
     @Override
     public long getId() {
@@ -58,6 +61,11 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
     @Override
     public List<String> getLabels() {
         return fLabels;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return fDataType;
     }
 
     @Override

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/model/tree/TmfTreeDataModelStub.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/model/tree/TmfTreeDataModelStub.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 
 /**
@@ -24,7 +25,7 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
     private final long fId;
     private final long fParentId;
     private final List<String> fLabels;
-    private final String fDataType;
+    private final DataType fDataType;
 
     /**
      * Constructor
@@ -36,7 +37,7 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
      * @param labels
      *            the labels
      */
-    public TmfTreeDataModelStub(long id, long parentId, List<String> labels, String dataType) {
+    public TmfTreeDataModelStub(long id, long parentId, List<String> labels, DataType dataType) {
         fId = id;
         fParentId = parentId;
         fLabels = labels;
@@ -63,7 +64,7 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
     }
 
     @Override
-    public String getDataType() {
+    public DataType getDataType() {
         return fDataType;
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/model/tree/TmfTreeDataModelStub.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/model/tree/TmfTreeDataModelStub.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 
 /**
@@ -25,7 +24,7 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
     private final long fId;
     private final long fParentId;
     private final List<String> fLabels;
-    private final DataType fDataType;
+    private final String fDataType;
 
     /**
      * Constructor
@@ -37,7 +36,7 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
      * @param labels
      *            the labels
      */
-    public TmfTreeDataModelStub(long id, long parentId, List<String> labels, DataType dataType) {
+    public TmfTreeDataModelStub(long id, long parentId, List<String> labels, String dataType) {
         fId = id;
         fParentId = parentId;
         fLabels = labels;
@@ -64,7 +63,7 @@ public class TmfTreeDataModelStub implements ITmfTreeDataModel {
     }
 
     @Override
-    public DataType getDataType() {
+    public String getDataType() {
         return fDataType;
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableColumnDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableColumnDataModel.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
 
 /**
@@ -52,7 +51,7 @@ public class TmfEventTableColumnDataModel extends TmfTreeDataModel {
      * @param dataType
      *            Data type, String by default
      */
-    public TmfEventTableColumnDataModel(long id, long parentId, List<String> columnLabels, String headerTooltip, boolean isHiddenByDefault, DataType dataType) {
+    public TmfEventTableColumnDataModel(long id, long parentId, List<String> columnLabels, String headerTooltip, boolean isHiddenByDefault, String dataType) {
         super(id, parentId, columnLabels, dataType);
         fHeaderTooltip = headerTooltip;
         fHiddenByDefault = isHiddenByDefault;

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableColumnDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableColumnDataModel.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
 
 /**
@@ -51,7 +52,7 @@ public class TmfEventTableColumnDataModel extends TmfTreeDataModel {
      * @param dataType
      *            Data type, String by default
      */
-    public TmfEventTableColumnDataModel(long id, long parentId, List<String> columnLabels, String headerTooltip, boolean isHiddenByDefault, String dataType) {
+    public TmfEventTableColumnDataModel(long id, long parentId, List<String> columnLabels, String headerTooltip, boolean isHiddenByDefault, DataType dataType) {
         super(id, parentId, columnLabels, dataType);
         fHeaderTooltip = headerTooltip;
         fHiddenByDefault = isHiddenByDefault;

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableColumnDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableColumnDataModel.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
 
 /**
@@ -48,9 +49,11 @@ public class TmfEventTableColumnDataModel extends TmfTreeDataModel {
      *            Header tooltip
      * @param isHiddenByDefault
      *            If the column should be hidden by default
+     * @param dataType
+     *            Data type, String by default
      */
-    public TmfEventTableColumnDataModel(long id, long parentId, List<String> columnLabels, String headerTooltip, boolean isHiddenByDefault) {
-        super(id, parentId, columnLabels);
+    public TmfEventTableColumnDataModel(long id, long parentId, List<String> columnLabels, String headerTooltip, boolean isHiddenByDefault, DataType dataType) {
+        super(id, parentId, columnLabels, dataType);
         fHeaderTooltip = headerTooltip;
         fHiddenByDefault = isHiddenByDefault;
     }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableDataProvider.java
@@ -152,7 +152,7 @@ public class TmfEventTableDataProvider extends AbstractTmfTableDataProvider impl
         for (ITmfEventAspect<?> aspect : aspects.values()) {
             synchronized (fAspectToIdMap) {
                 long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
-                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault()));
+                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType()));
                 hasTs |= (aspect == TmfBaseAspects.getTimestampAspect());
             }
         }
@@ -160,7 +160,7 @@ public class TmfEventTableDataProvider extends AbstractTmfTableDataProvider impl
             synchronized (fAspectToIdMap) {
                 ITmfEventAspect<Long> aspect = TmfBaseAspects.getTimestampNsAspect();
                 long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
-                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault()));
+                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType()));
             }
         }
         return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), model), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableDataProvider.java
@@ -152,7 +152,7 @@ public class TmfEventTableDataProvider extends AbstractTmfTableDataProvider impl
         for (ITmfEventAspect<?> aspect : aspects.values()) {
             synchronized (fAspectToIdMap) {
                 long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
-                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType()));
+                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType().name()));
                 hasTs |= (aspect == TmfBaseAspects.getTimestampAspect());
             }
         }
@@ -160,7 +160,7 @@ public class TmfEventTableDataProvider extends AbstractTmfTableDataProvider impl
             synchronized (fAspectToIdMap) {
                 ITmfEventAspect<Long> aspect = TmfBaseAspects.getTimestampNsAspect();
                 long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
-                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType()));
+                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType().name()));
             }
         }
         return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), model), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/provisional/tmf/core/model/events/TmfEventTableDataProvider.java
@@ -152,7 +152,7 @@ public class TmfEventTableDataProvider extends AbstractTmfTableDataProvider impl
         for (ITmfEventAspect<?> aspect : aspects.values()) {
             synchronized (fAspectToIdMap) {
                 long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
-                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType().name()));
+                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType()));
                 hasTs |= (aspect == TmfBaseAspects.getTimestampAspect());
             }
         }
@@ -160,7 +160,7 @@ public class TmfEventTableDataProvider extends AbstractTmfTableDataProvider impl
             synchronized (fAspectToIdMap) {
                 ITmfEventAspect<Long> aspect = TmfBaseAspects.getTimestampNsAspect();
                 long id = fAspectToIdMap.computeIfAbsent(aspect, a -> createColumnId());
-                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType().name()));
+                model.add(new TmfEventTableColumnDataModel(id, -1, Collections.singletonList(aspect.getName()), aspect.getHelpText(), aspect.isHiddenByDefault(), aspect.getDataType()));
             }
         }
         return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), model), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/ITmfEventAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/ITmfEventAspect.java
@@ -115,7 +115,7 @@ public interface ITmfEventAspect<T> {
      * The data type is considered as String by default
      *
      * @return the data type of the aspect
-     * @since 9.3
+     * @since 10.0
      */
     default DataType getDataType() {
         return DataType.STRING;

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/ITmfEventAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/ITmfEventAspect.java
@@ -17,6 +17,7 @@ package org.eclipse.tracecompass.tmf.core.event.aspect;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 
 /**
@@ -106,5 +107,17 @@ public interface ITmfEventAspect<T> {
      */
     default boolean isHiddenByDefault() {
         return false;
+    }
+
+
+    /**
+     * This method will return the data type of the aspect.
+     * The data type is considered as String by default
+     *
+     * @return the data type of the aspect
+     * @since 9.3
+     */
+    default DataType getDataType() {
+        return DataType.STRING;
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfBaseAspects.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfBaseAspects.java
@@ -14,6 +14,7 @@ package org.eclipse.tracecompass.tmf.core.event.aspect;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEventType;
 import org.eclipse.tracecompass.tmf.core.timestamp.ITmfTimestamp;
@@ -45,6 +46,11 @@ public final class TmfBaseAspects {
         public @Nullable ITmfTimestamp resolve(ITmfEvent event) {
             return event.getTimestamp();
         }
+
+        @Override
+        public DataType getDataType() {
+            return DataType.TIMESTAMP;
+        }
     };
 
     private static final ITmfEventAspect<Long> TIMESTAMP_NANOSECOND_ASPECT = new ITmfEventAspect<Long>() {
@@ -63,6 +69,11 @@ public final class TmfBaseAspects {
         @Override
         public boolean isHiddenByDefault() {
             return true;
+        }
+
+        @Override
+        public DataType getDataType() {
+            return DataType.NUMBER;
         }
     };
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfCpuAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfCpuAspect.java
@@ -15,7 +15,6 @@
 package org.eclipse.tracecompass.tmf.core.event.aspect;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 
 /**

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfCpuAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfCpuAspect.java
@@ -37,14 +37,6 @@ public abstract class TmfCpuAspect extends TmfDeviceAspect {
     }
 
     /**
-     * @since 9.3
-     */
-    @Override
-    public DataType getDataType() {
-        return DataType.NUMBER;
-    }
-
-    /**
      * Returns the CPU number of the CPU on which this event was executed or
      * {@code null} if the CPU is not available for an event.
      */

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfCpuAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfCpuAspect.java
@@ -15,6 +15,7 @@
 package org.eclipse.tracecompass.tmf.core.event.aspect;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 
 /**
@@ -33,6 +34,14 @@ public abstract class TmfCpuAspect extends TmfDeviceAspect {
     @Override
     public final String getHelpText() {
         return Messages.getMessage(Messages.AspectHelpText_CPU);
+    }
+
+    /**
+     * @since 9.3
+     */
+    @Override
+    public DataType getDataType() {
+        return DataType.NUMBER;
     }
 
     /**

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfDeviceAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/TmfDeviceAspect.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.tracecompass.tmf.core.event.aspect;
 
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
+
 /**
  * Device aspect, a category that could be an ASIC, CPU, DSP, GPU. Basically any
  * hardware context. Typically an event will only resolve by one device aspect.
@@ -28,4 +30,9 @@ public abstract class TmfDeviceAspect implements ITmfEventAspect<Integer> {
      * @return the machine readable (non-externalized) category of the device.
      */
     public abstract String getDeviceType();
+
+    @Override
+    public DataType getDataType() {
+        return DataType.NUMBER;
+    }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataModel.java
@@ -89,10 +89,10 @@ public interface ITmfTreeDataModel {
      * Get the type of the data tree
      *
      * @return the corresponding data type of the data tree
-     * @since 9.3
+     * @since 10.0
      */
-    default String getDataType() {
-        return DataType.STRING.name();
+    default DataType getDataType() {
+        return DataType.STRING;
     }
 
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataModel.java
@@ -91,8 +91,8 @@ public interface ITmfTreeDataModel {
      * @return the corresponding data type of the data tree
      * @since 9.3
      */
-    default DataType getDataType() {
-        return DataType.STRING;
+    default String getDataType() {
+        return DataType.STRING.name();
     }
 
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataModel.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
 
 /**
@@ -81,6 +82,17 @@ public interface ITmfTreeDataModel {
      */
     default boolean hasRowModel() {
         return true;
+    }
+
+
+    /**
+     * Get the type of the data tree
+     *
+     * @return the corresponding data type of the data tree
+     * @since 9.3
+     */
+    default DataType getDataType() {
+        return DataType.STRING;
     }
 
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeDataModel.java
@@ -32,7 +32,7 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
     private final List<String> fLabels;
     private final boolean fHasRowModel;
     private final @Nullable OutputElementStyle fStyle;
-    private final DataType fDataType;
+    private final String fDataType;
 
     /**
      * Constructor
@@ -76,7 +76,7 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
      *            The data type of this model
      * @since 9.3
      */
-    public TmfTreeDataModel(long id, long parentId, List<String> labels, DataType dataType) {
+    public TmfTreeDataModel(long id, long parentId, List<String> labels, String dataType) {
         this(id, parentId, labels, true, null, dataType);
     }
 
@@ -135,13 +135,13 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
      *            The data type of this entry
      * @since 9.3
      */
-    public TmfTreeDataModel(long id, long parentId, List<String> labels, boolean hasRowModel, @Nullable OutputElementStyle style, @Nullable DataType dataType) {
+    public TmfTreeDataModel(long id, long parentId, List<String> labels, boolean hasRowModel, @Nullable OutputElementStyle style, @Nullable String dataType) {
         fId = id;
         fParentId = parentId;
         fLabels = labels;
         fHasRowModel = hasRowModel;
         fStyle = style;
-        fDataType = dataType == null ? DataType.STRING : dataType;
+        fDataType = dataType == null ? DataType.STRING.name() : dataType;
     }
 
     @Override
@@ -174,8 +174,13 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
         return fStyle;
     }
 
+    /**
+     * Returns the data type of the model
+     *
+     * @since 9.3
+     */
     @Override
-    public DataType getDataType() {
+    public String getDataType() {
         return fDataType;
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeDataModel.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
 
 /**
@@ -31,6 +32,7 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
     private final List<String> fLabels;
     private final boolean fHasRowModel;
     private final @Nullable OutputElementStyle fStyle;
+    private final DataType fDataType;
 
     /**
      * Constructor
@@ -43,7 +45,7 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
      *            The name of this model
      */
     public TmfTreeDataModel(long id, long parentId, String name) {
-        this(id, parentId, Collections.singletonList(name), true, null);
+        this(id, parentId, Collections.singletonList(name), true, null, null);
     }
 
     /**
@@ -58,7 +60,41 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
      * @since 5.0
      */
     public TmfTreeDataModel(long id, long parentId, List<String> labels) {
-        this(id, parentId, labels, true, null);
+        this(id, parentId, labels, true, null, null);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param id
+     *            The id of the model
+     * @param parentId
+     *            The parent id of this model. If it has none, give <code>-1</code>.
+     * @param labels
+     *            The labels of this model
+     * @param dataType
+     *            The data type of this model
+     * @since 9.3
+     */
+    public TmfTreeDataModel(long id, long parentId, List<String> labels, DataType dataType) {
+        this(id, parentId, labels, true, null, dataType);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param id
+     *            The id of the model
+     * @param parentId
+     *            The parent id of this model. If it has none, give <code>-1</code>.
+     * @param labels
+     *            The labels of this model
+     * @param hasRowModel
+     *            Whether this entry has data or not
+     * @since 9.3
+     */
+    public TmfTreeDataModel(long id, long parentId, List<String> labels, boolean hasRowModel) {
+        this(id, parentId, labels, hasRowModel, null, null);
     }
 
     /**
@@ -75,14 +111,37 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
      *            Whether this entry has data or not
      * @param style
      *            The style of this entry
-     * @since 6.0
+     * @since 9.3
      */
     public TmfTreeDataModel(long id, long parentId, List<String> labels, boolean hasRowModel, @Nullable OutputElementStyle style) {
+        this(id, parentId, labels, hasRowModel, style, null);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param id
+     *            The id of the model
+     * @param parentId
+     *            The parent id of this model. If it has none, give
+     *            <code>-1</code>.
+     * @param labels
+     *            The labels of this model
+     * @param hasRowModel
+     *            Whether this entry has data or not
+     * @param style
+     *            The style of this entry
+     * @param dataType
+     *            The data type of this entry
+     * @since 9.3
+     */
+    public TmfTreeDataModel(long id, long parentId, List<String> labels, boolean hasRowModel, @Nullable OutputElementStyle style, @Nullable DataType dataType) {
         fId = id;
         fParentId = parentId;
         fLabels = labels;
         fHasRowModel = hasRowModel;
         fStyle = style;
+        fDataType = dataType == null ? DataType.STRING : dataType;
     }
 
     @Override
@@ -113,6 +172,11 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
     @Override
     public @Nullable OutputElementStyle getStyle() {
         return fStyle;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return fDataType;
     }
 
     @Override

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeDataModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeDataModel.java
@@ -32,7 +32,7 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
     private final List<String> fLabels;
     private final boolean fHasRowModel;
     private final @Nullable OutputElementStyle fStyle;
-    private final String fDataType;
+    private final DataType fDataType;
 
     /**
      * Constructor
@@ -74,9 +74,9 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
      *            The labels of this model
      * @param dataType
      *            The data type of this model
-     * @since 9.3
+     * @since 10.0
      */
-    public TmfTreeDataModel(long id, long parentId, List<String> labels, String dataType) {
+    public TmfTreeDataModel(long id, long parentId, List<String> labels, DataType dataType) {
         this(id, parentId, labels, true, null, dataType);
     }
 
@@ -133,15 +133,15 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
      *            The style of this entry
      * @param dataType
      *            The data type of this entry
-     * @since 9.3
+     * @since 10.0
      */
-    public TmfTreeDataModel(long id, long parentId, List<String> labels, boolean hasRowModel, @Nullable OutputElementStyle style, @Nullable String dataType) {
+    public TmfTreeDataModel(long id, long parentId, List<String> labels, boolean hasRowModel, @Nullable OutputElementStyle style, @Nullable DataType dataType) {
         fId = id;
         fParentId = parentId;
         fLabels = labels;
         fHasRowModel = hasRowModel;
         fStyle = style;
-        fDataType = dataType == null ? DataType.STRING.name() : dataType;
+        fDataType = dataType == null ? DataType.STRING : dataType;
     }
 
     @Override
@@ -177,10 +177,10 @@ public class TmfTreeDataModel implements ITmfTreeDataModel {
     /**
      * Returns the data type of the model
      *
-     * @since 9.3
+     * @since 10.0
      */
     @Override
-    public String getDataType() {
+    public DataType getDataType() {
         return fDataType;
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/ISegmentAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/ISegmentAspect.java
@@ -15,6 +15,7 @@ import java.util.Comparator;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 
 /**
  * An aspect is a piece of information that can be extracted, directly or
@@ -119,5 +120,16 @@ public interface ISegmentAspect {
      */
     default SegmentType getType() {
         return SegmentType.CATEGORICAL;
+    }
+
+    /**
+     * This method will return the data type of the aspect.
+     * The data type is considered as String by default
+     *
+     * @return the data type of the aspect
+     * @since 10.0
+     */
+    default DataType getDataType() {
+        return DataType.STRING;
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentDurationAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentDurationAspect.java
@@ -20,6 +20,7 @@ import org.eclipse.tracecompass.internal.tmf.core.segment.Messages;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.TmfStrings;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 
 /**
  * An aspect used to get the duration of a segment. It can be used with all
@@ -66,6 +67,11 @@ public final class SegmentDurationAspect implements ISegmentAspect {
     @Override
     public @NonNull SegmentType getType() {
         return ISegmentAspect.SegmentType.CONTINUOUS;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return DataType.DURATION;
     }
 
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentEndTimeAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentEndTimeAspect.java
@@ -20,6 +20,7 @@ import org.eclipse.tracecompass.internal.tmf.core.segment.Messages;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.TmfStrings;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 
 /**
  * An aspect used to get the end time of a segment. It can be used with most
@@ -66,6 +67,11 @@ public final class SegmentEndTimeAspect implements ISegmentAspect {
     @Override
     public @NonNull SegmentType getType() {
         return ISegmentAspect.SegmentType.CONTINUOUS;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return DataType.TIMESTAMP;
     }
 
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartNsTimeAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartNsTimeAspect.java
@@ -20,6 +20,7 @@ import org.eclipse.tracecompass.internal.tmf.core.segment.Messages;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.TmfStrings;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 
 /**
  * An aspect used to get the start time of a segment. It can be used with most
@@ -66,5 +67,10 @@ public final class SegmentStartNsTimeAspect implements ISegmentAspect {
     @Override
     public @NonNull SegmentType getType() {
         return ISegmentAspect.SegmentType.CONTINUOUS;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return DataType.TIMESTAMP;
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartTimeAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/segment/SegmentStartTimeAspect.java
@@ -20,6 +20,7 @@ import org.eclipse.tracecompass.internal.tmf.core.segment.Messages;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.TmfStrings;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 
 /**
  * An aspect used to get the start time of a segment. It can be used with most
@@ -66,5 +67,10 @@ public final class SegmentStartTimeAspect implements ISegmentAspect {
     @Override
     public @NonNull SegmentType getType() {
         return ISegmentAspect.SegmentType.CONTINUOUS;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return DataType.TIMESTAMP;
     }
 }


### PR DESCRIPTION
Added data type to the event and segment aspects (Segment already had getType, but the aspects didn't). The aim was to synchronize the trace-server functionalities w.r.t. tables in order to indicate the type of columns.