### PR TITLE
statesystem: Do not reduce time range condition for root nodes

### DIFF
--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HistoryTreeBackendIterator.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HistoryTreeBackendIterator.java
@@ -62,9 +62,10 @@ class HistoryTreeBackendIterator implements Iterator<@NonNull ITmfStateInterval>
                 HTNode currentNode = fSht.readNode(fSeqNumberQueue);
                 /*
                  * Compute reduced conditions here to reduce complexity in
-                 * queuing operations.
+                 * queuing operations. Do not reduce for the root node.
                  */
-                TimeRangeCondition subTimes = fTimes.subCondition(currentNode.getNodeStart(), currentNode.getNodeEnd());
+                TimeRangeCondition subTimes = currentNode.getParentSequenceNumber() == -1 ? fTimes :
+                    fTimes.subCondition(currentNode.getNodeStart(), currentNode.getNodeEnd());
                 /*
                  * During the SHT construction, the bounds of the children are
                  * not final, so we may have queued some nodes which don't


### PR DESCRIPTION
In HistoryBackEndIterator, do not reduce the time range condition for queuing children nodes when the current node is the root node, as its time range is not finalized during construction.

Fixes #156

[Fixed] Do not reduce time range condition for root nodes