### PR TITLE
tmf: Add configuration setter/getter in IAnalysisModule

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/analysis/AnalysisModuleTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/analysis/AnalysisModuleTest.java
@@ -33,12 +33,16 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.analysis.Messages;
 import org.eclipse.tracecompass.tmf.core.analysis.TmfAbstractAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
+import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
 import org.eclipse.tracecompass.tmf.core.tests.shared.TmfTestHelper;
 import org.eclipse.tracecompass.tmf.core.tests.shared.TmfTestTrace;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.tests.stubs.analysis.TestAnalysis;
 import org.eclipse.tracecompass.tmf.tests.stubs.analysis.TestAnalysis2;
+import org.eclipse.tracecompass.tmf.tests.stubs.analysis.TestConfigurableAnalysis;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +62,10 @@ public class AnalysisModuleTest {
 
     private static final @NonNull String MODULE_GENERIC_ID = "test.id";
     private static final @NonNull String MODULE_GENERIC_NAME = "Test analysis";
+
+    private static final @NonNull String CONFIG_GENERIC_ID = "test.config.id";
+    private static final @NonNull String CONFIG_GENERIC_NAME = "Test config";
+    private static final @NonNull String CONFIG_GENERIC_TYPE = "test.config.type.id";
 
     /**
      * Some tests use traces, let's clean them here
@@ -450,5 +458,32 @@ public class AnalysisModuleTest {
         moduleC.dispose();
         trace.dispose();
 
+    }
+
+    /**
+     * Test configurable analysis
+     *
+     * @throws TmfConfigurationException
+     *             if an unexpected error happens
+     */
+    @Test
+    public void testConfigurableAnalysis() throws TmfConfigurationException {
+        TestConfigurableAnalysis module = new TestConfigurableAnalysis();
+        module.setName(MODULE_GENERIC_NAME);
+        module.setId(MODULE_GENERIC_ID);
+        assertNull(module.getConfiguration());
+
+        ITmfConfiguration config = new TmfConfiguration.Builder()
+                .setId(CONFIG_GENERIC_ID)
+                .setName(CONFIG_GENERIC_NAME)
+                .setSourceTypeId(CONFIG_GENERIC_TYPE)
+                .build();
+
+        module.setConfiguration(config);
+        ITmfConfiguration moduleConfig = module.getConfiguration();
+        assertNotNull(moduleConfig);
+        assertEquals(config, moduleConfig);
+
+        module.dispose();
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/analysis/TestConfigurableAnalysis.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/stubs/org/eclipse/tracecompass/tmf/tests/stubs/analysis/TestConfigurableAnalysis.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.tmf.tests.stubs.analysis;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
+
+/**
+ * Simple analysis type for test
+ */
+public class TestConfigurableAnalysis extends TestAnalysis {
+
+    private @Nullable ITmfConfiguration fConfiguration = null;
+
+    /**
+     * Constructor
+     */
+    public TestConfigurableAnalysis() {
+        super();
+    }
+
+    @Override
+    public void setConfiguration(ITmfConfiguration configuration) throws TmfConfigurationException {
+        if (configuration == null) {
+            throw new TmfConfigurationException("Configuration is null");
+        }
+        fConfiguration = configuration;
+    }
+
+    @Override
+    public @Nullable ITmfConfiguration getConfiguration() {
+        return fConfiguration;
+    }
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/IAnalysisModule.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/IAnalysisModule.java
@@ -20,7 +20,9 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.tmf.core.analysis.requirements.IAnalysisRequirementProvider;
 import org.eclipse.tracecompass.tmf.core.component.ITmfComponent;
+import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
+import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 
 /**
@@ -137,6 +139,33 @@ public interface IAnalysisModule extends ITmfComponent, IAnalysisRequirementProv
      * @return The value of a parameter
      */
     @Nullable Object getParameter(@NonNull String name);
+
+    /**
+     * Sets a configuration instance which provides parameters to this analysis.
+     *
+     * Use this when creating and managing analysis modules programmatically.
+     * Call the method before calling {@link #schedule()}
+     *
+     * @param configuration
+     *            A ITmfConfiguration
+     * @throws TmfConfigurationException
+     *          This exception should be thrown if configuration is invalid
+     * @since 9.5
+     */
+    default void setConfiguration(ITmfConfiguration configuration) throws TmfConfigurationException {
+        throw new TmfConfigurationException("Not implemented"); //$NON-NLS-1$
+    }
+
+    /**
+     * Gets the configuration instance used to parameterize the analysis module.
+     *
+     * @return the configuration instance or null if no configuration is set or
+     *         used
+     * @since 9.5
+     */
+    default @Nullable ITmfConfiguration getConfiguration() {
+        return null;
+    }
 
     /**
      * Get the level of dependencies on other analyses that this analysis has.


### PR DESCRIPTION
This is meant to be used when creating and managing analysis modules programmatically and not through the TMF Analysis Framework (e.g. defining the analysis in the plug-in.xml). The configuration has to be  set before the analysis is scheduled, which is not supported by the TMF Analysis Framework.

This is useful in the trace server context for configurable analysis.

[Added] configuration setter/getter to IAnalysisModule

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>