### PR TITLE
tmf: remove unnecessary cast

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core.tests/src/org/eclipse/tracecompass/analysis/os/linux/core/tests/inputoutput/AbstractTestInputOutput.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core.tests/src/org/eclipse/tracecompass/analysis/os/linux/core/tests/inputoutput/AbstractTestInputOutput.java
@@ -31,7 +31,6 @@ import org.eclipse.tracecompass.tmf.core.event.TmfEvent;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfTraceException;
 import org.eclipse.tracecompass.tmf.core.signal.TmfTraceOpenedSignal;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
-import org.eclipse.tracecompass.tmf.core.trace.TmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 
@@ -131,7 +130,7 @@ public class AbstractTestInputOutput {
         }
 
         deleteSuppFiles(trace);
-        ((TmfTrace) trace).traceOpened(new TmfTraceOpenedSignal(this, trace, null));
+        trace.traceOpened(new TmfTraceOpenedSignal(this, trace, null));
         fTrace = trace;
 
         /* Start the kernel analysis module */

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProviderFactory.java
@@ -73,7 +73,7 @@ public class FlameChartDataProviderFactory implements IDataProviderFactory {
         // The trace can be an experiment, so we need to know if there are
         // multiple analysis modules with the same ID
         Iterable<IFlameChartProvider> modules = TmfTraceUtils.getAnalysisModulesOfClass(trace, IFlameChartProvider.class);
-        Iterable<IFlameChartProvider> filteredModules = Iterables.filter(modules, m -> ((IAnalysisModule) m).getId().equals(secondaryId));
+        Iterable<IFlameChartProvider> filteredModules = Iterables.filter(modules, m -> m.getId().equals(secondaryId));
         Iterator<IFlameChartProvider> iterator = filteredModules.iterator();
         if (iterator.hasNext()) {
             IFlameChartProvider module = iterator.next();
@@ -82,7 +82,7 @@ public class FlameChartDataProviderFactory implements IDataProviderFactory {
                 // the factory can try with individual traces
                 return null;
             }
-            ((IAnalysisModule) module).schedule();
+            module.schedule();
             return new FlameChartDataProvider(trace, module, secondaryId);
         }
         return null;

--- a/releng/org.eclipse.tracecompass.integration.swtbot.tests/src/org/eclipse/tracecompass/integration/swtbot/tests/markers/MarkerSetSwtBotTest.java
+++ b/releng/org.eclipse.tracecompass.integration.swtbot.tests/src/org/eclipse/tracecompass/integration/swtbot/tests/markers/MarkerSetSwtBotTest.java
@@ -30,7 +30,6 @@ import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
 import org.eclipse.tracecompass.tmf.core.signal.TmfWindowRangeUpdatedSignal;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestamp;
-import org.eclipse.tracecompass.tmf.ctf.core.trace.CtfTmfTrace;
 import org.eclipse.tracecompass.tmf.ui.swtbot.tests.shared.ConditionHelpers;
 import org.eclipse.tracecompass.tmf.ui.swtbot.tests.shared.SWTBotUtils;
 import org.eclipse.tracecompass.tmf.ui.tests.shared.WaitUtils;
@@ -92,7 +91,7 @@ public class MarkerSetSwtBotTest {
 
         final CtfTestTrace cygProfile = CtfTestTrace.CYG_PROFILE;
         LttngUstTrace trace = LttngUstTestTraceUtils.getTrace(cygProfile);
-        fStart = ((CtfTmfTrace) trace).getStartTime().toNanos();
+        fStart = trace.getStartTime().toNanos();
         fFullRange = new TmfTimeRange(TmfTimestamp.fromNanos(fStart), TmfTimestamp.fromNanos(fStart + 100l));
         final File file = new File(trace.getPath());
         LttngUstTestTraceUtils.dispose(cygProfile);

--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.ui/src/org/eclipse/tracecompass/internal/tmf/analysis/xml/ui/views/xychart/XmlXYView.java
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.ui/src/org/eclipse/tracecompass/internal/tmf/analysis/xml/ui/views/xychart/XmlXYView.java
@@ -68,7 +68,7 @@ public class XmlXYView extends TmfChartView {
 
                     TmfXYChartViewer chart = getChartViewer();
                     if (chart instanceof XmlXYViewer) {
-                        ((XmlXYViewer) chart).reset();
+                        chart.reset();
                     }
 
                     loadTrace();

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/statesystem/backends/partial/PartialHistoryBackend.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/statesystem/backends/partial/PartialHistoryBackend.java
@@ -36,7 +36,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.internal.tmf.core.Activator;
-import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.statesystem.core.backend.IPartialStateHistoryBackend;
 import org.eclipse.tracecompass.statesystem.core.backend.IStateHistoryBackend;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
@@ -303,7 +302,7 @@ public class PartialHistoryBackend implements IStateHistoryBackend {
          * Now, we have the intervals with their real end times written to the
          * backend, we should be able to get them from there
          */
-        List<ITmfStateInterval> intervalsList = ((ITmfStateSystem) fPartialSS).queryFullState(t);
+        List<ITmfStateInterval> intervalsList = fPartialSS.queryFullState(t);
 
         for (int i = 0; i < currentStateInfo.size(); i++) {
             ITmfStateInterval interval = currentStateInfo.get(i);
@@ -320,7 +319,7 @@ public class PartialHistoryBackend implements IStateHistoryBackend {
          * upper checkpoint exists
          */
         if (fCheckpoints.ceilingKey(t) != null) {
-            intervalsList = prepareIntervalList(((ITmfStateSystem) fPartialSS).getNbAttributes());
+            intervalsList = prepareIntervalList(fPartialSS.getNbAttributes());
             filledStateInfo.clear();
             try {
                 fInnerHistory.doQuery(intervalsList, checkpointTime2);
@@ -366,7 +365,7 @@ public class PartialHistoryBackend implements IStateHistoryBackend {
 
         /* Reload the previous checkpoint */
         long checkpointTime = fCheckpoints.floorKey(t);
-        int nbAtributes = ((ITmfStateSystem)fPartialSS).getNbAttributes();
+        int nbAtributes = fPartialSS.getNbAttributes();
         List<ITmfStateInterval> intervalsList = prepareIntervalList(nbAtributes);
 
         /* Checking if the interval was stored in the real backend */
@@ -416,7 +415,7 @@ public class PartialHistoryBackend implements IStateHistoryBackend {
         }
 
         /* Querying the partial history at the lowerCheckpoint */
-        List<@Nullable ITmfStateInterval> currentStateInfo = prepareIntervalList(((ITmfStateSystem)fPartialSS).getNbAttributes());
+        List<@Nullable ITmfStateInterval> currentStateInfo = prepareIntervalList(fPartialSS.getNbAttributes());
         try {
             fInnerHistory.doQuery(currentStateInfo, lowerCheckpoint);
         } catch (StateSystemDisposedException e) {
@@ -469,7 +468,7 @@ public class PartialHistoryBackend implements IStateHistoryBackend {
             Logger logger = Logger.getAnonymousLogger();
             try {
                 synchronized (fPartialSS) {
-                    for (ITmfStateInterval interval : ((ITmfStateSystem) fPartialSS).query2D(quarksColletion, min, max)) {
+                    for (ITmfStateInterval interval : fPartialSS.query2D(quarksColletion, min, max)) {
                         fCurrentIntervals.add(interval);
                     }
                 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/experiment/TmfExperiment.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/experiment/TmfExperiment.java
@@ -481,7 +481,7 @@ public class TmfExperiment extends TmfTrace implements ITmfPersistentlyIndexable
             traceContext.setRank(ranks[i]);
             // update location after seek
             locations[i] = traceContext.getLocation();
-            context.setContent(i, traceContext, ((ITmfTrace) getChild(i)).getNext(traceContext));
+            context.setContent(i, traceContext, getChild(i).getNext(traceContext));
             rank += ranks[i];
         }
 
@@ -627,7 +627,7 @@ public class TmfExperiment extends TmfTrace implements ITmfPersistentlyIndexable
                         trace, traceContext.getLocation(), traceContext.getRank());
                 experimentContext.setLocation(new TmfExperimentLocation(locationArray));
                 // queue the next event
-                ITmfEvent nextEvent = ((ITmfTrace) getChild(trace)).getNext(traceContext);
+                ITmfEvent nextEvent = getChild(trace).getNext(traceContext);
                 experimentContext.setContent(trace, traceContext, nextEvent);
             }
         }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/project/wizards/tracepkg/importexport/ImportTracePackageWizardPage.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/project/wizards/tracepkg/importexport/ImportTracePackageWizardPage.java
@@ -481,7 +481,7 @@ public class ImportTracePackageWizardPage extends AbstractTracePackageWizardPage
     private static void uncheckTraceElement(TracePackageTraceElement traceElement) {
         for (TracePackageElement e : traceElement.getChildren()) {
             if (e instanceof TracePackageFilesElement) {
-                ((TracePackageFilesElement) e).setChecked(false);
+                e.setChecked(false);
             }
         }
     }
@@ -489,7 +489,7 @@ public class ImportTracePackageWizardPage extends AbstractTracePackageWizardPage
     private static void uncheckExperimentElement(TracePackageExperimentElement experimentElement, List<TracePackageTraceElement> expTraceElements) {
         for (TracePackageElement e : experimentElement.getChildren()) {
             if (e instanceof TracePackageFilesElement) {
-                ((TracePackageFilesElement) e).setChecked(false);
+                e.setChecked(false);
             }
         }
 

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfAnalysisElement.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfAnalysisElement.java
@@ -118,7 +118,7 @@ public class TmfAnalysisElement extends TmfProjectModelElement implements ITmfSt
         IPath path = tracesFolder.getPath();
         IResource resource = getResource();
         if (resource instanceof IFolder) {
-            path = ((IFolder) resource).getFullPath();
+            path = resource.getFullPath();
         }
 
         IAnalysisModule module = getAnalysisModule();

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/events/TmfEventsCache.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/events/TmfEventsCache.java
@@ -25,7 +25,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.tracecompass.internal.tmf.core.filter.TmfCollapseFilter;
 import org.eclipse.tracecompass.internal.tmf.ui.Activator;
-import org.eclipse.tracecompass.tmf.core.component.ITmfEventProvider;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEventField;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEventType;
@@ -354,7 +353,7 @@ public class TmfEventsCache {
         }
 
         request = new DataRequest(ITmfEvent.class, filter, startRank, ITmfEventRequest.ALL_DATA);
-        ((ITmfEventProvider) fTrace).sendRequest(request);
+        fTrace.sendRequest(request);
         try {
             request.waitForCompletion();
             return ((DataRequest) request).getFilteredIndex();
@@ -461,7 +460,7 @@ public class TmfEventsCache {
                     }
                 };
 
-                ((ITmfEventProvider) fTrace).sendRequest(request);
+                fTrace.sendRequest(request);
                 try {
                     request.waitForCompletion();
                 } catch (InterruptedException e) {

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/xychart/XYChartLegendImageProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/xychart/XYChartLegendImageProvider.java
@@ -90,7 +90,7 @@ public class XYChartLegendImageProvider implements ILegendImageProvider2 {
         LineStyle lineStyle = LineStyle.valueOf((String) presProvider.getStyleOrDefault(appearance, StyleProperties.SERIES_STYLE, StyleProperties.SeriesStyle.SOLID));
         if (lineStyle != LineStyle.NONE) {
             gc.setForeground(lineColor);
-            gc.setLineWidth(((Number) presProvider.getFloatStyleOrDefault(appearance, StyleProperties.WIDTH, 1.0f)).intValue());
+            gc.setLineWidth(presProvider.getFloatStyleOrDefault(appearance, StyleProperties.WIDTH, 1.0f).intValue());
             gc.setLineStyle(lineStyle.ordinal());
             gc.drawLine(0, imageHeight / 2, imageWidth, imageHeight / 2);
             gc.setForeground(prev);

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/xychart/linechart/TmfCommonXAxisChartViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/xychart/linechart/TmfCommonXAxisChartViewer.java
@@ -637,7 +637,7 @@ public abstract class TmfCommonXAxisChartViewer extends TmfXYChartViewer {
             lineSeries.setLineColor(color);
             lineSeries.setSymbolColor(color);
             lineSeries.setVisible(true);
-            lineSeries.setLineWidth(((Number) presProvider.getFloatStyleOrDefault(appearance, StyleProperties.WIDTH, 1.0f)).intValue());
+            lineSeries.setLineWidth(presProvider.getFloatStyleOrDefault(appearance, StyleProperties.WIDTH, 1.0f).intValue());
             return lineSeries;
         }
 
@@ -674,7 +674,7 @@ public abstract class TmfCommonXAxisChartViewer extends TmfXYChartViewer {
             lineSeries.setLineColor(color);
             lineSeries.setSymbolColor(color);
             lineSeries.setVisible(true);
-            lineSeries.setLineWidth(((Number) presProvider.getFloatStyleOrDefault(appearance, StyleProperties.WIDTH, 1.0f)).intValue());
+            lineSeries.setLineWidth(presProvider.getFloatStyleOrDefault(appearance, StyleProperties.WIDTH, 1.0f).intValue());
             return lineSeries;
         }
 

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/timegraph/TimeGraphFindDialog.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/timegraph/TimeGraphFindDialog.java
@@ -945,7 +945,7 @@ class TimeGraphFindDialog extends Dialog {
      */
     private static void setGridData(Control component, int horizontalAlignment, boolean grabExcessHorizontalSpace, int verticalAlignment, boolean grabExcessVerticalSpace) {
         GridData gd;
-        if (component instanceof Button && (((Button) component).getStyle() & SWT.PUSH) != 0) {
+        if (component instanceof Button && (component.getStyle() & SWT.PUSH) != 0) {
             gd = (GridData) component.getLayoutData();
             gd.horizontalAlignment = GridData.FILL;
             gd.widthHint = 100;

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/uml2sd/SDWidget.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/uml2sd/SDWidget.java
@@ -1936,7 +1936,7 @@ public class SDWidget extends ScrollView implements SelectionListener,
         if (fSite instanceof SDView) {
             ((SDView) fSite).resetProviders();
             if (lm != null) {
-                lm.resetLoader(((SDView) fSite).getViewSite().getId());
+                lm.resetLoader(fSite.getViewSite().getId());
             }
         }
     }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/uml2sd/ScrollView.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/uml2sd/ScrollView.java
@@ -751,7 +751,7 @@ public class ScrollView extends Composite {
      */
     public boolean isOverviewEnabled() {
         if (fCornerControl instanceof Button) {
-            Object data = ((Button) fCornerControl).getData();
+            Object data = fCornerControl.getData();
             // overview alreay
             if (data instanceof Overview) {
                 return true;

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/uml2sd/core/Frame.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/uml2sd/core/Frame.java
@@ -769,7 +769,7 @@ public class Frame extends BasicFrame {
             int event = getMaxEventOccurrence();
             if (message != null) {
                 if (message instanceof AsyncMessage) {
-                    event = ((AsyncMessage) message).getStartOccurrence();
+                    event = message.getStartOccurrence();
                 } else {
                     event = message.getEventOccurrence();
                 }
@@ -829,7 +829,7 @@ public class Frame extends BasicFrame {
             int event = getMaxEventOccurrence();
             if (message != null) {
                 if (message instanceof AsyncMessage) {
-                    event = ((AsyncMessage) message).getStartOccurrence();
+                    event = message.getStartOccurrence();
                 } else {
                     event = message.getEventOccurrence();
                 }
@@ -864,8 +864,8 @@ public class Frame extends BasicFrame {
         if (node instanceof SyncMessage) {
             distance = ((SyncMessage) node).getEventOccurrence() - event;
         } else if (node instanceof AsyncMessage) {
-            int start = ((AsyncMessage) node).getStartOccurrence();
-            int end = ((AsyncMessage) node).getEndOccurrence();
+            int start = node.getStartOccurrence();
+            int end = node.getEndOccurrence();
             if ((start - event) < (end - event)) {
                 distance = start - event;
             } else {
@@ -993,7 +993,7 @@ public class Frame extends BasicFrame {
         int event = getMaxEventOccurrence();
         if (startMessage != null) {
             if (startMessage instanceof AsyncMessage) {
-                event = ((AsyncMessage) startMessage).getStartOccurrence();
+                event = startMessage.getStartOccurrence();
             } else {
                 event = startMessage.getEventOccurrence();
             }


### PR DESCRIPTION
This patch remove some casts that are showing as errors in eclipse.

I found two categories:
- Cast from children classes to parent classes: I removed those ones since they are not really needed.
- Cast after an instanceof check: It seems that in some recent version, the behaviour changed and these ones are sometimes classified as unnecessary. I found information on JEP 305 where that allows the following:
```java
if (animal instanceof Cat cat)  {  
      out.println(cat.meow());  
}
```
However, in this case the following code indicates the cast as unnecessary:
```java
IResource resource = getResource();
if (resource instanceof IFolder) {
    path = ((IFolder) resource).getFullPath();
}
```
IResource being a parent class of IFolder.
As I am not sure what really happens there, I have not made the change to remove those casts even though removing it seems to work.
