### PR TITLE
tmf: Add data provider ProviderType.NONE for DPs without graphs

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
@@ -59,7 +59,12 @@ public interface IDataProviderDescriptor {
          * A provider for a data tree, which has entries (rows) and columns.
          * @since 6.1
          */
-        DATA_TREE
+        DATA_TREE,
+        /**
+         * A provider with no data. Can be used for grouping purposes and/or as data provider configurator.
+         * @since 9.5
+         */
+        NONE
     }
 
     /**


### PR DESCRIPTION
This provider type can be used for grouping purposes as well as to have an entity to trigger configurations in the trace server front-ends.

[Added] data provider ProviderType.NONE for DPs without graphs

Bernd Hufmann <bernd.hufmann@ericsson.com>