### PR TITLE
Implement interface to delete persistant data for segment store analysis (on-disk)

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/.classpath
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/.classpath
@@ -11,5 +11,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="stubs"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/META-INF/MANIFEST.MF
@@ -23,7 +23,9 @@ Require-Bundle: org.junit;bundle-version="4.0.0",
 Import-Package: com.google.common.collect,
  org.eclipse.tracecompass.testtraces.ctf
 Export-Package: org.eclipse.tracecompass.analysis.timing.core.tests,
+ org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore,
  org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore.statistics,
- org.eclipse.tracecompass.analysis.timing.core.tests.statistics
+ org.eclipse.tracecompass.analysis.timing.core.tests.statistics,
+ org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore
 Bundle-Activator: org.eclipse.tracecompass.analysis.timing.core.tests.Activator
 Automatic-Module-Name: org.eclipse.tracecompass.analysis.timing.core.tests

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/build.properties
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/build.properties
@@ -9,7 +9,8 @@
 # SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 
-source.. = src/
+source.. = src/,\
+           stubs/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreAnalysisTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreAnalysisTest.java
@@ -1,0 +1,109 @@
+/**********************************************************************
+ * Copyright (c) 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.tracecompass.analysis.timing.core.segmentstore.AbstractSegmentStoreAnalysisModule;
+import org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreOnDiskProvider;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.tests.stubs.trace.xml.TmfXmlTraceStub;
+import org.eclipse.tracecompass.tmf.tests.stubs.trace.xml.TmfXmlTraceStubNs;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests the {@link AbstractSegmentStoreAnalysisModule}
+ *
+ * @author Bernd Hufmann
+ */
+public class SegmentStoreAnalysisTest {
+    private static TmfXmlTraceStub fTrace;
+
+    /**
+     * Set-up resources
+     */
+    @BeforeClass
+    public static void init() {
+        TmfXmlTraceStubNs trace = new TmfXmlTraceStubNs();
+        assertNotNull(trace);
+        fTrace = trace;
+    }
+
+    /**
+     * Disposes resources
+     */
+    @AfterClass
+    public static void tearDown() {
+        fTrace.dispose();
+    }
+
+    // --------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Test clearing persistent data
+     *
+     * @throws TmfAnalysisException
+     *             An exception when setting the trace
+     */
+    @Test
+    public void testClearPersistentData() throws TmfAnalysisException {
+        StubSegmentStoreOnDiskProvider module = new StubSegmentStoreOnDiskProvider();
+        StubSegmentStoreOnDiskProvider module2 = new StubSegmentStoreOnDiskProvider();
+        try {
+            ITmfTrace trace = fTrace;
+            assertNotNull(trace);
+            module.setTrace(trace);
+            module2.setTrace(trace);
+
+            // Execute the first module
+            module.schedule();
+            assertTrue(module.waitForCompletion());
+
+            // Check if data file exists
+            assertTrue(Files.exists(module.getDataFilePath()));
+
+            // Delete data file while open
+            module.clearPersistentData();
+
+            // The data file should be deleted
+            Path dataFile = module.getDataFilePath();
+            assertNotNull(dataFile);
+            assertFalse(Files.exists(dataFile));
+
+            // Re-schedule
+            module.schedule();
+            assertTrue(module.waitForCompletion());
+            // Dispose module (close file)
+            module.dispose();
+
+            module2.clearPersistentData();
+
+            // Delete state system file while closed
+            dataFile = module.getDataFilePath();
+            assertNotNull(dataFile);
+            assertFalse(Files.exists(dataFile));
+        } finally {
+            module.dispose();
+            module2.dispose();
+        }
+    }
+
+}

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreDensityDataProviderTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreDensityDataProviderTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreProvider;
 import org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider;
 import org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProviderFactory;
 import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderExperimentTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderExperimentTest.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore;
 
-import static org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore.StubSegmentStoreProvider.NEXT_DIR_UNDER_TEST;
+import static org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreProvider.NEXT_DIR_UNDER_TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -31,6 +31,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.AbstractSegmentStoreAnalysisModule;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.ISegmentStoreProvider;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.SegmentStoreAnalysisModule;
+import org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreProvider;
 import org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreTableDataProvider;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.VirtualTableQueryFilter;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.table.ITmfVirtualTableDataProvider;

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreTableDataProviderTest.java
@@ -10,8 +10,8 @@
  **********************************************************************/
 package org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore;
 
