### PR TITLE
timing: set parentId and creation configuration in DataProviderDescriptor for Latency Analysis with conifgurations

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
@@ -99,6 +99,7 @@ public class FlameChartDataProviderFactory implements IDataProviderFactory {
             if (!existingModules.contains(analysis.getId())) {
                 DataProviderDescriptor.Builder builder = new DataProviderDescriptor.Builder();
                 builder.setId(FlameChartDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
+                        .setParentId(analysis.getConfiguration() != null ? analysis.getId() : null)
                         .setName(Objects.requireNonNull(analysis.getName() + " - " +Messages.FlameChartDataProvider_Title)) //$NON-NLS-1$
                         .setDescription(Objects.requireNonNull(NLS.bind(Messages.FlameChartDataProvider_Description, analysis.getHelpText())))
                         .setProviderType(ProviderType.TIME_GRAPH)

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
@@ -101,7 +101,8 @@ public class FlameChartDataProviderFactory implements IDataProviderFactory {
                 builder.setId(FlameChartDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
                         .setName(Objects.requireNonNull(analysis.getName() + " - " +Messages.FlameChartDataProvider_Title)) //$NON-NLS-1$
                         .setDescription(Objects.requireNonNull(NLS.bind(Messages.FlameChartDataProvider_Description, analysis.getHelpText())))
-                        .setProviderType(ProviderType.TIME_GRAPH);
+                        .setProviderType(ProviderType.TIME_GRAPH)
+                        .setConfiguration(analysis.getConfiguration());
                 descriptors.add(builder.build());
                 existingModules.add(analysis.getId());
             }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentNameSegmentStoreStatisticsDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentNameSegmentStoreStatisticsDataProviderFactory.java
@@ -55,7 +55,8 @@ public class SegmentNameSegmentStoreStatisticsDataProviderFactory extends Abstra
         builder.setId(SegmentStoreStatisticsDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
                 .setName(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreStatisticsDataProvider_title, analysis.getName())))
                 .setDescription(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreStatisticsDataProvider_description, analysis.getHelpText())))
-                .setProviderType(ProviderType.DATA_TREE);
+                .setProviderType(ProviderType.DATA_TREE)
+                .setConfiguration(analysis.getConfiguration());
         return builder.build();
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentNameSegmentStoreStatisticsDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentNameSegmentStoreStatisticsDataProviderFactory.java
@@ -53,6 +53,7 @@ public class SegmentNameSegmentStoreStatisticsDataProviderFactory extends Abstra
     protected @Nullable IDataProviderDescriptor getDataProviderDescriptor(IAnalysisModule analysis) {
         DataProviderDescriptor.Builder builder = new DataProviderDescriptor.Builder();
         builder.setId(SegmentStoreStatisticsDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
+                .setParentId(analysis.getConfiguration() != null ? analysis.getId() : null)
                 .setName(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreStatisticsDataProvider_title, analysis.getName())))
                 .setDescription(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreStatisticsDataProvider_description, analysis.getHelpText())))
                 .setProviderType(ProviderType.DATA_TREE)

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreScatterDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreScatterDataProviderFactory.java
@@ -75,7 +75,8 @@ public class SegmentStoreScatterDataProviderFactory implements IDataProviderFact
                 builder.setId(SegmentStoreScatterDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
                     .setName(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreScatterGraphDataProvider_title, analysis.getName())))
                     .setDescription(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreScatterGraphDataProvider_description, analysis.getHelpText())))
-                    .setProviderType(ProviderType.TREE_TIME_XY);
+                    .setProviderType(ProviderType.TREE_TIME_XY)
+                    .setConfiguration(analysis.getConfiguration());
                 descriptors.add(builder.build());
                 existingModules.add(analysis.getId());
             }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreScatterDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreScatterDataProviderFactory.java
@@ -73,6 +73,7 @@ public class SegmentStoreScatterDataProviderFactory implements IDataProviderFact
             if (!existingModules.contains(analysis.getId())) {
                 DataProviderDescriptor.Builder builder = new DataProviderDescriptor.Builder();
                 builder.setId(SegmentStoreScatterDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
+                    .setParentId(analysis.getConfiguration() != null ? analysis.getId() : null)
                     .setName(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreScatterGraphDataProvider_title, analysis.getName())))
                     .setDescription(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreScatterGraphDataProvider_description, analysis.getHelpText())))
                     .setProviderType(ProviderType.TREE_TIME_XY)

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProviderFactory.java
@@ -77,6 +77,7 @@ public class SegmentStoreTableDataProviderFactory implements IDataProviderFactor
             if (!existingModules.contains(analysis.getId())) {
                 DataProviderDescriptor.Builder builder = new DataProviderDescriptor.Builder();
                 builder.setId(SegmentStoreTableDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
+                        .setParentId(analysis.getConfiguration() != null ? analysis.getId() : null)
                         .setName(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreTableDataProvider_title, analysis.getName())))
                         .setDescription(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreTableDataProvider_description, analysis.getHelpText())))
                         .setProviderType(ProviderType.TABLE)

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProviderFactory.java
@@ -79,7 +79,8 @@ public class SegmentStoreTableDataProviderFactory implements IDataProviderFactor
                 builder.setId(SegmentStoreTableDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
                         .setName(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreTableDataProvider_title, analysis.getName())))
                         .setDescription(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreTableDataProvider_description, analysis.getHelpText())))
-                        .setProviderType(ProviderType.TABLE);
+                        .setProviderType(ProviderType.TABLE)
+                        .setConfiguration(analysis.getConfiguration());
                 descriptors.add(builder.build());
                 existingModules.add(analysis.getId());
             }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderDescriptor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderDescriptor.java
@@ -104,7 +104,7 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fName, fId, fType, fDescription);
+        return Objects.hash(fParentId, fName, fId, fType, fDescription, fConfiguration);
     }
 
     /**


### PR DESCRIPTION
If a latency analysis was configured using an ITmfConfiguration instance, then set the configuration and parent ID in the Data Provider Descriptors of the corresponding data providers that being spawn by the Latency Analysis (e.g. Latency Statistics, Scatter Chart, Table and Flame Chart). This can be used for to show this information to end users of the trace server front-ends and for grouping of data providers in the front-end implementations.

- analysis: Set creation configuration to Latency Analysis DataProviderDescriptors
- timing: Use analysis id as parent ID for latency data providers with configurations. 

[Updated] Latency Analysis DataProviderDescriptors with config
[Updated] Latency Analysis DataProviderDescriptors with parentId

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>