### PR TITLE
Expose the clock properties in CTFTrace

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/trace/MetadataTest.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/trace/MetadataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 Ericsson
+ * Copyright (c) 2013, 2024 Ericsson
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -346,6 +346,6 @@ public class MetadataTest {
         setUp();
         assertEquals(new UUID(0xd18e637435a1cd42L, 0x8e70a9cffa712793L), CtfTestTraceUtils.getTrace(testTrace).getUUID());
         assertEquals(1332166405241713920.0, CtfTestTraceUtils.getTrace(testTrace).getClock().getClockOffset(), 200.0);
-        assertEquals(8, CtfTestTraceUtils.getTrace(testTrace).getEnvironment().size());
+        assertEquals(10, CtfTestTraceUtils.getTrace(testTrace).getEnvironment().size());
     }
 }

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFTrace.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFTrace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Ericsson, Ecole Polytechnique de Montreal and others
+ * Copyright (c) 2011, 2024 Ericsson, Ecole Polytechnique de Montreal and others
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -29,9 +29,9 @@ import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -153,6 +153,18 @@ public class CTFTrace implements IDefinitionScope {
     /** Handlers for the metadata files */
     private static final FileFilter METADATA_FILE_FILTER = new MetadataFileFilter();
     private static final Comparator<File> METADATA_COMPARATOR = new MetadataComparator();
+
+    /**
+     * Clock offset property
+     *
+     * @since 6.1
+     */
+    public static final String CLOCK_OFFSET = "clock_offset"; //$NON-NLS-1$
+
+    /**
+     * Clock scale property
+     */
+    private static final String CLOCK_SCALE = "clock_scale"; //$NON-NLS-1$
 
     private final DeclarationScope fScope = new DeclarationScope(null, MetadataStrings.TRACE);
 
@@ -777,7 +789,11 @@ public class CTFTrace implements IDefinitionScope {
      *         (key, value)
      */
     public Map<String, String> getEnvironment() {
-        return Collections.unmodifiableMap(fEnvironment);
+        Map<String, String> env = new LinkedHashMap<>();
+        env.putAll(fEnvironment);
+        env.put(CLOCK_OFFSET, String.valueOf(getOffset()));
+        env.put(CLOCK_SCALE, String.valueOf(getTimeScale()));
+        return env;
     }
 
     /**

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core.tests/src/org/eclipse/tracecompass/tmf/ctf/core/tests/trace/CtfTmfTraceTest.java
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core.tests/src/org/eclipse/tracecompass/tmf/ctf/core/tests/trace/CtfTmfTraceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 Ericsson
+ * Copyright (c) 2012, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -245,7 +245,7 @@ public class CtfTmfTraceTest {
     @Test
     public void testGetTraceProperties() {
         int result = fixture.getProperties().size();
-        assertEquals(10, result);
+        assertEquals(11, result);
         assertEquals(String.valueOf(1332166405241713987L), fixture.getProperties().get("clock_offset"));
     }
 

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/trace/CtfTmfTrace.java
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/trace/CtfTmfTrace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 Ericsson, École Polytechnique de Montréal
+ * Copyright (c) 2012, 2024 Ericsson, École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -113,7 +113,9 @@ public class CtfTmfTrace extends TmfTrace
      * Clock offset property
      *
      * @since 1.2
+     * @deprecated use {@link CTFTrace#CLOCK_OFFSET} instead
      */
+    @Deprecated
     public static final String CLOCK_OFFSET = "clock_offset"; //$NON-NLS-1$
 
     /**
@@ -584,7 +586,6 @@ public class CtfTmfTrace extends TmfTrace
             return properties;
         }
         properties.putAll(trace.getEnvironment());
-        properties.put(CLOCK_OFFSET, Long.toUnsignedString(trace.getOffset()));
         properties.put(Messages.CtfTmfTrace_HostID, getHostId());
         return properties;
     }


### PR DESCRIPTION
There is the need to get clock scale of the trace.
This commit added the clock scale to the environment variables of the trace.

[Added] clock scale in getEnvironment() in CTFTrace
[Changed] moved clock offset into getEnvironment() in CTFTrace
[Deprecated] CtfTmfTrace.CLOCK_OFFSET, use CTFTrace.CLOCK_OFFSET instead.

Signed-off-by: Siwei Zhang <siwei.zhang@ericsson.com>