### PR TITLE
tmf: add ITmfDataProviderConfigurator interface for custom data provider

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.tmf.core.config;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderManager;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+/**
+ * Interface for creating data providers. Implementers only return a data provider descriptor.
+ * Instantiating the actual data provider(s) will be done using {@link DataProviderManager}.
+ * @since 9.5
+ */
+public interface ITmfDataProviderConfigurator {
+
+    /**
+     * @return a list of {@link ITmfConfigurationSourceType}
+     */
+    List<ITmfConfigurationSourceType> getConfigurationSourceTypes();
+
+    /**
+     * Prepares a data provider based on input parameters and returns its
+     * corresponding data provider descriptor.
+     *
+     * The data provider descriptor shall return the parent data provider ID
+     * through {@link IDataProviderDescriptor#getParentId()}, as well as the
+     * creation configuration through
+     * {@link IDataProviderDescriptor#getConfiguration()}.
+     *
+     * @param typeId
+     *            The Configuration type ID specified in corresponding
+     *            {@link ITmfConfigurationSourceType}
+     * @param trace
+     *            The trace (or experiment) instance
+     * @param parameters
+     *            The configuration parameters.
+     * @return a data provider descriptor corresponding to the derived data
+     *         provider.
+     *
+     * @throws TmfConfigurationException
+     *             if an error occurs
+     */
+    IDataProviderDescriptor createDataProviderDescriptors(String typeId, ITmfTrace trace, Map<String, Object> parameters) throws TmfConfigurationException;
+
+    /**
+     * Remove a data provider provider that was created by
+     * {@link #createDataProviderDescriptors(String, ITmfTrace, Map)}
+     *
+     * @param trace
+     *            The trace (or experiment) instance
+     * @param descriptor
+     *            The data provider descriptor
+     * @throws TmfConfigurationException
+     *             if an error occurs
+     */
+    void removeDataProviderDescriptor(ITmfTrace trace, IDataProviderDescriptor descriptor) throws TmfConfigurationException;
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
@@ -83,6 +83,7 @@ public class DataProviderManager {
             TmfSignalManager.deregister(manager);
             for (IDataProviderFactory factory : manager.fDataProviderFactories.values()) {
                 TmfSignalManager.deregister(factory);
+                factory.dispose();
             }
             manager.fDataProviderFactories.clear();
             manager.fInstances.clear();
@@ -343,4 +344,5 @@ public class DataProviderManager {
         String[] ids = id.split(DataProviderConstants.ID_SEPARATOR, 2);
         return ids.length > 1 ? ids[0] : id;
     }
+
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderParameterUtils.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderParameterUtils.java
@@ -140,6 +140,13 @@ public class DataProviderParameterUtils {
         PREVIOUS
     }
 
+    /**
+     * Key for configuration type ID
+     *
+     * @since 9.5
+     */
+    public static final String CONFIGURATION_TYPE_ID = "typeId"; //$NON-NLS-1$
+
     private DataProviderParameterUtils() {
         // Private constructor
     }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderFactory.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderFactory.java
@@ -14,8 +14,10 @@ package org.eclipse.tracecompass.tmf.core.dataprovider;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.config.ITmfDataProviderConfigurator;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataProvider;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
@@ -28,7 +30,7 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
  * @author Simon Delisle
  * @since 3.2
  */
-public interface IDataProviderFactory {
+public interface IDataProviderFactory extends IAdaptable {
 
     /**
      * Create a {@link ITmfTreeDataProvider} for the given trace. If this factory
@@ -77,4 +79,25 @@ public interface IDataProviderFactory {
         return Collections.emptyList();
     }
 
+    /**
+     *  Disposes the data provider factory
+     *  @since 9.5
+     */
+    default void dispose() {
+        // do nothing
+    }
+
+    /**
+     * Supported classes that a factory can adapt:
+     * - {@link ITmfDataProviderConfigurator}
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    default <T> T getAdapter(Class<T> adapter) {
+        if (adapter.isInstance(this)) {
+            return adapter.cast(this);
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Add interface to implement to prepare a derived data provider with input parameter defined by ITmfConfigurationSourceType.

For that add interfaces ITmfDataProviderConfigurator for capabilities to create data providers that a data provider factory could implement.

Add getAdapter() interface to IDataProviderFactory to allow retrieving ITmfDataProviderConfigurator.

Example:
ITmfDataProviderConfigurator configurator =
factory.getAdapter(ITmfDataProviderConfigurator.class);

[Added] ITmfDataProviderConfigurator interface for custom data provider
[Added] getAdapter() interface to IDataProviderFactory

For example, to get a ITmfDataProviderSource implementation do:
```java
   ITmfDataProviderSource source = factory.getAdapter(IDataProviderSource.class);
```

Note that this PR includes changes of other PR (#141)

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>

 