### PR TITLE
lttng.control: Fix listing UST domains if there are no logger agents

### DIFF
--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/src/org/eclipse/tracecompass/lttng2/control/ui/tests/service/LTTngControlServiceMiTest.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/src/org/eclipse/tracecompass/lttng2/control/ui/tests/service/LTTngControlServiceMiTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2014 Ericsson
+ * Copyright (c) 2014, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -30,6 +31,7 @@ import org.eclipse.tracecompass.internal.lttng2.control.core.model.IDomainInfo;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.IEventInfo;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.ILoggerInfo;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.ISessionInfo;
+import org.eclipse.tracecompass.internal.lttng2.control.core.model.IUstProviderInfo;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.LogLevelType;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.TraceChannelOutputType;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.TraceDomainType;
@@ -60,6 +62,7 @@ public class LTTngControlServiceMiTest extends LTTngControlServiceTest {
     private static final String SCEN_ENABLING_JUL_LOGGERS = "EnableJulLoggers";
     private static final String SCEN_ENABLING_LOG4J_LOGGERS = "EnableLog4jLoggers";
     private static final String SCEN_ENABLING_PYTHON_LOGGERS = "EnablePythonLoggers";
+    private static final String SCEN_GET_UST_PROVIDER4 = "GetUstProvider4";
 
     @Override
     protected ILttngControlService getControlService() {
@@ -459,6 +462,25 @@ public class LTTngControlServiceMiTest extends LTTngControlServiceTest {
             assertEquals(TracePythonLogLevel.PYTHON_CRITICAL, loggerInfo.getLogLevel());
             assertEquals(LogLevelType.LOGLEVEL_ONLY, loggerInfo.getLogLevelType());
             assertEquals(TraceEnablement.ENABLED, loggerInfo.getState());
+        } catch (ExecutionException e) {
+            fail(e.toString());
+        }
+    }
+
+    @Test
+    @Override
+    public void testUstProvider4() {
+        try {
+            fShell.setScenario(SCEN_GET_UST_PROVIDER4);
+            List<IUstProviderInfo> providers = fService.getUstProvider();
+
+            assertNotNull(providers);
+            assertEquals(2, providers.size());
+
+            // Verify that there are no logger ust provider
+            Optional<IUstProviderInfo> optional = providers.stream().filter(provider -> provider.getLoggers().size() > 0).findFirst();
+            assertTrue(optional.isEmpty());
+
         } catch (ExecutionException e) {
             fail(e.toString());
         }

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/src/org/eclipse/tracecompass/lttng2/control/ui/tests/service/LTTngControlServiceTest.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/src/org/eclipse/tracecompass/lttng2/control/ui/tests/service/LTTngControlServiceTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2012, 2015 Ericsson
+ * Copyright (c) 2012, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -746,6 +746,10 @@ public class LTTngControlServiceTest {
         }
     }
 
+    @Test
+    public void testUstProvider4() {
+        // Nothing to do because loggers are only supported with MI.
+    }
 
     @Test
     public void testGetKernelProviderNoUst1() {

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/testfiles/LTTngServiceMi3Test.cfg
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/testfiles/LTTngServiceMi3Test.cfg
@@ -1,5 +1,5 @@
 ####################################################################
-# Copyright (c) 2014, 2016 Ericsson
+# Copyright (c) 2014, 2024 Ericsson
 #
 # All rights reserved. This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License 2.0 which
@@ -1334,6 +1334,160 @@ lttng --mi xml list -p
 </command>
 </COMMAND_OUTPUT>
 </SCENARIO>
+
+####################################################################
+# Scenario: Test "lttng list -u -f" with missing logger agents
+####################################################################
+<SCENARIO>
+GetUstProvider4
+<COMMAND_INPUT>
+lttng --mi xml list -u -f
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+0
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+  <name>list</name>
+  <output>
+    <domains>
+      <domain>
+        <type>UST</type>
+        <buffer_type>PER_PID</buffer_type>
+        <pids>
+          <pid>
+            <id>9379</id>
+            <name>/home/user/git/lttng-ust/tests/hello.cxx/.libs/lt-hello</name>
+            <events>
+              <event>
+                <name>ust_tests_hello:tptest_sighandler</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_DEBUG_MODULE</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields/>
+              </event>
+              <event>
+                <name>ust_tests_hello:tptest</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_INFO</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields>
+                  <event_field>
+                    <name>doublefield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>floatfield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>stringfield</name>
+                    <type>STRING</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                </event_fields>
+              </event>
+            </events>
+          </pid>
+          <pid>
+            <id>4852</id>
+            <name>/home/user/git/lttng-ust/tests/hello.cxx/.libs/lt-hello</name>
+            <events>
+              <event>
+                <name>ust_tests_hello:tptest_sighandler</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_WARNING</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields/>
+              </event>
+              <event>
+                <name>ust_tests_hello:tptest</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_DEBUG_FUNCTION</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields>
+                  <event_field>
+                    <name>doublefield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>floatfield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>stringfield</name>
+                    <type>STRING</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                </event_fields>
+              </event>
+            </events>
+          </pid>
+        </pids>
+      </domain>
+    </domains>
+  </output>
+</command>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -j
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list jul events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -l
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list log4j events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -p
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list python events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+</SCENARIO>
+
 ####################################################################
 # Scenario: Test "lttng create <session>
 ####################################################################

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/testfiles/LTTngServiceMi3TestLTTng211.cfg
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/testfiles/LTTngServiceMi3TestLTTng211.cfg
@@ -1,5 +1,5 @@
 ####################################################################
-# Copyright (c) 2014, 2016 Ericsson
+# Copyright (c) 2014, 2024 Ericsson
 #
 # All rights reserved. This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License 2.0 which
@@ -1341,6 +1341,160 @@ lttng --mi xml list -p
 </command>
 </COMMAND_OUTPUT>
 </SCENARIO>
+
+####################################################################
+# Scenario: Test "lttng list -u -f" with missing logger agents
+####################################################################
+<SCENARIO>
+GetUstProvider4
+<COMMAND_INPUT>
+lttng --mi xml list -u -f
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+0
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+  <name>list</name>
+  <output>
+    <domains>
+      <domain>
+        <type>UST</type>
+        <buffer_type>PER_PID</buffer_type>
+        <pids>
+          <pid>
+            <id>9379</id>
+            <name>/home/user/git/lttng-ust/tests/hello.cxx/.libs/lt-hello</name>
+            <events>
+              <event>
+                <name>ust_tests_hello:tptest_sighandler</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_DEBUG_MODULE</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields/>
+              </event>
+              <event>
+                <name>ust_tests_hello:tptest</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_INFO</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields>
+                  <event_field>
+                    <name>doublefield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>floatfield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>stringfield</name>
+                    <type>STRING</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                </event_fields>
+              </event>
+            </events>
+          </pid>
+          <pid>
+            <id>4852</id>
+            <name>/home/user/git/lttng-ust/tests/hello.cxx/.libs/lt-hello</name>
+            <events>
+              <event>
+                <name>ust_tests_hello:tptest_sighandler</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_WARNING</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields/>
+              </event>
+              <event>
+                <name>ust_tests_hello:tptest</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <loglevel>TRACE_DEBUG_FUNCTION</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <event_fields>
+                  <event_field>
+                    <name>doublefield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>floatfield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>stringfield</name>
+                    <type>STRING</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                </event_fields>
+              </event>
+            </events>
+          </pid>
+        </pids>
+      </domain>
+    </domains>
+  </output>
+</command>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -j
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list jul events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -l
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list log4j events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -p
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command xmlns="http://lttng.org/xml/ns/lttng-mi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://lttng.org/xml/ns/lttng-mi http://lttng.org/xml/schemas/lttng-mi/3/lttng-mi-3.0.xsd" schemaVersion="3.0">
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list python events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+</SCENARIO>
+
 ####################################################################
 # Scenario: Test "lttng create <session>
 ####################################################################

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/testfiles/LTTngServiceMiTest.cfg
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/testfiles/LTTngServiceMiTest.cfg
@@ -1,5 +1,5 @@
 ####################################################################
-# Copyright (c) 2014, 2015 Ericsson
+# Copyright (c) 2014, 2024 Ericsson
 #
 # All rights reserved. This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License 2.0 which
@@ -1269,6 +1269,168 @@ lttng --mi xml list -p
 </command>
 </COMMAND_OUTPUT>
 </SCENARIO>
+
+####################################################################
+# Scenario: Test "lttng list -u -f" with missing logger agents
+####################################################################
+<SCENARIO>
+GetUstProvider4
+<COMMAND_INPUT>
+lttng --mi xml list -u -f
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+0
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command>
+  <name>list</name>
+  <output>
+    <domains>
+      <domain>
+        <type>UST</type>
+        <buffer_type>PER_PID</buffer_type>
+        <pids>
+          <pid>
+            <id>9379</id>
+            <name>/home/user/git/lttng-ust/tests/hello.cxx/.libs/lt-hello</name>
+            <events>
+              <event>
+                <name>ust_tests_hello:tptest_sighandler</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <filter>false</filter>
+                <loglevel>TRACE_DEBUG_MODULE</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <exclusion>false</exclusion>
+                <event_fields/>
+              </event>
+              <event>
+                <name>ust_tests_hello:tptest</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <filter>false</filter>
+                <loglevel>TRACE_INFO</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <exclusion>false</exclusion>
+                <event_fields>
+                  <event_field>
+                    <name>doublefield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>floatfield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>stringfield</name>
+                    <type>STRING</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                </event_fields>
+              </event>
+            </events>
+          </pid>
+          <pid>
+            <id>4852</id>
+            <name>/home/user/git/lttng-ust/tests/hello.cxx/.libs/lt-hello</name>
+            <events>
+              <event>
+                <name>ust_tests_hello:tptest_sighandler</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <filter>false</filter>
+                <loglevel>TRACE_WARNING</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <exclusion>false</exclusion>
+                <event_fields/>
+              </event>
+              <event>
+                <name>ust_tests_hello:tptest</name>
+                <type>TRACEPOINT</type>
+                <enabled>true</enabled>
+                <filter>false</filter>
+                <loglevel>TRACE_DEBUG_FUNCTION</loglevel>
+                <loglevel_type>ALL</loglevel_type>
+                <exclusion>false</exclusion>
+                <event_fields>
+                  <event_field>
+                    <name>doublefield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>floatfield</name>
+                    <type>FLOAT</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                  <event_field>
+                    <name>stringfield</name>
+                    <type>STRING</type>
+                    <nowrite>0</nowrite>
+                  </event_field>
+                </event_fields>
+              </event>
+            </events>
+          </pid>
+        </pids>
+      </domain>
+    </domains>
+  </output>
+</command>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -j
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command>
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list jul events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -l
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command>
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list log4j events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+<COMMAND_INPUT>
+lttng --mi xml list -p
+</COMMAND_INPUT>
+<COMMAND_RESULT>
+1
+</COMMAND_RESULT>
+<COMMAND_OUTPUT>
+<?xml version="1.0" encoding="UTF-8"?>
+<command>
+    <name>list</name>
+    <output/>
+</command>
+<COMMAND_ERROR_OUTPUT>
+Error: Unable to list python events: Session daemon agent tracing is disabled
+</COMMAND_ERROR_OUTPUT>
+</COMMAND_OUTPUT>
+</SCENARIO>
+
 ####################################################################
 # Scenario: Test "lttng create <session>
 ####################################################################

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/service/LTTngControlServiceConstants.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/service/LTTngControlServiceConstants.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2012, 2016 Ericsson
+ * Copyright (c) 2012, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -513,7 +513,7 @@ public interface LTTngControlServiceConstants {
     /**
      * Pattern to match error line if no ust tracer is available or installed.
      */
-    Pattern LIST_UST_NO_UST_PROVIDER_PATTERN = Pattern.compile(".*Unable\\s*to\\s*list\\s*UST\\s*event.*"); //$NON-NLS-1$
+    Pattern LIST_UST_NO_UST_PROVIDER_PATTERN = Pattern.compile(".*Unable\\s*to\\s*list\\s*(.*)\\s*event.*"); //$NON-NLS-1$
     /**
      * Pattern to match for list snapshot information (lttng snapshot list-output)
      */

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/service/LTTngControlServiceMI.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/service/LTTngControlServiceMI.java
@@ -1141,6 +1141,11 @@ public class LTTngControlServiceMI extends LTTngControlService {
         ICommandResult result = executeCommand(command, monitor, false);
 
         if (isError(result)) {
+            // Ignore the following case (example jul):
+            // Error: Unable to list jul events: Session daemon agent tracing is disabled
+            if (ignoredPattern(result.getErrorOutput(), LTTngControlServiceConstants.LIST_UST_NO_UST_PROVIDER_PATTERN)) {
+                return;
+            }
             throw new ExecutionException(Messages.TraceControl_CommandError + command.toString());
         }
 


### PR DESCRIPTION
Don't fail if logger agents are not available (e.g. JUL).

[Fixed] listing UST domains if there are no logger agents

Fixes #192

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>