### PR TITLE
Remove recently added unused constant in DataProviderParameterUtils

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderParameterUtils.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderParameterUtils.java
@@ -140,13 +140,6 @@ public class DataProviderParameterUtils {
         PREVIOUS
     }
 
-    /**
-     * Key for configuration type ID
-     *
-     * @since 9.5
-     */
-    public static final String CONFIGURATION_TYPE_ID = "typeId"; //$NON-NLS-1$
-
     private DataProviderParameterUtils() {
         // Private constructor
     }


### PR DESCRIPTION
No need to add APIs if not needed.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>