### PR TITLE
statesystem: Implement new query2D API in ThreadedHistoryTreeBackend

### DIFF
--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/ThreadedHistoryTreeBackend.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/ThreadedHistoryTreeBackend.java
@@ -295,7 +295,7 @@ public final class ThreadedHistoryTreeBackend extends HistoryTreeBackend
     }
 
     @Override
-    public Iterable<@NonNull ITmfStateInterval> query2D(IntegerRangeCondition quarks, TimeRangeCondition times)
+    public Iterable<@NonNull ITmfStateInterval> query2D(IntegerRangeCondition quarks, TimeRangeCondition times, boolean reverse)
             throws TimeRangeException {
         try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINEST, "ThreadedHistoryTreeBackend:query2D", //$NON-NLS-1$
                 "ssid", getSSID(), //$NON-NLS-1$
@@ -311,7 +311,7 @@ public final class ThreadedHistoryTreeBackend extends HistoryTreeBackend
             Iterable<@NonNull HTInterval> queuedIntervals = Iterables.filter(intervalQueue,
                     interval -> !isFinishedBuilding() && quarks.test(interval.getAttribute())
                             && times.intersects(interval.getStartTime(), interval.getEndTime()));
-            return Iterables.concat(super.query2D(quarks, times), queuedIntervals);
+            return Iterables.concat(super.query2D(quarks, times, reverse), queuedIntervals);
         }
     }
 }


### PR DESCRIPTION
The new API for query2D with reverse parameter is implemented in ThreadedHistoryTreeBackend. This avoids the base class implementation from being used, which is missing queued intervals.

Fixes #158

[Fixed] Implement new query2D API in ThreadedHistoryTreeBackend\