### PR TITLE
tmf: Use ITmfConfiguration configuration create and update methods

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core.tests/src/org/eclipse/tracecompass/tmf/analysis/xml/core/tests/config/XmlConfigurationSourceTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core.tests/src/org/eclipse/tracecompass/tmf/analysis/xml/core/tests/config/XmlConfigurationSourceTest.java
@@ -34,6 +34,7 @@ import org.eclipse.tracecompass.tmf.core.config.ITmfConfigParamDescriptor;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfigurationSource;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfigurationSourceType;
+import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.TmfConfigurationSourceManager;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
 import org.junit.After;
@@ -179,6 +180,58 @@ public class XmlConfigurationSourceTest {
         try {
             ITmfConfiguration config = sfXmlConfigSource.create(VALID_PARAM);
             validateConfig(PATH_TO_VALID_FILE, config);
+        } catch (TmfConfigurationException e) {
+            fail();
+        }
+    }
+
+
+    /**
+     * Test the creation of a configuration instance
+     */
+    @Test
+    public void testCreationNewApi() {
+        // Test missing path
+        Map<String, Object> param = Collections.emptyMap();
+
+        TmfConfiguration.Builder builder = new TmfConfiguration.Builder();
+        builder.setId("test.id")
+               .setName("Dummy")
+               .setDescription("Dummy")
+               .setName(EXPECTED_CONFIG_NAME)
+               .setSourceTypeId(XML_ANALYSIS_TYPE_ID)
+               .setParameters(param);
+
+        ITmfConfiguration config = builder.build();
+        try {
+            sfXmlConfigSource.create(config);
+        } catch (TmfConfigurationException e) {
+            // success
+            assertEquals(EXPECTED_MESSAGE_NO_PATH, e.getMessage());
+        }
+
+        // Test XML file doesn't exist
+        param = ImmutableMap.of(EXPECTED_KEY_NAME, XmlUtils.getXmlFilesPath().append(UNKNOWN_TYPE).toOSString());
+        config = builder.setParameters(param).build();
+        try {
+            sfXmlConfigSource.create(config);
+        } catch (TmfConfigurationException e) {
+            // success
+            assertEquals(EXPECTED_MESSAGE_FILE_NOT_FOUND, e.getMessage());
+        }
+
+        // Test invalid XML file
+        config = builder.setParameters(INVALID_PARAM).build();
+        try {
+            sfXmlConfigSource.create(config);
+        } catch (TmfConfigurationException e) {
+            // success
+        }
+
+        config = builder.setParameters(VALID_PARAM).build();
+        try {
+            ITmfConfiguration configInstance = sfXmlConfigSource.create(config);
+            validateConfig(PATH_TO_VALID_FILE, configInstance);
         } catch (TmfConfigurationException e) {
             fail();
         }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSource.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSource.java
@@ -32,7 +32,8 @@ public interface ITmfConfigurationSource {
     /**
      * Creates a new configuration instance.
      * <p>
-     * The parameters to be provided are described by
+     * The parameters to be provided are described by the
+     * {@link ITmfConfigurationSourceType#getSchemaFile()} or by the list of
      * {@link ITmfConfigurationSourceType#getConfigParamDescriptors()}.
      *
      * @param parameters
@@ -44,9 +45,30 @@ public interface ITmfConfigurationSource {
     ITmfConfiguration create(Map<String, Object> parameters) throws TmfConfigurationException;
 
     /**
+     * Creates a new configuration instance.
+     * <p>
+     * The input configuration instance will have default parameters (e.g. name,
+     * description or sourceTypeId) and custom parameters which are described by
+     * the corresponding {@link ITmfConfigurationSourceType#getSchemaFile()} or
+     * by the list of
+     * {@link ITmfConfigurationSourceType#getConfigParamDescriptors()}.
+     *
+     * @param configuration
+     *            The input configuration parameters to create a configuration instance.
+     * @return a new {@link ITmfConfiguration} if successful
+     * @throws TmfConfigurationException
+     *             If the creation of the configuration fails
+     * @since 9.5
+     */
+    default ITmfConfiguration create(ITmfConfiguration configuration) throws TmfConfigurationException {
+        return create(configuration.getParameters());
+    }
+
+    /**
      * Updates a configuration instance.
      * <p>
-     * The parameters to be provided are described by
+     * The parameters to be provided are described by the
+     * {@link ITmfConfigurationSourceType#getSchemaFile()} or by the list of
      * {@link ITmfConfigurationSourceType#getConfigParamDescriptors()}.
      *
      * @param id
@@ -58,6 +80,29 @@ public interface ITmfConfigurationSource {
      *             If the update of the configuration fails
      */
     ITmfConfiguration update(String id, Map<String, Object> parameters) throws TmfConfigurationException;
+
+    /**
+     * Updates a configuration instance.
+     * <p>
+     * The input configuration instance will have default parameters (e.g. name,
+     * description or sourceTypeId) and custom parameters which are described by
+     * the corresponding {@link ITmfConfigurationSourceType#getSchemaFile()} or
+     * by the list of
+     * {@link ITmfConfigurationSourceType#getConfigParamDescriptors()}.
+     *
+     * @param id
+     *            The configuration ID of the configuration to update
+     * @param configuration
+     *            The input configuration parameters to update a configuration
+     *            instance.
+     * @return a new {@link ITmfConfiguration} if successful
+     * @throws TmfConfigurationException
+     *             If the update of the configuration fails
+     * @since 9.5
+     */
+    default ITmfConfiguration update(String id, ITmfConfiguration configuration) throws TmfConfigurationException {
+        return update(id, configuration.getParameters());
+    }
 
     /**
      * Gets a configuration instance.

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
@@ -12,7 +12,6 @@
 package org.eclipse.tracecompass.tmf.core.config;
 
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderManager;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
@@ -35,17 +34,20 @@ public interface ITmfDataProviderConfigurator {
      * Prepares a data provider based on input parameters and returns its
      * corresponding data provider descriptor.
      *
+     * The input configuration instance will have default parameters (e.g. name,
+     * description or sourceTypeId) and custom parameters which are described by
+     * the corresponding {@link ITmfConfigurationSourceType#getSchemaFile()} or
+     * by the list of
+     * {@link ITmfConfigurationSourceType#getConfigParamDescriptors()}.
+     *
      * The data provider descriptor shall return the parent data provider ID
      * through {@link IDataProviderDescriptor#getParentId()}, as well as the
      * creation configuration through
      * {@link IDataProviderDescriptor#getConfiguration()}.
      *
-     * @param typeId
-     *            The Configuration type ID specified in corresponding
-     *            {@link ITmfConfigurationSourceType}
      * @param trace
      *            The trace (or experiment) instance
-     * @param parameters
+     * @param configuration
      *            The configuration parameters.
      * @return a data provider descriptor corresponding to the derived data
      *         provider.
@@ -53,11 +55,11 @@ public interface ITmfDataProviderConfigurator {
      * @throws TmfConfigurationException
      *             if an error occurs
      */
-    IDataProviderDescriptor createDataProviderDescriptors(String typeId, ITmfTrace trace, Map<String, Object> parameters) throws TmfConfigurationException;
+    IDataProviderDescriptor createDataProviderDescriptors(ITmfTrace trace, ITmfConfiguration configuration) throws TmfConfigurationException;
 
     /**
      * Remove a data provider provider that was created by
-     * {@link #createDataProviderDescriptors(String, ITmfTrace, Map)}
+     * {@link #createDataProviderDescriptors(ITmfTrace, ITmfConfiguration)}
      *
      * @param trace
      *            The trace (or experiment) instance


### PR DESCRIPTION
- Add new API and default implementation of create and update methods in ITmfConfigurationSource.
- Change create method of ITmfDataProviderConfigurator. It has not been released and can be changed.

This is as alternative to Map<String, Object>.

[Added] ITmfConfiguration configuration create and update methods

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>