### PR TITLE
tmf: add capabilities data structure to IDataProviderDescriptor

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/DataProviderCapabilitiesTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/DataProviderCapabilitiesTest.java
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.tmf.core.tests.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderCapabilities;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderCapabilities;
+import org.junit.Test;
+
+/**
+ * JUnit Test class to test {@link DataProviderCapabilities}
+ *
+ * @author Bernd Hufmann
+ */
+public class DataProviderCapabilitiesTest {
+
+    private static final String EXPECTED_TO_STRING = "DataProviderCapabilities[canCreate=true, canDelete=true]";
+
+    // ------------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------------
+    /**
+     * Test builder, constructor and getter/setters.
+     */
+    @Test
+    public void testBuilder() {
+        DataProviderCapabilities.Builder builder = new DataProviderCapabilities.Builder()
+                .setCanCreate(true)
+                .setCanDelete(true);
+        IDataProviderCapabilities capabilities = builder.build();
+        assertTrue(capabilities.canCreate());
+        assertTrue(capabilities.canDelete());
+    }
+
+    /**
+     * Test {@Link DataProviderCapabilities#equals()}
+     */
+    @Test
+    public void testEquality() {
+        DataProviderCapabilities.Builder builder = new DataProviderCapabilities.Builder()
+                .setCanCreate(true)
+                .setCanDelete(true);
+        IDataProviderCapabilities baseCapabilities = builder.build();
+
+        // Make sure it is equal to itself
+        IDataProviderCapabilities testCapabilities = builder.build();
+        assertEquals(baseCapabilities, testCapabilities);
+        assertEquals(testCapabilities, baseCapabilities);
+
+        // Change each of the variable and make sure result is not equal
+        builder.setCanCreate(false);
+        testCapabilities = builder.build();
+        assertNotEquals(baseCapabilities, testCapabilities);
+        assertNotEquals(testCapabilities, baseCapabilities);
+
+        builder.setCanCreate(true);
+        builder.setCanDelete(false);
+        testCapabilities = builder.build();
+        assertNotEquals(baseCapabilities, testCapabilities);
+        assertNotEquals(testCapabilities, baseCapabilities);
+
+        builder.setCanCreate(false);
+        builder.setCanDelete(false);
+        testCapabilities = builder.build();
+        assertNotEquals(baseCapabilities, testCapabilities);
+        assertNotEquals(testCapabilities, baseCapabilities);
+
+        // Different objects with same content
+        assertFalse(testCapabilities == DataProviderCapabilities.NULL_INSTANCE);
+
+        // Equal by content
+        assertEquals(DataProviderCapabilities.NULL_INSTANCE, testCapabilities);
+    }
+
+    /**
+     * Test {@Link TmfConfiguration#toString()}
+     **/
+    @Test
+    public void testToString() {
+        DataProviderCapabilities.Builder builder = new DataProviderCapabilities.Builder()
+                .setCanCreate(true)
+                .setCanDelete(true);
+        assertEquals(EXPECTED_TO_STRING, builder.build().toString());
+    }
+
+    /**
+     * Test {@Link TmfConfiguration#hashCode()}
+     */
+    @Test
+    public void testHashCode() {
+        DataProviderCapabilities.Builder builder = new DataProviderCapabilities.Builder()
+                .setCanCreate(true)
+                .setCanDelete(true);
+
+        IDataProviderCapabilities capabilities1 = builder.build();
+        IDataProviderCapabilities capabilities2 = DataProviderCapabilities.NULL_INSTANCE;
+
+        assertEquals(capabilities1.hashCode(), capabilities1.hashCode());
+        assertEquals(capabilities2.hashCode(), capabilities2.hashCode());
+        assertNotEquals(capabilities1.hashCode(), capabilities2.hashCode());
+    }
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/DataProviderDescriptorTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/DataProviderDescriptorTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 École Polytechnique de Montréal
+ * Copyright (c) 2020, 2025 École Polytechnique de Montréal, Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -16,8 +16,10 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderCapabilities;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderCapabilities;
 import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
 import org.junit.Test;
 
@@ -75,6 +77,22 @@ public class DataProviderDescriptorTest {
                .setProviderType(ProviderType.TABLE)
                .setParentId(PARENT_ID)
                .setConfiguration(config);
+        assertFalse(baseDescriptor.equals(builder.build()));
+
+        // Check for NULL_INSTANCE (object equality)
+        assertTrue(baseDescriptor.getCapabilities() == DataProviderCapabilities.NULL_INSTANCE);
+
+        // Change capabilities
+        builder.setCapabilities(new IDataProviderCapabilities() {
+            @Override
+            public boolean canDelete() {
+                return true;
+            }
+            @Override
+            public boolean canCreate() {
+                return false;
+            }
+        });
         assertFalse(baseDescriptor.equals(builder.build()));
 
         // Make sure it is equal to itself (with parent id and config)

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderCapabilities.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderCapabilities.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.tmf.core.dataprovider;
+
+import org.eclipse.tracecompass.tmf.core.config.ITmfDataProviderConfigurator;
+
+/**
+ * Interface to implement to indicate capabilities of a data provider, such as
+ * "canCreate" and "canDelete" capability.
+ *
+ * "canCreate" indicates that a given data provider can create a derived data
+ * provider. "canDelete" indicates that a given data provider can be deleted.
+ *
+ * Call method {@link IDataProviderFactory#getAdapter(Class)} with class
+ * {@link ITmfDataProviderConfigurator} to obtain an instance of
+ * {@link ITmfDataProviderConfigurator}, which implements the "canCreate" and
+ * "canDelete" capabilities.
+ *
+ * @since 9.5
+ * @author Bernd Hufmann
+ */
+public interface IDataProviderCapabilities {
+    /**
+     * Whether the data provider can create derived data providers.
+     *
+     * @return {@code true} if this data provider can create a derived data
+     *         provider, else {@code false}
+     */
+    boolean canCreate();
+
+    /**
+     * Whether the data provider can be deleted.
+     *
+     * @return {@code true} if this data provider can be deleted, else
+     *         {@code false}
+     */
+    boolean canDelete();
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Ericsson
+ * Copyright (c) 2019, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -14,6 +14,7 @@ package org.eclipse.tracecompass.tmf.core.dataprovider;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderCapabilities;
 
 /**
  * Data Provider description, used to list the available providers for a trace
@@ -114,5 +115,13 @@ public interface IDataProviderDescriptor {
      */
     default @Nullable ITmfConfiguration getConfiguration() {
         return null;
+    }
+
+    /**
+     * @return The data provider capabilities instance
+     * @since 9.5
+     */
+    default IDataProviderCapabilities getCapabilities() {
+        return DataProviderCapabilities.NULL_INSTANCE;
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderCapabilities.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderCapabilities.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.tmf.core.model;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderCapabilities;
+
+/**
+ * An instance of data provider capabilities, indicating what capabilities a
+ * data provider has.
+ *
+ * @since 9.5
+ * @author Bernd Hufmann
+ */
+public class DataProviderCapabilities implements IDataProviderCapabilities {
+
+    /** The NullCapabilities instance */
+    public static final IDataProviderCapabilities NULL_INSTANCE = new DataProviderCapabilities.Builder().build();
+
+    private final boolean canCreate;
+    private final boolean canDelete;
+
+    /**
+     * Constructor
+     *
+     * @param builder
+     *            a builder instance
+     */
+    public DataProviderCapabilities(Builder builder) {
+        canCreate = builder.canCreate;
+        canDelete = builder.canDelete;
+    }
+
+    @Override
+    public boolean canCreate() {
+        return canCreate;
+    }
+
+    @Override
+    public boolean canDelete() {
+        return canDelete;
+    }
+
+    @Override
+    @SuppressWarnings("nls")
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName())
+                .append("[")
+                .append("canCreate=").append(canCreate())
+                .append(", canDelete=").append(canDelete())
+                .append("]").toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(canCreate, canDelete);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof DataProviderCapabilities)) {
+            return false;
+        }
+        DataProviderCapabilities other = (DataProviderCapabilities) obj;
+        return canCreate == other.canCreate && canDelete == other.canDelete;
+    }
+
+    /**
+     * Builder class to build a IDataProviderCapabilities instance
+     */
+    public static class Builder {
+        private boolean canCreate = false;
+        private boolean canDelete = false;
+
+        /**
+         * Sets canCreate flag
+         *
+         * @param canCreate
+         *            {@code true} if this data provider can create a derived
+         *            data provider, else {@code false}
+         * @return the builder instance.
+         */
+        public Builder setCanCreate(boolean canCreate) {
+            this.canCreate = canCreate;
+            return this;
+        }
+
+        /**
+         * Sets canDelete flag
+         *
+         * @param canDelete
+         *            {@code true} if this data provider can be deleted, else
+         *            {@code false}
+         * @return the builder instance.
+         */
+        public Builder setCanDelete(boolean canDelete) {
+            this.canDelete = canDelete;
+            return this;
+        }
+
+        /**
+         * The method to construct an instance of
+         * {@link IDataProviderCapabilities}
+         *
+         * @return a {@link IDataProviderCapabilities} instance
+         */
+        public IDataProviderCapabilities build() {
+            return new DataProviderCapabilities(this);
+        }
+    }
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderDescriptor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/DataProviderDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Ericsson
+ * Copyright (c) 2019, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -15,6 +15,7 @@ import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderCapabilities;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 
 /**
@@ -34,6 +35,7 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
     private final ProviderType fType;
     private final @Nullable String fParentId;
     private final @Nullable ITmfConfiguration fConfiguration;
+    private final IDataProviderCapabilities fCapabilities;
 
     /**
      * Constructor
@@ -48,6 +50,7 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
         fType = Objects.requireNonNull(builder.fType);
         fParentId = builder.fParentId;
         fConfiguration = builder.fConfiguration;
+        fCapabilities = builder.fCapabilities;
     }
 
     @Override
@@ -71,6 +74,11 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
     }
 
     @Override
+    public IDataProviderCapabilities getCapabilities() {
+        return fCapabilities;
+    }
+
+    @Override
     public @Nullable String getParentId() {
         return fParentId;
     }
@@ -88,6 +96,7 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
                 +  ", fId=" + getId()
                 +  ", fParentId=" + fParentId
                 +  ", fConfiguration=" + fConfiguration
+                +  ", fCapabilities=" + fCapabilities
                 + "]";
     }
 
@@ -99,12 +108,13 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
         DataProviderDescriptor other = (DataProviderDescriptor) arg0;
         return Objects.equals(fName, other.fName) && Objects.equals(fId, other.fId)
                 && Objects.equals(fType, other.fType) && Objects.equals(fDescription, other.fDescription)
-                && Objects.equals(fParentId, other.fParentId) && Objects.equals(fConfiguration, other.fConfiguration);
+                && Objects.equals(fParentId, other.fParentId) && Objects.equals(fConfiguration, other.fConfiguration)
+                && Objects.equals(fCapabilities, other.fCapabilities);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fParentId, fName, fId, fType, fDescription, fConfiguration);
+        return Objects.hash(fParentId, fName, fId, fType, fDescription, fConfiguration, fCapabilities);
     }
 
     /**
@@ -117,6 +127,7 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
         private @Nullable ProviderType fType = null;
         private @Nullable String fParentId = null;
         private @Nullable ITmfConfiguration fConfiguration = null;
+        private IDataProviderCapabilities fCapabilities = DataProviderCapabilities.NULL_INSTANCE;
 
         /**
          * Constructor
@@ -196,6 +207,19 @@ public class DataProviderDescriptor implements IDataProviderDescriptor {
          */
         public Builder setConfiguration(@Nullable ITmfConfiguration configuration) {
             fConfiguration = configuration;
+            return this;
+        }
+
+        /**
+         * Set data provider capabilities
+         *
+         * @param capabilities
+         *            the capabilities to set
+         * @return the builder instance.
+         * @since 9.5
+         */
+        public Builder setCapabilities(IDataProviderCapabilities capabilities) {
+            fCapabilities = capabilities;
             return this;
         }
 


### PR DESCRIPTION
With this a data provider factory instance can advertise special capabilities that can be applied for the given data provider.

This commit adds code for that and implements the "canCreate" and "canDelete" capability. "canCreate" indicates that this instance can create a derived data provider. Use the IDataProviderFactory method getAdapter(ITmfDataProviderConfigurator) to obtains a ITmfDataProviderConfigurator. This interface has methods to get List<ITmfConfigurationSourceType> describing the parameters needed to create a derived data provider using method createDataProvider.

"canDelete" indicates a the data provider can be deleted using the method ITmfDataProviderConfigurator#deleteDataProviderDescriptor.

[Added] capabilities data structure to IDataProviderDescriptor

see also https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1158

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
