### PR TITLE
tmf: Add support for json-schema file to TmfConfigurationSourceType

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSourceType.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSourceType.java
@@ -11,7 +11,10 @@
 
 package org.eclipse.tracecompass.tmf.core.config;
 
+import java.io.File;
 import java.util.List;
+
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Interface to implement that describes a configuration source.
@@ -46,7 +49,31 @@ public interface ITmfConfigurationSourceType {
      * Gets a list of query parameter keys to be passed when creating
      * configuration instance of this type.
      *
+     * Implement either {@link #getConfigParamDescriptors()} or
+     * {@link #getSchemaFile()}, but not both.
+     *
+     * Note: If list is empty use {@link #getSchemaFile()} instead.
+     *
      * @return A list of query parameter descriptors to be passed
      */
     List<ITmfConfigParamDescriptor> getConfigParamDescriptors();
+
+    /**
+     * Gets a file containing a json-schema describing the query parameters to
+     * be passed when creating a configuration instance of this type.
+     *
+     * See https://json-schema.org/ for specification of the schema.
+     *
+     * Implement either {@link #getConfigParamDescriptors()} or
+     * {@link #getSchemaFile()}, but not both.
+     *
+     * Note: If the schema file is null, use
+     * {@link #getConfigParamDescriptors()} instead.
+     *
+     * @return A file containing a valid json-schema or null if not used
+     * @since 9.5
+     */
+    default @Nullable File getSchemaFile() {
+        return null;
+    }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/TmfConfigurationSourceType.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/TmfConfigurationSourceType.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.tracecompass.tmf.core.config;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -28,6 +29,7 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
     private final String fId;
     private final String fName;
     private final String fDescription;
+    private final @Nullable File fSchemaFile;
     private final List<ITmfConfigParamDescriptor> fParamDescriptors;
 
     /**
@@ -41,6 +43,7 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         fName = builder.fName;
         fDescription = builder.fDescription;
         fParamDescriptors = builder.fDescriptors;
+        fSchemaFile = builder.fSchemaFile;
     }
 
     @Override
@@ -64,14 +67,22 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
     }
 
     @Override
+    public @Nullable File getSchemaFile() {
+        return fSchemaFile;
+    }
+
+    @Override
     @SuppressWarnings("nls")
     public String toString() {
+        File schemaFile = getSchemaFile();
+        String schemaFileName = schemaFile == null ? "null" : schemaFile.getName();
         return new StringBuilder(getClass().getSimpleName())
                 .append("[")
                 .append("fName=").append(getName())
                 .append(", fDescription=").append(getDescription())
                 .append(", fId=").append(getId())
                 .append(", fKeys=").append(getConfigParamDescriptors())
+                .append(", fSchemaFile=").append(schemaFileName)
                 .append("]").toString();
     }
 
@@ -82,7 +93,8 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         }
         TmfConfigurationSourceType other = (TmfConfigurationSourceType) arg0;
         return Objects.equals(fName, other.fName) && Objects.equals(fId, other.fId) && Objects.equals(fDescription, other.fDescription)
-                && Objects.equals(fParamDescriptors, other.fParamDescriptors);
+                && Objects.equals(fParamDescriptors, other.fParamDescriptors)
+                && Objects.equals(fSchemaFile, other.fSchemaFile);
     }
 
     @Override
@@ -98,6 +110,7 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         private String fId = ""; //$NON-NLS-1$
         private String fName = ""; //$NON-NLS-1$
         private String fDescription = ""; //$NON-NLS-1$
+        private @Nullable File fSchemaFile = null;
         private List<ITmfConfigParamDescriptor> fDescriptors = new ArrayList<>();
 
         /**
@@ -157,6 +170,19 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         }
 
         /**
+         * Sets the json-schema of the configuration source type
+         *
+         * @param schema
+         *            the json schema file
+         * @return the builder instance.
+         * @since 9.5
+         */
+        public Builder setSchemaFile(@Nullable File schema) {
+            fSchemaFile = schema;
+            return this;
+        }
+
+        /**
          * The method to construct an instance of
          * {@link ITmfConfigurationSourceType}
          *
@@ -169,6 +195,10 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
 
             if (fName.isBlank()) {
                 throw new IllegalStateException("Configuration source type name not set"); //$NON-NLS-1$
+            }
+
+            if (fSchemaFile != null && !fSchemaFile.exists()) {
+                throw new IllegalStateException("Configuration source type schema file doesn't exist"); //$NON-NLS-1$
             }
             return new TmfConfigurationSourceType(this);
         }


### PR DESCRIPTION
For schema specification see https://json-schema.org/

[Added] support for json-schema file to TmfConfigurationSourceType

See https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/103

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>