### PR TITLE
testing: add o.e.tc.datastore.core.tests to testing feature

### DIFF
--- a/releng/org.eclipse.tracecompass.testing/feature.xml
+++ b/releng/org.eclipse.tracecompass.testing/feature.xml
@@ -76,6 +76,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.tracecompass.datastore.core.tests"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.tracecompass.gdbtrace.core.tests"
          version="0.0.0"/>
 
@@ -206,5 +210,4 @@
    <plugin
          id="org.eclipse.tracecompass.slf4j.binding.simple.properties"
          version="0.0.0"/>
-
 </feature>


### PR DESCRIPTION
Commit e12b98a made o.e.tc.datastore.core.tests a plug-in instead of a fragment. It needs to be part of the testing feature so that downstream test plug-ins can successfully build.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>