### PR TITLE
tmf: Add parent ID and creation configuration to IDataProviderDescriptor

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/DataProviderDescriptorTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/DataProviderDescriptorTest.java
@@ -14,6 +14,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
+import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
 import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
@@ -31,6 +33,9 @@ public class DataProviderDescriptorTest {
     private static final String ID = "my.data.provider.id";
     private static final String NAME = "Data Provider Name";
     private static final ProviderType TYPE = ProviderType.TIME_GRAPH;
+    private static final String PARENT_ID = "a.parent.id";
+    private static final String CONFIG_ID = "a.config.id";
+    private static final String CONFIG_TYPE_ID = "a.type.id";
 
     /**
      * Test the equality methods
@@ -59,6 +64,22 @@ public class DataProviderDescriptorTest {
         assertFalse(baseDescriptor.equals(builder.build()));
         builder.setDescription(DESCRIPTION).setId(ID).setName(NAME).setProviderType(ProviderType.TABLE);
         assertFalse(baseDescriptor.equals(builder.build()));
+        builder.setDescription(DESCRIPTION).setId(ID).setName(NAME).setProviderType(ProviderType.TABLE).setParentId(PARENT_ID);
+        assertFalse(baseDescriptor.equals(builder.build()));
+
+        baseDescriptor = builder.build();
+        ITmfConfiguration config = new TmfConfiguration.Builder().setId(CONFIG_ID).setSourceTypeId(CONFIG_TYPE_ID).build();
+        builder.setDescription(DESCRIPTION)
+               .setId(ID)
+               .setName(NAME)
+               .setProviderType(ProviderType.TABLE)
+               .setParentId(PARENT_ID)
+               .setConfiguration(config);
+        assertFalse(baseDescriptor.equals(builder.build()));
+
+        // Make sure it is equal to itself (with parent id and config)
+        baseDescriptor = builder.build();
+        assertTrue(baseDescriptor.equals(builder.build()));
     }
 
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
@@ -12,6 +12,8 @@
 package org.eclipse.tracecompass.tmf.core.dataprovider;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 
 /**
  * Data Provider description, used to list the available providers for a trace
@@ -87,4 +89,25 @@ public interface IDataProviderDescriptor {
      * @return a short description of this data provider.
      */
     String getDescription();
+
+    /**
+     * Gets the parent data provider ID for grouping purposes.
+     *
+     * @return parent ID or null if not grouped or derived data provider
+     * @since 9.5
+     */
+    default @Nullable String getParentId() {
+        return null;
+    }
+
+    /**
+     * Gets the input configuration used to create this data provider.
+     *
+     * @return the {@link ITmfConfiguration} configuration use to create this
+     * data provider, or null if not applicable
+     * @since 9.5
+     */
+    default @Nullable ITmfConfiguration getConfiguration() {
+        return null;
+    }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderDescriptor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderDescriptor.java
@@ -14,6 +14,7 @@ package org.eclipse.tracecompass.tmf.core.model;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 
 /**
@@ -31,11 +32,13 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
     private final String fName;
     private final String fDescription;
     private final ProviderType fType;
+    private final @Nullable String fParentId;
+    private final @Nullable ITmfConfiguration fConfiguration;
 
     /**
      * Constructor
      *
-     * @param bulider
+     * @param builder
      *            the builder object to create the descriptor
      */
     private DataProviderDescriptor(Builder builder) {
@@ -43,6 +46,8 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
         fName = builder.fName;
         fDescription = builder.fDescription;
         fType = Objects.requireNonNull(builder.fType);
+        fParentId = builder.fParentId;
+        fConfiguration = builder.fConfiguration;
     }
 
     @Override
@@ -66,11 +71,23 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
     }
 
     @Override
+    public @Nullable String getParentId() {
+        return fParentId;
+    }
+
+    @Override
+    public @Nullable ITmfConfiguration getConfiguration() {
+        return fConfiguration;
+    }
+
+    @Override
     @SuppressWarnings("nls")
     public String toString() {
         return getClass().getSimpleName() + " [fName=" + getName()
                 + ", fDescription=" + getDescription() + ", fType=" + getType()
                 +  ", fId=" + getId()
+                +  ", fParentId=" + fParentId
+                +  ", fConfiguration=" + fConfiguration
                 + "]";
     }
 
@@ -81,7 +98,8 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
         }
         DataProviderDescriptor other = (DataProviderDescriptor) arg0;
         return Objects.equals(fName, other.fName) && Objects.equals(fId, other.fId)
-                && Objects.equals(fType, other.fType) && Objects.equals(fDescription, other.fDescription);
+                && Objects.equals(fType, other.fType) && Objects.equals(fDescription, other.fDescription)
+                && Objects.equals(fParentId, other.fParentId) && Objects.equals(fConfiguration, other.fConfiguration);
     }
 
     @Override
@@ -97,6 +115,8 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
         private String fName = ""; //$NON-NLS-1$
         private String fDescription = ""; //$NON-NLS-1$
         private @Nullable ProviderType fType = null;
+        private @Nullable String fParentId = null;
+        private @Nullable ITmfConfiguration fConfiguration = null;
 
         /**
          * Constructor
@@ -150,6 +170,32 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
          */
         public Builder setProviderType(ProviderType type) {
             fType = type;
+            return this;
+        }
+
+        /**
+         * Sets the parent ID of the descriptor
+         *
+         * @param parentId
+         *            the parent ID to set
+         * @return the builder instance.
+         * @since 9.5
+         */
+        public Builder setParentId(@Nullable String parentId) {
+            fParentId = parentId;
+            return this;
+        }
+
+        /**
+         * Sets the {@link ITmfConfiguration} used to create this data provider
+         *
+         * @param configuration
+         *            the {@link ITmfConfiguration} to set
+         * @return the builder instance.
+         * @since 9.5
+         */
+        public Builder setConfiguration(@Nullable ITmfConfiguration configuration) {
+            fConfiguration = configuration;
             return this;
         }
 


### PR DESCRIPTION
This will allow to show configuration parameters that were used to create a data provider to the user, as well as, group data providers using the parent ID.

[Added] parent ID and creation configuration to IDataProviderDescriptor

Bernd Hufmann <bernd.hufmann@ericsson.com>