### PR TITLE
tmf: Fix HistogramDataProvider index OOB

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/histogram/HistogramDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/histogram/HistogramDataProvider.java
@@ -126,6 +126,9 @@ public class HistogramDataProvider extends AbstractTmfTraceDataProvider implemen
         final ITmfStatistics stats = Objects.requireNonNull(fModule.getStatistics());
         if (selected.contains(fTotalId)) {
             List<Long> values = stats.histogramQuery(filter.getTimesRequested());
+            if (values.size() < n) {
+                return TmfXyResponseFactory.create(TITLE, xValues, Collections.emptyList(), false);
+            }
 
             double[] y = new double[n];
             Arrays.setAll(y, values::get);


### PR DESCRIPTION
For the event statistics histogram view, the HistogramDataProvider will occasionally fail with an IndexOutOfBoundsException when its fetchXY method is called before its state-system backed statistics have been populated with attributes.

Add a check to verify that the y-values provided by the statistics is large enough for the x-values.

The stacktrace in question. I occasionally see it when I open traces in vscode using the incubator trace-server.
```
Caused by: java.lang.IndexOutOfBoundsException: Index: 0
	at java.base/java.util.Collections$EmptyList.get(Collections.java:4483)
	at java.base/java.util.Arrays.setAll(Arrays.java:5414)
	at org.eclipse.tracecompass.internal.tmf.core.histogram.HistogramDataProvider.fetchXY(HistogramDataProvider.java:131)
	at org.eclipse.tracecompass.tmf.core.model.xy.TmfTreeXYCompositeDataProvider.getXyResponses(TmfTreeXYCompositeDataProvider.java:187)
	at org.eclipse.tracecompass.tmf.core.model.xy.TmfTreeXYCompositeDataProvider.fetchXY(TmfTreeXYCompositeDataProvider.java:136)
	at org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.DataProviderService.getXY(DataProviderService.java:417)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:469)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:391)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:80)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:253)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:232)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:680)
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394)
	... 30 more

```