### PR TITLE
tmf: Support for configuration sources to create data providers

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/.settings/.api_filters
+++ b/tmf/org.eclipse.tracecompass.tmf.core/.settings/.api_filters
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.tracecompass.tmf.core" version="2">
+    <resource path="src/org/eclipse/tracecompass/tmf/core/config/TmfConfigurationSourceManager.java" type="org.eclipse.tracecompass.tmf.core.config.TmfConfigurationSourceManager">
+        <filter comment="Static variable was not supposed to be public. It's pretty new and save to make it private." id="388018290">
+            <message_arguments>
+                <message_argument value="org.eclipse.tracecompass.tmf.core.config.TmfConfigurationSourceManager"/>
+                <message_argument value="CONFIG_EXTENSION_POINT_ID"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Static variable was not supposed to be public. It's pretty new and save to make it private." id="388018290">
+            <message_arguments>
+                <message_argument value="org.eclipse.tracecompass.tmf.core.config.TmfConfigurationSourceManager"/>
+                <message_argument value="SOURCE_ATTR"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Static variable was not supposed to be public. It's pretty new and save to make it private." id="388018290">
+            <message_arguments>
+                <message_argument value="org.eclipse.tracecompass.tmf.core.config.TmfConfigurationSourceManager"/>
+                <message_argument value="SOURCE_TYPE_ELEM"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.tracecompass.tmf.core.config.exsd
+++ b/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.tracecompass.tmf.core.config.exsd
@@ -18,7 +18,8 @@
       </annotation>
       <complexType>
          <choice minOccurs="0" maxOccurs="unbounded">
-            <element ref="source"/>
+            <element ref="source" minOccurs="0" maxOccurs="1"/>
+            <element ref="dpSource" minOccurs="0" maxOccurs="1"/>
          </choice>
          <attribute name="point" type="string" use="required">
             <annotation>