-import static org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore.StubSegmentStoreProvider.NEXT_DIR_UNDER_TEST;
-import static org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore.StubSegmentStoreProvider.PREV_DIR_UNDER_TEST;
+import static org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreProvider.NEXT_DIR_UNDER_TEST;
+import static org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreProvider.PREV_DIR_UNDER_TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -28,6 +28,7 @@ import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.SegmentStoreAnalysisModule;
+import org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreProvider;
 import org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreTableDataProvider;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.VirtualTableQueryFilter;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.table.ITmfVirtualTableDataProvider;

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/stubs/org/eclipse/tracecompass/analysis/timing/core/tests/stubs/segmentstore/StubSegmentStoreOnDiskProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/stubs/org/eclipse/tracecompass/analysis/timing/core/tests/stubs/segmentstore/StubSegmentStoreOnDiskProvider.java
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (c) 2022 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore;
+
+import java.nio.file.Path;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.datastore.core.interval.IHTIntervalReader;
+import org.eclipse.tracecompass.segmentstore.core.BasicSegment;
+import org.eclipse.tracecompass.segmentstore.core.ISegment;
+import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
+import org.eclipse.tracecompass.segmentstore.core.SegmentStoreFactory.SegmentStoreType;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
+
+/**
+ * Test stub for segment store on disk
+ *
+ * @author Bernd Hufmann
+ */
+public class StubSegmentStoreOnDiskProvider extends StubSegmentStoreProvider {
+
+    /**
+     * The reader for this segment class
+     */
+    public static final @NonNull IHTIntervalReader<@NonNull ISegment> READER = buffer -> new BasicSegment(buffer.getLong(), buffer.getLong());
+
+    /**
+     * The constructor
+     */
+    public StubSegmentStoreOnDiskProvider() {
+        super();
+    }
+
+    /**
+     * Constructor to initialize segments
+     *
+     * @param nullSegments
+     *            : to decide on null or not null segments
+     */
+    public StubSegmentStoreOnDiskProvider(boolean nullSegments) {
+        super(nullSegments);
+    }
+
+    @Override
+    protected boolean buildAnalysisSegments(@NonNull ISegmentStore<@NonNull ISegment> segmentStore, @NonNull IProgressMonitor monitor) throws TmfAnalysisException {
+        return super.buildAnalysisSegments(segmentStore, monitor);
+    }
+
+    @Override
+    protected @NonNull SegmentStoreType getSegmentStoreType() {
+        return SegmentStoreType.OnDisk;
+    }
+
+    @Override
+    protected IHTIntervalReader<@NonNull ISegment> getSegmentReader() {
+        return READER;
+    }
+
+    /**
+     * Get on-disk date file path
+     *
+     * @return on-disk data file path
+     */
+    @Override
+    public Path getDataFilePath() {
+        return super.getDataFilePath();
+    }
+}

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/stubs/org/eclipse/tracecompass/analysis/timing/core/tests/stubs/segmentstore/StubSegmentStoreProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/stubs/org/eclipse/tracecompass/analysis/timing/core/tests/stubs/segmentstore/StubSegmentStoreProvider.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-package org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore;
+package org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore;
 
 import java.util.Comparator;
 import java.util.List;
@@ -37,14 +37,14 @@ import com.google.common.collect.ImmutableList.Builder;
 public class StubSegmentStoreProvider extends AbstractSegmentStoreAnalysisModule {
 
     /** Stub column name */
-    static final String STUB_COLUMN_NAME = "Stub Column";
+    public static final String STUB_COLUMN_NAME = "Stub Column";
 
     /** Stub column content */
-    static final String STUB_COLUMN_CONTENT = "Stub Content";
+    public static final String STUB_COLUMN_CONTENT = "Stub Content";
 
     /** Search direction values to reuse */
-    static final String NEXT_DIR_UNDER_TEST = "NEXT";
-    static final String PREV_DIR_UNDER_TEST = "PREVIOUS";
+    public static final String NEXT_DIR_UNDER_TEST = "NEXT";
+    public static final String PREV_DIR_UNDER_TEST = "PREVIOUS";
 
     private static final int SIZE = 65535;
 

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/stubs/org/eclipse/tracecompass/analysis/timing/core/tests/stubs/segmentstore/StubSegmentStoreProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/stubs/org/eclipse/tracecompass/analysis/timing/core/tests/stubs/segmentstore/StubSegmentStoreProvider.java
@@ -113,7 +113,9 @@ public class StubSegmentStoreProvider extends AbstractSegmentStoreAnalysisModule
 
     @Override
     protected boolean buildAnalysisSegments(@NonNull ISegmentStore<@NonNull ISegment> segmentStore, @NonNull IProgressMonitor monitor) throws TmfAnalysisException {
-        return segmentStore.addAll(fPreFixture);
+        boolean retVal = segmentStore.addAll(fPreFixture);
+        segmentStore.close(false);
+        return retVal;
     }
 
     @Override

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 6.0.0.qualifier
+Bundle-Version: 6.1.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.analysis.timing.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.analysis.timing.core.Activator


### PR DESCRIPTION
This PR contains 2 commits:

- Implement AbstractSegmentStoreAnalysisModule.clearPersistentData()
  - This allows to delete on-disk segment store data file from the analysis module. If segment store is open, it will close the segment store file first before deleting the file. Otherwise delete the file directly.
  - Calling methods are responsible to re-trigger the analysis execution
  - This allows deleting on-disk segment store state while a trace is open
- timing.tests: Move SegmentStoreAnalysisTest to stubs directory

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>