### PR TITLE
profiling: add wasd controls to flamegraphview

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/META-INF/MANIFEST.MF
@@ -69,7 +69,7 @@ Export-Package: org.eclipse.tracecompass.internal.provisional.tmf.ui.model;x-int
  org.eclipse.tracecompass.internal.tmf.ui.viewers.timegraph.handlers;x-internal:=true,
  org.eclipse.tracecompass.internal.tmf.ui.viewers.tree;x-internal:=true,
  org.eclipse.tracecompass.internal.tmf.ui.viewers.xychart;x-internal:=true,
- org.eclipse.tracecompass.internal.tmf.ui.views;x-friends:="org.eclipse.tracecompass.tmf.ui.swtbot.tests",
+ org.eclipse.tracecompass.internal.tmf.ui.views;x-friends:="org.eclipse.tracecompass.tmf.ui.swtbot.tests,org.eclipse.tracecompass.analysis.profiling.ui",
  org.eclipse.tracecompass.internal.tmf.ui.views.eventdensity;x-internal:=true,
  org.eclipse.tracecompass.internal.tmf.ui.views.handler;x-internal:=true,
  org.eclipse.tracecompass.internal.tmf.ui.views.histogram;x-internal:=true,


### PR DESCRIPTION
### What it does
Fix issue #201 by using the context service already used by the timegraphview and the xyview.

### How to test
1) Open a trace with a call stack analysis
2) Open the flamegraph view
3) Use the keys 'w', 'a', 's', 'd' to move in the view

### Follow-ups
As the flamegraph view reuses a lot of the timegraph view code. Most of the code for this patch is copied from the timegraph implementation. Refactoring the timegraph view so that it is not coupled to a time based x-axis would fix that issue.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
