### PR TITLE
Post 10.2 release master activities

### DIFF
--- a/TraceCompass.setup
+++ b/TraceCompass.setup
@@ -75,7 +75,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="tracecompass-e4.33"
+      defaultValue="tracecompass-e4.34"
       storageURI="scope://Workspace"
       label="Target Platform">
     <choice
@@ -119,7 +119,10 @@
         label="Trace Compass Eclipse 2024-06 - 4.32"/>
     <choice
         value="tracecompass-e4.33"
-        label="Trace Compass Eclipse 2024-09 - 4.32"/>
+        label="Trace Compass Eclipse 2024-09 - 4.33"/>
+    <choice
+        value="tracecompass-e4.34"
+        label="Trace Compass Eclipse 2024-09 - 4.34"/>
     <choice
         value="tracecompass-eStaging"
         label="Trace Compass Eclipse Latest"/>
@@ -157,15 +160,15 @@
     <setupTask
         xsi:type="pde:TargetPlatformTask"
         id="tracecompass-baseline-resolve"
-        name="tracecompass-baseline-10.1.0"
+        name="tracecompass-baseline-10.2.0"
         activate="false">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask
         xsi:type="pde:APIBaselineFromTargetTask"
-        id="tracecompass-baseline-10.1.0"
+        id="tracecompass-baseline-10.2.0"
         name="Trace Compass Baseline"
-        targetName="tracecompass-baseline-10.1.0">
+        targetName="tracecompass-baseline-10.2.0">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
-    <target-platform>tracecompass-e4.33</target-platform>
+    <target-platform>tracecompass-e4.34</target-platform>
     <help-docs-eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.23</help-docs-eclipserun-repo>
 
     <rcptt-version>2.5.4</rcptt-version>

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -287,7 +287,7 @@
 
    <plugin
          id="org.mortbay.jasper.apache-jsp"
-         version="9.0.90"/>
+         version="9.0.96"/>
 
    <plugin
          id="com.google.guava.failureaccess"
@@ -407,7 +407,7 @@
 
    <plugin
          id="org.mortbay.jasper.apache-el"
-         version="9.0.90"/>
+         version="9.0.96"/>
 
    <plugin
          id="jakarta.el-api"
@@ -435,6 +435,10 @@
 
    <plugin
          id="org.tukaani.xz"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.xmlgraphics"
          version="0.0.0"/>
 
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.32/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.32/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="10.0.0.qualifier"
+      version="10.2.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.33/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.33/feature.xml
@@ -287,7 +287,7 @@
 
    <plugin
          id="org.mortbay.jasper.apache-jsp"
-         version="9.0.96"/>
+         version="9.0.90"/>
 
    <plugin
          id="com.google.guava.failureaccess"
@@ -407,7 +407,7 @@
 
    <plugin
          id="org.mortbay.jasper.apache-el"
-         version="9.0.96"/>
+         version="9.0.90"/>
 
    <plugin
          id="jakarta.el-api"
@@ -435,10 +435,6 @@
 
    <plugin
          id="org.tukaani.xz"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.xmlgraphics"
          version="0.0.0"/>
 
 </feature>

--- a/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-10.2.0.target
+++ b/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-10.2.0.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="tracecompass-baseline-10.1.0" sequenceNumber="1">
+<?pde version="3.8"?><target name="tracecompass-baseline-10.2.0" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.analysis.counters.core" version="0.0.0"/>
@@ -46,11 +46,11 @@
 <unit id="org.eclipse.tracecompass.tmf.remote.core" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.ui" version="0.0.0"/>
-<repository location="http://download.eclipse.org/tracecompass/releases/10.1.0/repository/"/>
+<repository location="http://download.eclipse.org/tracecompass/releases/10.2.0/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.core.runtime" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/2024-09"/>
+<repository location="http://download.eclipse.org/releases/2024-12"/>
 </location>
 </locations>
 </target>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.34.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.34.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.34" sequenceNumber="4">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.34" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -68,7 +68,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20241120-1800/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.34/R-4.34-202411201800/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -78,7 +78,7 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.36.0/S-3.36M3-20241110095156/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.36.0/R-3.36.0-20241110095156/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xsd" version="0.0.0"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="240">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="241">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -68,7 +68,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20241120-1800/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.34/R-4.34-202411201800/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -78,7 +78,7 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.36.0/S-3.36M3-20241110095156/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.36.0/R-3.36.0-20241110095156/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xsd" version="0.0.0"/>


### PR DESCRIPTION
- releng: Update e4.34 and eStaging targets to 2024-12 release
- releng: Add Trace Compass 10.2.0 baseline
- releng: Update OOMPH setup file for 10.2.0
- releng: Build with tracecompass-e4.34 target by default

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