@@ -63,6 +64,28 @@
                </documentation>
                <appinfo>
                   <meta.attribute kind="java" basedOn=":org.eclipse.tracecompass.tmf.core.config.IConfigurationSource"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="dpSource">
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The unique ID that identifies this configuration source type handler for data providers
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  The fully qualified name of a class that implements the &lt;samp&gt;ITmfDataProviderConfigSource&lt;/samp&gt; interface.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.tracecompass.tmf.core.config.ITmfDataProviderConfigSource"/>
                </appinfo>
             </annotation>
          </attribute>

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSourceType.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSourceType.java
@@ -52,11 +52,13 @@ public interface ITmfConfigurationSourceType {
      * @return A list of query parameter descriptors to be passed
      */
     List<ITmfConfigParamDescriptor> getConfigParamDescriptors();
+
     /**
-     * A string containing a json-schema describing the query parameters
-     * to be passed when creating a configuration instance of this type.
+     * A string containing a json-schema describing the query parameters to be
+     * passed when creating a configuration instance of this type.
      *
-     * Note: Use either {@link #getConfigParamDescriptors()} or {@link #getSchemaFile()}
+     * Note: Use either {@link #getConfigParamDescriptors()} or
+     * {@link #getSchemaFile()}
      *
      * @return A file containing a valid json-schema or null if not used
      * @since 9.5

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSourceType.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSourceType.java
@@ -11,7 +11,10 @@
 
 package org.eclipse.tracecompass.tmf.core.config;
 
+import java.io.File;
 import java.util.List;
+
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Interface to implement that describes a configuration source.
@@ -49,4 +52,16 @@ public interface ITmfConfigurationSourceType {
      * @return A list of query parameter descriptors to be passed
      */
     List<ITmfConfigParamDescriptor> getConfigParamDescriptors();
+    /**
+     * A string containing a json-schema describing the query parameters
+     * to be passed when creating a configuration instance of this type.
+     *
+     * Note: Use either {@link #getConfigParamDescriptors()} or {@link #getSchemaFile()}
+     *
+     * @return A file containing a valid json-schema or null if not used
+     * @since 9.5
+     */
+    default @Nullable File getSchemaFile() {
+        return null;
+    }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigSource.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigSource.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.tmf.core.config;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+/**
+ * Interface for configuring data providers for given experiment.
+ *
+ * @since 9.5
+ */
+public interface ITmfDataProviderConfigSource {
+
+    /**
+     * @return {@link ITmfConfigurationSourceType} of this configuration source
+     */
+    ITmfConfigurationSourceType getConfigurationSourceType();
+
+    /**
+     * Check if a this configuration source is applies to a give data provider.
+     *
+     * @param dataProviderId
+     *          the data provider ID
+     * @return true if it applies else false
+     */
+    boolean appliesToDataProvider(String dataProviderId);
+
+    /**
+     * Create a list of data provider descriptors base on input parameters.
+     *
+     * @param parameters
+     *            The input parameter
+     * @param trace
+     *            The trace (or experiment) instance
+     * @param srcDataProviderId
+     *            The sourceDataProviderId
+     * @return a new {@link ITmfConfiguration} if successful
+     * @throws TmfConfigurationException
+     *             If the creation of the configuration fails
+     */
+    ITmfConfiguration create(Map<String, Object> parameters, ITmfTrace trace, String srcDataProviderId) throws TmfConfigurationException;
+
+    /**
+     * Removes a configuration instance.
+     *
+     * @param id
+     *            The configuration ID of the configuration to remove
+     * @param trace
+     *            The trace (or experiment) instance
+     * @param srcDataProviderId
+     *            The sourceDataProviderId
+     * @return removed {@link ITmfConfiguration} instance if remove or null if
+     *         not found
+     */
+    @Nullable ITmfConfiguration remove(String id, ITmfTrace trace, String srcDataProviderId);
+
+    /**
+     * Dispose the configuration source.
+     */
+    void dispose();
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderSource.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderSource.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.tmf.core.config;
+
+import java.util.List;
+
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderManager;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+/**
+ * Interface for creating data providers. Implementers only return the data provider descriptors.
+ * Instantiating the actual data provider(s) should be done using {@link DataProviderManager}.
+ * @since 9.5
+ */
+public interface ITmfDataProviderSource {
+    /**
+     * Create a list of data provider descriptors base on input parameters.
+     *
+     * @param srcDataProviderId
+     *            The sourceDataProviderId
+     * @param trace
+     *            The trace (or experiment) instance
+     * @param configId
+     *            The configuration ID
+     * @return List of data provider descriptor
+     * @throws TmfConfigurationException
+     *             if an error occurs
+     */
+    List<IDataProviderDescriptor> getDataProviderDescriptors(String srcDataProviderId, ITmfTrace trace, String configId) throws TmfConfigurationException;
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/TmfConfiguration.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/TmfConfiguration.java
@@ -25,6 +25,14 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 public class TmfConfiguration implements ITmfConfiguration {
 
+    /**
+     * Key to use in parameter map for passing a JSON string defining the
+     * configuration parameters.
+     * @since 9.5
+     */
+    @SuppressWarnings("nls")
+    public static final String JSON_STRING_KEY = "--json-string-key--";
+
     private final String fId;
     private final String fName;
     private final String fDescription;

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/TmfConfigurationSourceType.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/TmfConfigurationSourceType.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.tracecompass.tmf.core.config;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -28,6 +29,7 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
     private final String fId;
     private final String fName;
     private final String fDescription;
+    private final @Nullable File fSchemaFile;
     private final List<ITmfConfigParamDescriptor> fParamDescriptors;
 
     /**
@@ -41,6 +43,7 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         fName = builder.fName;
         fDescription = builder.fDescription;
         fParamDescriptors = builder.fDescriptors;
+        fSchemaFile = builder.fSchemaFile;
     }
 
     @Override
@@ -64,14 +67,22 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
     }
 
     @Override
+    public @Nullable File getSchemaFile() {
+        return fSchemaFile;
+    }
+
+    @Override
     @SuppressWarnings("nls")
     public String toString() {
+        File schemaFile = getSchemaFile();
+        String schemaFileName = schemaFile == null ? "null" : schemaFile.getName();
         return new StringBuilder(getClass().getSimpleName())
                 .append("[")
                 .append("fName=").append(getName())
                 .append(", fDescription=").append(getDescription())
                 .append(", fId=").append(getId())
                 .append(", fKeys=").append(getConfigParamDescriptors())
+                .append(", fSchemaFile=").append(schemaFileName)
                 .append("]").toString();
     }
 
@@ -82,7 +93,8 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         }
         TmfConfigurationSourceType other = (TmfConfigurationSourceType) arg0;
         return Objects.equals(fName, other.fName) && Objects.equals(fId, other.fId) && Objects.equals(fDescription, other.fDescription)
-                && Objects.equals(fParamDescriptors, other.fParamDescriptors);
+                && Objects.equals(fParamDescriptors, other.fParamDescriptors)
+                && Objects.equals(fSchemaFile, other.fSchemaFile);
     }
 
     @Override
@@ -98,6 +110,7 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         private String fId = ""; //$NON-NLS-1$
         private String fName = ""; //$NON-NLS-1$
         private String fDescription = ""; //$NON-NLS-1$
+        private @Nullable File fSchemaFile = null;
         private List<ITmfConfigParamDescriptor> fDescriptors = new ArrayList<>();
 
         /**
@@ -157,6 +170,19 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
         }
 
         /**
+         * Sets the json-schema of the configuration source type
+         *
+         * @param schema
+         *            the json schema file
+         * @return the builder instance.
+         * @since 9.5
+         */
+        public Builder setSchemaFile(@Nullable File schema) {
+            fSchemaFile = schema;
+            return this;
+        }
+
+        /**
          * The method to construct an instance of
          * {@link ITmfConfigurationSourceType}
          *
@@ -169,6 +195,10 @@ public class TmfConfigurationSourceType implements ITmfConfigurationSourceType {
 
             if (fName.isBlank()) {
                 throw new IllegalStateException("Configuration source type name not set"); //$NON-NLS-1$
+            }
+
+            if (fSchemaFile != null && !fSchemaFile.exists()) {
+                throw new IllegalStateException("Configuration source type schema file doesn't exist"); //$NON-NLS-1$
             }
             return new TmfConfigurationSourceType(this);
         }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
@@ -12,6 +12,8 @@
 package org.eclipse.tracecompass.tmf.core.dataprovider;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 
 /**
  * Data Provider description, used to list the available providers for a trace
@@ -87,4 +89,25 @@ public interface IDataProviderDescriptor {
      * @return a short description of this data provider.
      */
     String getDescription();
+
+    /**
+     * Gets the parent data provider ID for grouping purposes.
+     *
+     * @return parent ID or null if not grouped or derived data provider
+     * @since 9.5
+     */
+    default @Nullable String getParentId() {
+        return null;
+    }
+
+    /**
+     * Gets the input configuration used to create this data provider.
+     *
+     * @return the {@link ITmfConfiguration} configuration use to create this
+     * data provider, or null if not applicable
+     * @since 9.5
+     */
+    default @Nullable ITmfConfiguration getCreationConfiguration() {
+        return null;
+    }
 }


### PR DESCRIPTION
tmf: Support for configuration sources to create data providers

Updated org.eclipse.tracecompass.tmf.core.config extension point:
- add data provider configuration source ITmfDataProviderConfigSource
- make global ITmfConfigurationSource
- Update TmfConfigurationSourceManager to handle update extension point

Introduce API ITmfDataProviderSource to implement for getting a list
of data provider descriptors for a given trace, data provider ID and
config ID. Implementers need to make sure that data provider factories
are registered to the DataProviderManager, that the new list are
also returned by DataProviderProvider#getDescriptors() and data
providers can be instantiated with it.

[Added] Support for configuration sources to create data providers
[Updated] org.eclipse.tracecompass.tmf.core.config extension point

This PR includes #144 and will rebased once dependent pull requests are merged. 

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
