### PR TITLE
profiling: Change DP name of Flame Charts created by different analyses

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/FlameChartDataProviderTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/FlameChartDataProviderTest.java
@@ -88,9 +88,9 @@ public class FlameChartDataProviderTest extends CallStackTestBase2 {
 
         for (IDataProviderDescriptor descriptor : descriptors) {
             if (descriptor.getId().equals("org.eclipse.tracecompass.analysis.profiling.core.flamechart:org.eclipse.tracecompass.analysis.profiling.core.tests.stub")) {
-                assertEquals("FlameChart Test Callstack (new)", descriptor.getName());
+                assertEquals("Test Callstack (new) - Flame Chart", descriptor.getName());
                 assertEquals(IDataProviderDescriptor.ProviderType.TIME_GRAPH, descriptor.getType());
-                assertEquals("Show FlameChart provided by Analysis module: Test Callstack (new)", descriptor.getDescription());
+                assertEquals("Show Flame Chart provided by Analysis module: Test Callstack (new)", descriptor.getDescription());
             } else {
                 fail("Unknown Entry" + descriptor.getId());
             }

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
@@ -99,7 +99,7 @@ public class FlameChartDataProviderFactory implements IDataProviderFactory {
             if (!existingModules.contains(analysis.getId())) {
                 DataProviderDescriptor.Builder builder = new DataProviderDescriptor.Builder();
                 builder.setId(FlameChartDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
-                        .setName(Objects.requireNonNull(Messages.FlameChartDataProvider_Title + " " + analysis.getName())) //$NON-NLS-1$
+                        .setName(Objects.requireNonNull(analysis.getName() + " - " +Messages.FlameChartDataProvider_Title)) //$NON-NLS-1$
                         .setDescription(Objects.requireNonNull(NLS.bind(Messages.FlameChartDataProvider_Description, analysis.getHelpText())))
                         .setProviderType(ProviderType.TIME_GRAPH);
                 descriptors.add(builder.build());

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/messages.properties
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/messages.properties
@@ -12,5 +12,5 @@
 FlameChartDataProvider_Symbol=Symbol
 FlameChartDataProvider_ThreadId=TID
 FlameChartDataProvider_KernelStatusTitle=Kernel statuses
-FlameChartDataProvider_Title=FlameChart
-FlameChartDataProvider_Description=Show FlameChart provided by {0}
+FlameChartDataProvider_Title=Flame Chart
+FlameChartDataProvider_Description=Show Flame Chart provided by {0}

--- a/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/DataProviderManagerTest.java
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/DataProviderManagerTest.java
@@ -312,8 +312,8 @@ public class DataProviderManagerTest {
                 .setId("org.eclipse.tracecompass.internal.analysis.os.linux.core.segmentstore.PriorityStatisticsDataProvider:org.eclipse.linuxtools.lttng2.ust.analysis.callstack");
         EXPECTED_UST_DP_DESCRIPTORS.add(builder.build());
         builder = new DataProviderDescriptor.Builder();
-        builder.setName("FlameChart LTTng-UST CallStack (new)")
-                .setDescription("Show FlameChart provided by Analysis module: LTTng-UST CallStack (new)")
+        builder.setName("LTTng-UST CallStack (new) - Flame Chart")
+                .setDescription("Show Flame Chart provided by Analysis module: LTTng-UST CallStack (new)")
                 .setProviderType(ProviderType.TIME_GRAPH)
                 .setId("org.eclipse.tracecompass.analysis.profiling.core.flamechart:org.eclipse.tracecompass.lttng2.ust.core.analysis.callstack");
         EXPECTED_UST_DP_DESCRIPTORS.add(builder.build());


### PR DESCRIPTION
Prepend the analysis name before the view type, e.g. "Function Graph - Flame Chart". This to be consistent with other data providers that have common analysis (e.g. Function Graph - Latency Statistics)

This helps also with the default grouping by name of data providers in the trace server front-end.

[Changed] DP name of Flame Chart created by different analyses

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>