### PR TITLE
common: Deprecate TraceCompassLogUtils and use trace-event-logger lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .polyglot.build.properties
 .tycho-consumer-pom.xml
+jsonify.py
 bin/
 target/
 workspace/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -44,7 +44,12 @@ Trace Compass can be traced by doing the following in the launch configuration:
 * -Djava.util.logging.config.file=%gitroot%/logging.properties (where %gitroot% is the directory tracecompass is checked out to)
 * -Dorg.eclipse.tracecompass.logging=true
 
-Additionally the folder the trace is being written to (default is `home/.tracecompass/logs`) needs to be created in advance. After running Trace Compass, a `trace_n.json` will be created in the tracing folder. It needs to be converted to true json, so use the `jsonify.sh` script in the root directory to convert it. Then it can be loaded into Trace Compass, if the **Trace Event format** is installed from the incubator, or from a web browser such as Chromium.
+Additionally the folder the trace is being written to (default is `%home%/.tracecompass/logs`) needs to be created in advance. After running Trace Compass, a `trace_n.json` will be created in the tracing folder. It needs to be converted to true json, so use the `jsonify.sh` script in the root directory to convert it. Then it can be loaded into Trace Compass, if the **Trace Event format** is installed from the incubator, or from a web browser such as Chromium.
+
+To use the handlers provided in the trace-event-logger library by adding them to the logging config file, they will need to be added to the bootstrap class path in vmargs using a relative path (RCP) or absolute path (development):
+
+* -Xbootclasspath/a:./plugins/org.eclipse.tracecompass.trace-event-logger_x.y.z.jar
+* -Xbootclasspath/a:%home%/.m2/repository/org/eclipse/tracecompass/trace-event-logger/x.y.z/trace-event-logger-x.y.z.jar
 
 The performance impact is low enough as long as the log level is greater than "*FINEST*".
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Eclipse IDE, as well as standalone application.
 
 Check [Downloads](https://projects.eclipse.org/projects/tools.tracecompass/downloads) for downloading specific versions of Trace Compass.
 
+## Building and Tracing Trace Compass
+
+Information about building and tracing Trace Compass can be found in the [building guide](BUILDING.md).
+
 ## Contributing to Trace Compass
 
 **👋 Want to help?** Read our [contributor guide](CONTRIBUTING.md) and follow the

--- a/analysis/org.eclipse.tracecompass.analysis.counters.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.counters.core/META-INF/MANIFEST.MF
@@ -18,5 +18,6 @@ Export-Package: org.eclipse.tracecompass.analysis.counters.core,
  org.eclipse.tracecompass.internal.analysis.counters.core;x-friends:="org.eclipse.tracecompass.analysis.counters.ui"
 Import-Package: com.google.common.base,
  com.google.common.collect,
- com.google.common.primitives
+ com.google.common.primitives,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.analysis.counters.core

--- a/analysis/org.eclipse.tracecompass.analysis.counters.core/src/org/eclipse/tracecompass/analysis/counters/core/CounterStateProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.counters.core/src/org/eclipse/tracecompass/analysis/counters/core/CounterStateProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Ericsson
+ * Copyright (c) 2017, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -21,7 +21,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.analysis.counters.core.aspects.CounterAspect;
 import org.eclipse.tracecompass.analysis.counters.core.aspects.ITmfCounterAspect;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.analysis.counters.core.Activator;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
 import org.eclipse.tracecompass.statesystem.core.StateSystemBuilderUtils;
@@ -33,6 +32,7 @@ import org.eclipse.tracecompass.tmf.core.statesystem.AbstractTmfStateProvider;
 import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -192,7 +192,7 @@ public class CounterStateProvider extends AbstractTmfStateProvider {
                         break;
                     }
                 } catch (StateValueTypeException e) {
-                    TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, "HandleCounterAspect:Exception", e); //$NON-NLS-1$
+                    LogUtils.traceInstant(LOGGER, Level.WARNING, "HandleCounterAspect:Exception", e); //$NON-NLS-1$
                 }
             } else {
                 ss.modifyAttribute(event.getTimestamp().toNanos(), eventContent, quark);

--- a/analysis/org.eclipse.tracecompass.analysis.graph.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.graph.core/META-INF/MANIFEST.MF
@@ -29,5 +29,6 @@ Import-Package: com.google.common.annotations,
  com.google.common.cache,
  com.google.common.collect,
  com.google.common.hash,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.analysis.graph.core

--- a/analysis/org.eclipse.tracecompass.analysis.graph.core/src/org/eclipse/tracecompass/internal/analysis/graph/core/graph/historytree/HtIo.java
+++ b/analysis/org.eclipse.tracecompass.analysis.graph.core/src/org/eclipse/tracecompass/internal/analysis/graph/core/graph/historytree/HtIo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 École Polytechnique de Montréal and others
+ * Copyright (c) 2022, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -26,9 +26,9 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.datastore.core.interval.IHTIntervalReader;
 import org.eclipse.tracecompass.internal.analysis.graph.core.Activator;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -101,7 +101,7 @@ public class HtIo {
                     HtIo io = key.fHistoryTreeIo;
                     int seqNb = key.fSeqNumber;
 
-                    TraceCompassLogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheMiss", "seqNum", seqNb); //$NON-NLS-1$ //$NON-NLS-2$
+                    LogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheMiss", "seqNum", seqNb); //$NON-NLS-1$ //$NON-NLS-2$
 
                     synchronized (io) {
                         io.seekFCToNodePos(io.fFileChannelIn, seqNb);
@@ -233,7 +233,7 @@ public class HtIo {
      */
     public GraphTreeNode readNode(int seqNumber) throws ClosedChannelException {
         /* Do a cache lookup. If it's not present it will be loaded from disk */
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheLookup", "seqNum", seqNumber); //$NON-NLS-1$ //$NON-NLS-2$
+        LogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheLookup", "seqNum", seqNumber); //$NON-NLS-1$ //$NON-NLS-2$
         CacheKey key = new CacheKey(this, seqNumber);
         try {
             return checkNotNull(NODE_CACHE.get(key));

--- a/analysis/org.eclipse.tracecompass.analysis.lami.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.lami.core/META-INF/MANIFEST.MF
@@ -29,5 +29,6 @@ Export-Package: org.eclipse.tracecompass.internal.analysis.lami.core;x-internal:
 Import-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.collect,
+ org.eclipse.tracecompass.traceeventlogger,
  org.json
 Automatic-Module-Name: org.eclipse.tracecompass.analysis.lami.core

--- a/analysis/org.eclipse.tracecompass.analysis.lami.core/src/org/eclipse/tracecompass/internal/provisional/analysis/lami/core/module/LamiAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.lami.core/src/org/eclipse/tracecompass/internal/provisional/analysis/lami/core/module/LamiAnalysis.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 EfficiOS Inc., Alexandre Montplaisir
+ * Copyright (c) 2015, 2025 EfficiOS Inc., Alexandre Montplaisir and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -41,7 +41,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.common.core.process.ProcessUtils;
 import org.eclipse.tracecompass.common.core.process.ProcessUtils.OutputReaderFunction;
 import org.eclipse.tracecompass.internal.analysis.lami.core.Activator;
@@ -68,6 +67,7 @@ import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.La
 import org.eclipse.tracecompass.tmf.core.analysis.ondemand.IOnDemandAnalysis;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -309,18 +309,18 @@ public class LamiAnalysis implements IOnDemandAnalysis {
         final String output = getOutputFromCommand(commandLine);
 
         if (output == null) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.INFO, LOG_NO_MI_VERSION, INVALID_MI_VERSION, command);
+            LogUtils.traceInstant(LOGGER, Level.INFO, LOG_NO_MI_VERSION, INVALID_MI_VERSION, command);
             return;
         }
 
         final String versionString = output.trim();
 
         if (!versionString.matches("\\d{1,3}\\.\\d{1,3}")) { //$NON-NLS-1$
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.INFO, LOG_NO_MI_VERSION, COMMAND, command, VERSION, versionString);
+            LogUtils.traceInstant(LOGGER, Level.INFO, LOG_NO_MI_VERSION, COMMAND, command, VERSION, versionString);
             return;
         }
 
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, LOG_VERSION, COMMAND, command, VERSION, versionString);
+        LogUtils.traceInstant(LOGGER, Level.FINE, LOG_VERSION, COMMAND, command, VERSION, versionString);
 
 
         final String[] parts = versionString.split("\\."); //$NON-NLS-1$
@@ -406,7 +406,7 @@ public class LamiAnalysis implements IOnDemandAnalysis {
          */
         List<String> command = ImmutableList.<@NonNull String> builder()
                 .addAll(fScriptCommand).add(METADATA_FLAG).build();
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.INFO, RUNNING_METADATA_COMMAND, COMMAND, command);
+        LogUtils.traceInstant(LOGGER, Level.INFO, RUNNING_METADATA_COMMAND, COMMAND, command);
         String output = getOutputFromCommand(command);
         if (output == null || output.isEmpty()) {
             fHelpMessage = noMetadata(NonNullUtils.nullToEmptyString(Messages.LamiAnalysis_ErrorNoOutput));
@@ -492,7 +492,7 @@ public class LamiAnalysis implements IOnDemandAnalysis {
 
         } catch (JSONException e) {
             /* Error in the parsing of the JSON, script is broken? */
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, ERROR_PARSING_METADATA, e.getMessage());
+            LogUtils.traceInstant(LOGGER, Level.WARNING, ERROR_PARSING_METADATA, e.getMessage());
             fHelpMessage = noMetadata(NonNullUtils.nullToEmptyString(NLS.bind(Messages.LamiAnalysis_ParsingError, e.getMessage())));
             return false;
         }
@@ -699,7 +699,7 @@ public class LamiAnalysis implements IOnDemandAnalysis {
         builder.addAll(extraParams);
         builder.add(tracePath);
         List<String> command = builder.build();
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.INFO, RUNNING_EXECUTE_COMMAND, COMMAND, command);
+        LogUtils.traceInstant(LOGGER, Level.INFO, RUNNING_EXECUTE_COMMAND, COMMAND, command);
         String output = getResultsFromCommand(command, monitor);
 
         if (output.isEmpty()) {
@@ -848,7 +848,7 @@ public class LamiAnalysis implements IOnDemandAnalysis {
             }
 
         } catch (JSONException e) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, ERROR_PARSING_EXECUTION_OUTPUT, e.getMessage());
+            LogUtils.traceInstant(LOGGER, Level.WARNING, ERROR_PARSING_EXECUTION_OUTPUT, e.getMessage());
             IStatus status = new Status(IStatus.ERROR, Activator.instance().getPluginId(), e.getMessage(), e);
             throw new CoreException(status);
         }
@@ -868,7 +868,7 @@ public class LamiAnalysis implements IOnDemandAnalysis {
 
     @Nullable
     private static String getOutputFromCommand(List<String> command, boolean orError) {
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, LOG_RUNNING_MESSAGE, COMMAND, command);
+        LogUtils.traceInstant(LOGGER, Level.FINE, LOG_RUNNING_MESSAGE, COMMAND, command);
         List<String> lines = ProcessUtils.getOutputFromCommand(command, orError);
         if (lines == null) {
             return null;

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Import-Package: com.google.common.base,
  com.google.common.primitives,
  org.apache.commons.io,
  org.apache.commons.io.input,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger
 Export-Package: org.eclipse.tracecompass.analysis.os.linux.core.contextswitch,
  org.eclipse.tracecompass.analysis.os.linux.core.cpuusage,
  org.eclipse.tracecompass.analysis.os.linux.core.event.aspect,

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/cpuusage/KernelCpuUsageAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/cpuusage/KernelCpuUsageAnalysis.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 École Polytechnique de Montréal and others.
+ * Copyright (c) 2014, 2025 École Polytechnique de Montréal and others.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -35,8 +35,6 @@ import org.eclipse.tracecompass.analysis.os.linux.core.trace.IKernelTrace;
 import org.eclipse.tracecompass.analysis.os.linux.core.trace.KernelEventLayoutRequirement;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.internal.analysis.os.linux.core.Activator;
 import org.eclipse.tracecompass.internal.analysis.os.linux.core.kernel.Attributes;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
@@ -52,6 +50,8 @@ import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
 import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -274,7 +274,7 @@ public class KernelCpuUsageAnalysis extends TmfStateSystemAnalysisModule {
 
                     long currentCount = countAtEnd - countAtStart;
                     if (currentCount < 0) {
-                        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, "Negative count", //$NON-NLS-1$
+                        LogUtils.traceInstant(LOGGER, Level.FINE, "Negative count", //$NON-NLS-1$
                                 "CPU", curCpuName, //$NON-NLS-1$
                                 "tid", curTidName, //$NON-NLS-1$
                                 "startTime", startTime, //$NON-NLS-1$
@@ -283,7 +283,7 @@ public class KernelCpuUsageAnalysis extends TmfStateSystemAnalysisModule {
                                 "countAtEnd", countAtEnd); //$NON-NLS-1$
                         currentCount = 0;
                     } else if (currentCount > endTime - startTime) {
-                        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, "CPU usage over 100%", //$NON-NLS-1$
+                        LogUtils.traceInstant(LOGGER, Level.FINE, "CPU usage over 100%", //$NON-NLS-1$
                                 "CPU", curCpuName, //$NON-NLS-1$
                                 "tid", curTidName, //$NON-NLS-1$
                                 "startTime", startTime, //$NON-NLS-1$

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/META-INF/MANIFEST.MF
@@ -55,4 +55,5 @@ Import-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.cache,
  com.google.common.collect,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/flamegraph/FlameGraphDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/flamegraph/FlameGraphDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 École Polytechnique de Montréal
+ * Copyright (c) 2019, 2025 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -40,14 +40,12 @@ import org.eclipse.tracecompass.analysis.profiling.core.model.IHostModel;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.ITree;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeGroupDescriptor;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeProvider;
+import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeProvider.MetricType;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeSet;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTreeGroupBy;
-import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeProvider.MetricType;
 import org.eclipse.tracecompass.analysis.timing.core.statistics.IStatistics;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.datastore.core.serialization.ISafeByteBufferWriter;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.instrumented.FlameChartEntryModel;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.instrumented.FlameChartEntryModel.EntryType;
@@ -81,6 +79,8 @@ import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.util.Pair;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 École Polytechnique de Montréal
+ * Copyright (c) 2018, 2025 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -45,8 +45,6 @@ import org.eclipse.tracecompass.analysis.profiling.core.instrumented.EdgeStateVa
 import org.eclipse.tracecompass.analysis.profiling.core.instrumented.IFlameChartProvider;
 import org.eclipse.tracecompass.analysis.profiling.core.model.IHostModel;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.instrumented.FlameChartEntryModel.EntryType;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.model.ModelManager;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.model.ProcessStatusInterval;
@@ -77,6 +75,8 @@ import org.eclipse.tracecompass.tmf.core.symbols.SymbolProviderManager;
 import org.eclipse.tracecompass.tmf.core.symbols.SymbolProviderUtils;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.util.Pair;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.ui/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.ui/META-INF/MANIFEST.MF
@@ -37,4 +37,5 @@ Import-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.collect,
  org.apache.commons.lang3,
- org.eclipse.swtchart
+ org.eclipse.swtchart,
+ org.eclipse.tracecompass.traceeventlogger

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.ui/src/org/eclipse/tracecompass/internal/analysis/profiling/ui/flamegraph2/FlameGraphView.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.ui/src/org/eclipse/tracecompass/internal/analysis/profiling/ui/flamegraph2/FlameGraphView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Ericsson
+ * Copyright (c) 2016, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -74,12 +74,10 @@ import org.eclipse.tracecompass.analysis.profiling.core.callgraph.ICallGraphProv
 import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeGroupDescriptor;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeProvider;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
-import org.eclipse.tracecompass.internal.analysis.profiling.ui.Activator;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.flamegraph.DataProviderUtils;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.flamegraph.FlameGraphDataProvider;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.tree.AllGroupDescriptor;
+import org.eclipse.tracecompass.internal.analysis.profiling.ui.Activator;
 import org.eclipse.tracecompass.internal.analysis.profiling.ui.flamegraph.SortOption;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.TmfFilterAppliedSignal;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.TraceCompassFilter;
@@ -129,6 +127,8 @@ import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry.Sampling;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.TimeGraphControl;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.Utils.TimeFormat;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchActionConstants;

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/META-INF/MANIFEST.MF
@@ -33,5 +33,6 @@ Import-Package: com.google.common.annotations,
  com.google.common.collect,
  com.google.common.hash,
  com.google.common.primitives,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.analysis.timing.core

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/analysis/timing/core/segmentstore/SegmentStoreAnalysisModule.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/analysis/timing/core/segmentstore/SegmentStoreAnalysisModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Ericsson
+ * Copyright (c) 2022, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -29,7 +29,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
@@ -38,6 +37,7 @@ import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Ericsson
+ * Copyright (c) 2022, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -38,9 +38,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.ISegmentStoreProvider;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.VirtualTableQueryFilter;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.table.ITmfVirtualTableDataProvider;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.table.ITmfVirtualTableModel;
@@ -68,6 +65,9 @@ import org.eclipse.tracecompass.tmf.core.segment.SegmentEndTimeAspect;
 import org.eclipse.tracecompass.tmf.core.segment.SegmentStartNsTimeAspect;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -247,7 +247,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
      */
     public SegmentStoreTableDataProvider(ITmfTrace trace, ISegmentStoreProvider segmentProvider, String analysisId) {
         super(trace);
-        TraceCompassLogUtils.traceObjectCreation(LOGGER, Level.FINE, this);
+        LogUtils.traceObjectCreation(LOGGER, Level.FINE, this);
         fId = analysisId;
         fIsFirstAspect = true;
         fAllIndexes = new HashMap<>();
@@ -257,7 +257,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
 
     @Override
     public void dispose() {
-        TraceCompassLogUtils.traceObjectDestruction(LOGGER, Level.FINE, this, 10);
+        LogUtils.traceObjectDestruction(LOGGER, Level.FINE, this, 10);
     }
 
     /**
@@ -278,7 +278,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
         if (segStore != null) {
             synchronized (fAllIndexes) {
                 try (FlowScopeLog scope = new FlowScopeLogBuilder(LOGGER, Level.FINE, "SegmentStoreTableDataProvider#buildIndex.buildingIndexes").build()) { //$NON-NLS-1$
-                    TraceCompassLogUtils.traceObjectCreation(LOGGER, Level.FINE, fAllIndexes);
+                    LogUtils.traceObjectCreation(LOGGER, Level.FINE, fAllIndexes);
                     Iterable<ISegment> sortedSegmentStore = segStore.iterator(comparator);
                     List<SegmentStoreIndex> indexes = getIndexes(sortedSegmentStore);
                     if (fIsFirstAspect) {
@@ -289,9 +289,9 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
                         fAllIndexes.put(id, new SegmentIndexesComparatorWrapper(indexes, comparator, aspectName));
                     }
                 } catch (Exception ex) {
-                    TraceCompassLogUtils.traceInstant(LOGGER, Level.SEVERE, "error build index", ex.getMessage()); //$NON-NLS-1$
+                    LogUtils.traceInstant(LOGGER, Level.SEVERE, "error build index", ex.getMessage()); //$NON-NLS-1$
                 } finally {
-                    TraceCompassLogUtils.traceObjectDestruction(LOGGER, Level.FINE, fAllIndexes);
+                    LogUtils.traceObjectDestruction(LOGGER, Level.FINE, fAllIndexes);
                 }
             }
         }
@@ -372,7 +372,7 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
 
     @Override
     public TmfModelResponse<ITmfVirtualTableModel<VirtualTableLine>> fetchLines(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
-        TraceCompassLogUtils.traceAsyncStart(LOGGER, Level.FINE, "SegmentStoreTableDataProvider#fetchLines", fId, 2); //$NON-NLS-1$
+        LogUtils.traceAsyncStart(LOGGER, Level.FINE, "SegmentStoreTableDataProvider#fetchLines", fId, 2); //$NON-NLS-1$
         fetchParameters.putIfAbsent(DataProviderParameterUtils.REQUESTED_COLUMN_IDS_KEY, Collections.emptyList());
         VirtualTableQueryFilter queryFilter = FetchParametersUtils.createVirtualTableQueryFilter(fetchParameters);
         if (queryFilter == null) {
@@ -394,12 +394,12 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
             }
             synchronized (fAllIndexes) {
                 try (FlowScopeLog scope = new FlowScopeLogBuilder(LOGGER, Level.FINE, "SegmentStoreTableDataProvider#fetchLines").build()) { //$NON-NLS-1$
-                    TraceCompassLogUtils.traceObjectCreation(LOGGER, Level.FINER, fAllIndexes);
+                    LogUtils.traceObjectCreation(LOGGER, Level.FINER, fAllIndexes);
                     return extractRequestedLines(queryFilter, fetchParameters, segStore, aspects, indexesComparatorWrapper);
                 } catch (Exception ex) {
-                    TraceCompassLogUtils.traceInstant(LOGGER, Level.SEVERE, "error fetching lines ", ex.getMessage()); //$NON-NLS-1$
+                    LogUtils.traceInstant(LOGGER, Level.SEVERE, "error fetching lines ", ex.getMessage()); //$NON-NLS-1$
                 } finally {
-                    TraceCompassLogUtils.traceObjectDestruction(LOGGER, Level.FINER, fAllIndexes);
+                    LogUtils.traceObjectDestruction(LOGGER, Level.FINER, fAllIndexes);
                 }
             }
         }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.ui/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.ui/META-INF/MANIFEST.MF
@@ -31,4 +31,5 @@ Export-Package: org.eclipse.tracecompass.analysis.timing.ui.views.segmentstore,
  org.eclipse.tracecompass.internal.analysis.timing.ui.views.segmentstore.statistics;x-internal:=true,
  org.eclipse.tracecompass.internal.analysis.timing.ui.views.segmentstore.table;x-internal:=true,
  org.eclipse.tracecompass.internal.analysis.timing.ui.views.segmentstore.xyscatter;x-internal:=true
+Import-Package: org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.analysis.timing.ui

--- a/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/analysis/timing/ui/views/segmentstore/table/AbstractSegmentStoreTableViewer.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/analysis/timing/ui/views/segmentstore/table/AbstractSegmentStoreTableViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Ericsson
+ * Copyright (c) 2015, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -55,8 +55,6 @@ import org.eclipse.tracecompass.analysis.timing.core.segmentstore.IAnalysisProgr
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.ISegmentStoreProvider;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.internal.analysis.timing.ui.Activator;
 import org.eclipse.tracecompass.internal.analysis.timing.ui.views.segmentstore.table.Messages;
 import org.eclipse.tracecompass.internal.analysis.timing.ui.views.segmentstore.table.SegmentStoreContentProvider;
@@ -87,6 +85,8 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.ui.actions.OpenSourceCodeAction;
 import org.eclipse.tracecompass.tmf.ui.viewers.table.TmfSimpleTableViewer;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
@@ -329,7 +329,7 @@ public abstract class AbstractSegmentStoreTableViewer extends TmfSimpleTableView
                     SegmentStoreContentProvider contentProvider = (SegmentStoreContentProvider) getTableViewer().getContentProvider();
                     long segmentCount = contentProvider.getSegmentCount();
                     String contentProviderName = contentProvider.getClass().getSimpleName();
-                    TraceCompassLogUtils.traceCounter(LOGGER, Level.FINE, "SegmentStoreTableViewer#updateModel", contentProviderName, segmentCount); //$NON-NLS-1$
+                    LogUtils.traceCounter(LOGGER, Level.FINE, "SegmentStoreTableViewer#updateModel", contentProviderName, segmentCount); //$NON-NLS-1$
                     if (segmentCount > MAX_ITEMS) {
                         tableViewer.setItemCount(MAX_ITEMS);
                         Activator.getDefault().logWarning("Too many items to display for " + contentProviderName + ". Cannot display " + segmentCount + " in a reasonable timeframe."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/common/org.eclipse.tracecompass.common.core.tests/META-INF/MANIFEST.MF
+++ b/common/org.eclipse.tracecompass.common.core.tests/META-INF/MANIFEST.MF
@@ -20,5 +20,6 @@ Export-Package: org.eclipse.tracecompass.common.core.tests;x-friends:="org.eclip
  org.eclipse.tracecompass.common.core.tests.math;x-internal:=true
 Import-Package: com.google.common.base,
  com.google.common.collect,
- com.google.common.primitives
+ com.google.common.primitives,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.common.core.tests

--- a/common/org.eclipse.tracecompass.common.core/META-INF/MANIFEST.MF
+++ b/common/org.eclipse.tracecompass.common.core/META-INF/MANIFEST.MF
@@ -21,5 +21,7 @@ Export-Package: org.eclipse.tracecompass.common.core,
  org.eclipse.tracecompass.internal.common.core;x-internal:=true,
  org.eclipse.tracecompass.internal.common.core.log;x-friends:="org.eclipse.tracecompass.common.core.tests"
 Import-Package: com.google.common.base,
- com.google.common.collect
+ com.google.common.collect,
+ org.eclipse.tracecompass.traceeventlogger,
+ org.eclipse.tracecompass.traceeventlogger.beans
 Automatic-Module-Name: org.eclipse.tracecompass.common.core

--- a/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/log/TraceCompassLogUtils.java
+++ b/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/log/TraceCompassLogUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Ericsson
+ * Copyright (c) 2016, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 /**
  * Logger helper
@@ -102,7 +103,9 @@ import org.eclipse.jdt.annotation.Nullable;
  * @since 3.0
  * @noinstantiate This class is not intended to be instantiated by clients. It
  *                is a helper class.
+ * @deprecated Use {@link LogUtils} instead.
  */
+@Deprecated
 public final class TraceCompassLogUtils {
 
     private static final Format FORMAT = new DecimalFormat("#.###"); //$NON-NLS-1$

--- a/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/log/TraceCompassMonitorManager.java
+++ b/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/log/TraceCompassMonitorManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Ericsson
+ * Copyright (c) 2022, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v1.0 which
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.internal.common.core.log.TraceCompassMonitor;
+import org.eclipse.tracecompass.traceeventlogger.beans.TraceEventLoggerManager;
 
 /**
  * Trace Compass Monitor, shows the state of every scoped logger
@@ -22,7 +23,9 @@ import org.eclipse.tracecompass.internal.common.core.log.TraceCompassMonitor;
  *
  * @author Matthew Khouzam
  * @since 5.1
+ * @deprecated Use {@link TraceEventLoggerManager} instead.
  */
+@Deprecated
 public final class TraceCompassMonitorManager {
 
     private final Map<String, TraceCompassMonitor> fCounters = new LinkedHashMap<>();

--- a/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/process/ProcessUtils.java
+++ b/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/process/ProcessUtils.java
@@ -30,8 +30,8 @@ import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.common.core.Activator;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 /**
  * Common utility methods for launching external processes and retrieving their
@@ -62,7 +62,7 @@ public final class ProcessUtils {
      * @since 5.0
      */
     public static @Nullable List<String> getOutputFromCommand(List<String> command, boolean orError) {
-        try (TraceCompassLogUtils.ScopeLog sl = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ProcessUtils#getOutputFromComment", "args", command)) { //$NON-NLS-1$ //$NON-NLS-2$
+        try (ScopeLog sl = new ScopeLog(LOGGER, Level.FINER, "ProcessUtils#getOutputFromComment", "args", command)) { //$NON-NLS-1$ //$NON-NLS-2$
             ProcessBuilder builder = new ProcessBuilder(command);
             builder.redirectErrorStream(true);
 
@@ -162,7 +162,7 @@ public final class ProcessUtils {
         CancellableRunnable cancellerRunnable = null;
         Thread cancellerThread = null;
 
-        try (TraceCompassLogUtils.ScopeLog sl = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ProcessUtils#getOutputFromCommandCancellable", "MainTaskName", mainTaskName, "args", command)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        try (ScopeLog sl = new ScopeLog(LOGGER, Level.FINER, "ProcessUtils#getOutputFromCommandCancellable", "MainTaskName", mainTaskName, "args", command)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             monitor.beginTask(mainTaskName, PROGRESS_DURATION);
 
             ProcessBuilder builder = new ProcessBuilder(command);

--- a/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/xml/XmlUtils.java
+++ b/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/common/core/xml/XmlUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Ericsson
+ * Copyright (c) 2018, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,7 @@ import javax.xml.validation.Validator;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
@@ -157,7 +157,7 @@ public final class XmlUtils {
 
     private static void logException(String feature, ParserConfigurationException e) {
         // This should catch a failed setFeature feature
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, "ParserConfigurationException", "feature", feature, "stack", e.getStackTrace()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        LogUtils.traceInstant(LOGGER, Level.WARNING, "ParserConfigurationException", "feature", feature, "stack", e.getStackTrace()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 
     /**

--- a/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/internal/common/core/Activator.java
+++ b/common/org.eclipse.tracecompass.common.core/src/org/eclipse/tracecompass/internal/common/core/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Ericsson
+ * Copyright (c) 2014, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
 
 import org.eclipse.tracecompass.common.core.TraceCompassActivator;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 /**
  * Plugin activator
@@ -77,7 +77,7 @@ public class Activator extends TraceCompassActivator {
         }
         long end = System.nanoTime();
         long bogoMips = (long) (1e12 / (end - start));
-        TraceCompassLogUtils.traceInstant(logger, Level.SEVERE, PLUGIN_ID, "HostName", hostName, "OS", os, "Nb Processors", nbCpus, "BogoMips", bogoMips, "Memory", memory); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        LogUtils.traceInstant(logger, Level.SEVERE, PLUGIN_ID, "HostName", hostName, "OS", os, "Nb Processors", nbCpus, "BogoMips", bogoMips, "Memory", memory); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
     }
 
     @Override

--- a/jsonify.sh
+++ b/jsonify.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2020 Ericsson
+# Copyright (c) 2020, 2025 Ericsson
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v20.html
 #*******************************************************************************
 
-if [ -f "$1" ]; then
-    sed -i s#}\"\"{#},\\n{#g $1
-    sed -i s#\"\"#\"},\\n{\"#g $1
-    sed -i s#\"{#\[{#g $1
-    sed -i s#}\"#}\]#g $1
-else
+if [ -z "$1" ] || [ -z "$2" ] ; then
+    echo "usage: jsonify.sh input output"
+    exit 1
+fi
+if [ ! -f "$1" ]; then
     echo "$1 file not found!"
     exit 1
 fi
+if [ ! -f "jsonify.py" ]; then
+    wget https://raw.githubusercontent.com/eclipse-tracecompass/trace-event-logger/refs/heads/main/jsonify.py
+fi
+if [ ! -x "jsonify.py" ]; then
+    chmod +x jsonify.py
+fi
+./jsonify.py $1 $2

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core/META-INF/MANIFEST.MF
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: org.eclipse.tracecompass.common.core,
 Export-Package: org.eclipse.tracecompass.internal.jsontrace.core;x-internal:=true,
  org.eclipse.tracecompass.internal.jsontrace.core.job;x-friends:="org.eclipse.tracecompass.jsontrace.core.tests",
  org.eclipse.tracecompass.internal.provisional.jsontrace.core.trace;x-friends:="org.eclipse.tracecompass.jsontrace.core.tests"
+Import-Package: org.eclipse.tracecompass.traceeventlogger
 Bundle-Activator: org.eclipse.tracecompass.internal.jsontrace.core.Activator

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core/src/org/eclipse/tracecompass/internal/jsontrace/core/job/SortingJob.java
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core/src/org/eclipse/tracecompass/internal/jsontrace/core/job/SortingJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Ericsson
+ * Copyright (c) 2018, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -33,12 +33,12 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.jsontrace.core.Activator;
 import org.eclipse.tracecompass.internal.jsontrace.core.Messages;
 import org.eclipse.tracecompass.internal.provisional.jsontrace.core.trace.JsonTrace;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 /**
  * On-disk sorting job. It splits a trace into tracelets. Each tracelet is
@@ -269,7 +269,7 @@ public abstract class SortingJob extends Job {
                 tmpParser.close();
             }
         } catch (IOException e) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, "IOException in sorting job", "trace", fPath, //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceInstant(LOGGER, Level.WARNING, "IOException in sorting job", "trace", fPath, //$NON-NLS-1$ //$NON-NLS-2$
                     "exception", e); //$NON-NLS-1$
             return new Status(IStatus.WARNING, Activator.PLUGIN_ID, "IOException in sorting job for " + fPath, e); //$NON-NLS-1$
         } finally {

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core/META-INF/MANIFEST.MF
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core/META-INF/MANIFEST.MF
@@ -44,5 +44,6 @@ Import-Package: com.google.common.annotations;version="15.0.0",
  com.google.common.collect,
  com.google.common.io,
  org.apache.commons.lang3,
- org.apache.commons.lang3.builder
+ org.apache.commons.lang3.builder,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.lttng2.ust.core

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/debuginfo/FileOffsetMapper.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/debuginfo/FileOffsetMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 EfficiOS Inc., Alexandre Montplaisir
+ * Copyright (c) 2015, 2025 EfficiOS Inc., Alexandre Montplaisir and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,10 +26,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.common.core.process.ProcessUtils;
 import org.eclipse.tracecompass.tmf.core.event.lookup.TmfCallsite;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -185,7 +184,7 @@ public final class FileOffsetMapper {
                 .build(new CacheLoader<FileOffset, @NonNull Iterable<Addr2lineInfo>>() {
                     @Override
                     public @NonNull Iterable<Addr2lineInfo> load(FileOffset fo) {
-                        try (ScopeLog sl = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "FileOffsetMapper:CacheMiss",  //$NON-NLS-1$
+                        try (ScopeLog sl = new ScopeLog(LOGGER, Level.FINER, "FileOffsetMapper:CacheMiss",  //$NON-NLS-1$
                                 "File", fo.fFilePath,  //$NON-NLS-1$
                                 "Offset", fo.fOffset, //$NON-NLS-1$
                                 "Build id", fo.fBuildId)) { //$NON-NLS-1$
@@ -218,7 +217,7 @@ public final class FileOffsetMapper {
     }
 
     private static @Nullable Iterable<Addr2lineInfo> getAddr2lineInfo(File file, @Nullable String buildId, long offset) {
-        try (ScopeLog sl = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "FileOffsetMapper:Addr2lineInfo", //$NON-NLS-1$
+        try (ScopeLog sl = new ScopeLog(LOGGER, Level.FINER, "FileOffsetMapper:Addr2lineInfo", //$NON-NLS-1$
                 "File", file,  //$NON-NLS-1$
                 "Offset", offset, //$NON-NLS-1$
                 "Build id", buildId)) { //$NON-NLS-1$

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/debuginfo/UstDebugInfoStateProvider.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/debuginfo/UstDebugInfoStateProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 EfficiOS Inc., Alexandre Montplaisir
+ * Copyright (c) 2015, 2025 EfficiOS Inc., Alexandre Montplaisir and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -29,7 +29,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.os.linux.core.event.aspect.LinuxPidAspect;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.common.core.process.ProcessUtils;
 import org.eclipse.tracecompass.internal.lttng2.ust.core.trace.layout.LttngUst28EventLayout;
 import org.eclipse.tracecompass.lttng2.ust.core.trace.LttngUstTrace;
@@ -45,6 +44,7 @@ import org.eclipse.tracecompass.tmf.core.statesystem.AbstractTmfStateProvider;
 import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 import org.eclipse.tracecompass.tmf.core.util.Pair;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -423,7 +423,7 @@ public class UstDebugInfoStateProvider extends AbstractTmfStateProvider {
                 hasBuildIdValue == null ||
                 hasDebugLinkValue == null ||
                 (statedump && isPicValue == null)) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidBinInfoEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidBinInfoEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
             return;
         }
 
@@ -456,7 +456,7 @@ public class UstDebugInfoStateProvider extends AbstractTmfStateProvider {
         Long baddr = event.getContent().getFieldValue(Long.class, fLayout.fieldBaddr());
 
         if (buildIdArray == null || baddr == null) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidBinIdEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidBinIdEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
             return;
         }
 
@@ -487,7 +487,7 @@ public class UstDebugInfoStateProvider extends AbstractTmfStateProvider {
         String debugLink = event.getContent().getFieldValue(String.class, fLayout.fieldDebugLinkFilename());
 
         if (baddr == null || debugLink == null) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidDebugLinkEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidDebugLinkEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
             return;
         }
 
@@ -511,7 +511,7 @@ public class UstDebugInfoStateProvider extends AbstractTmfStateProvider {
         Long baddr = event.getContent().getFieldValue(Long.class, fLayout.fieldBaddr());
 
         if (baddr == null) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidDlCloseEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "UstDebugInfoStateProvider:InvalidDlCloseEvent", "event", event); //$NON-NLS-1$ //$NON-NLS-2$
             return;
         }
 

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -441,4 +441,8 @@
          id="org.apache.xmlgraphics"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.tracecompass.trace-event-logger"
+         version="0.0.0"/>
+
 </feature>

--- a/releng/org.eclipse.tracecompass.releng-site/category.xml
+++ b/releng/org.eclipse.tracecompass.releng-site/category.xml
@@ -37,6 +37,7 @@
    <feature url="features/org.eclipse.tracecompass.tmf.cli.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.cli.source" version="0.0.0"/>
    <bundle id="org.eclipse.tracecompass.common.core"/>
    <bundle id="org.eclipse.tracecompass.common.core.source"/>
+   <bundle id="org.eclipse.tracecompass.trace-event-logger"/>
    <bundle id="org.apache.commons.lang3"/>
    <bundle id="json"/>
    <category-def name="Trace Compass" label="Trace Compass Main Features"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.20.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.20.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.20" sequenceNumber="18">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.20" sequenceNumber="19">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/11/updates/release/11.0.26/"/>
@@ -92,6 +92,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.21.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.21.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.21" sequenceNumber="20">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.21" sequenceNumber="21">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/11/updates/release/11.0.26/"/>
@@ -92,6 +92,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.22.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.22.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.22" sequenceNumber="20">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.22" sequenceNumber="21">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/11/updates/release/11.0.26/"/>
@@ -92,6 +92,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.23.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.23.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.23" sequenceNumber="18">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.23" sequenceNumber="19">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/11/updates/release/11.0.26/"/>
@@ -92,6 +92,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.24.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.24.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.24" sequenceNumber="18">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.24" sequenceNumber="19">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/11/updates/release/11.0.26/"/>
@@ -93,6 +93,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.25.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.25.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.25" sequenceNumber="17">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.25" sequenceNumber="18">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/11/updates/release/11.0.26/"/>
@@ -93,6 +93,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.26.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.26.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.26" sequenceNumber="12">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.26" sequenceNumber="13">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -95,6 +95,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.27.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.27.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.27" sequenceNumber="10">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.27" sequenceNumber="11">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -89,6 +89,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.28.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.28.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.28" sequenceNumber="11">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.28" sequenceNumber="12">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -86,6 +86,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.29.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.29.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.29" sequenceNumber="7">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.29" sequenceNumber="8">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -89,6 +89,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.30.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.30.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.30" sequenceNumber="7">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.30" sequenceNumber="8">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -90,6 +90,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.31.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.31.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.31" sequenceNumber="7">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.31" sequenceNumber="8">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/1/updates/release/17.0.14/"/>
@@ -93,6 +93,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.32.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.32.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.32" sequenceNumber="6">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.32" sequenceNumber="7">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -92,6 +92,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.33.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.33.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.33" sequenceNumber="5">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.33" sequenceNumber="6">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -92,6 +92,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.34.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.34.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.34" sequenceNumber="6">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.34" sequenceNumber="7">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -92,6 +92,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.35.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.35.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.35" sequenceNumber="3">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.35" sequenceNumber="4">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -99,6 +99,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="244">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="245">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -99,6 +99,16 @@
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtchart.feature.source.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/swtchart/releases/0.14.0/repository/"/>
+</location>
+<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tracecompass</groupId>
+            <artifactId>trace-event-logger</artifactId>
+            <version>0.3.0</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/statesystem/org.eclipse.tracecompass.datastore.core/META-INF/MANIFEST.MF
+++ b/statesystem/org.eclipse.tracecompass.datastore.core/META-INF/MANIFEST.MF
@@ -31,5 +31,6 @@ Export-Package: org.eclipse.tracecompass.datastore.core.encoding,
 Import-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.cache,
- com.google.common.collect
+ com.google.common.collect,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.datastore.core

--- a/statesystem/org.eclipse.tracecompass.datastore.core/src/org/eclipse/tracecompass/internal/datastore/core/historytree/HtIo.java
+++ b/statesystem/org.eclipse.tracecompass.datastore.core/src/org/eclipse/tracecompass/internal/datastore/core/historytree/HtIo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 École Polytechnique de Montréal and others
+ * Copyright (c) 2010, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -26,13 +26,13 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.datastore.core.interval.IHTInterval;
 import org.eclipse.tracecompass.datastore.core.interval.IHTIntervalReader;
 import org.eclipse.tracecompass.internal.datastore.core.Activator;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.historytree.AbstractHistoryTree.IHTNodeFactory;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.historytree.HTNode;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.historytree.IHistoryTree;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -105,7 +105,7 @@ public class HtIo<E extends IHTInterval, N extends HTNode<E>> {
                     HtIo<IHTInterval, HTNode<IHTInterval>> io = key.fHistoryTreeIo;
                     int seqNb = key.fSeqNumber;
 
-                    TraceCompassLogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheMiss", "seqNum", seqNb); //$NON-NLS-1$ //$NON-NLS-2$
+                    LogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheMiss", "seqNum", seqNb); //$NON-NLS-1$ //$NON-NLS-2$
 
                     synchronized (io) {
                         io.seekFCToNodePos(io.fFileChannelIn, seqNb);
@@ -239,7 +239,7 @@ public class HtIo<E extends IHTInterval, N extends HTNode<E>> {
     @SuppressWarnings("unchecked")
     public N readNode(int seqNumber) throws ClosedChannelException {
         /* Do a cache lookup. If it's not present it will be loaded from disk */
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheLookup", "seqNum", seqNumber); //$NON-NLS-1$ //$NON-NLS-2$
+        LogUtils.traceInstant(LOGGER, Level.FINEST, "HtIo:CacheLookup", "seqNum", seqNumber); //$NON-NLS-1$ //$NON-NLS-2$
         CacheKey key = new CacheKey((HtIo<IHTInterval, HTNode<IHTInterval>>) this, seqNumber);
         try {
             return (N) checkNotNull(NODE_CACHE.get(key));

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/META-INF/MANIFEST.MF
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/META-INF/MANIFEST.MF
@@ -32,5 +32,6 @@ Import-Package: com.google.common.annotations;version="15.0.0",
  com.google.gson,
  com.google.gson.annotations,
  com.google.gson.stream,
- org.apache.commons.lang3.builder
+ org.apache.commons.lang3.builder,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.statesystem.core

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/StateSystem.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/StateSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 Ericsson and others
+ * Copyright (c) 2012, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -32,8 +32,6 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
@@ -46,6 +44,7 @@ import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
 import org.eclipse.tracecompass.statesystem.core.statevalue.ITmfStateValue;
 import org.eclipse.tracecompass.statesystem.core.statevalue.ITmfStateValue.Type;
 import org.eclipse.tracecompass.statesystem.core.statevalue.TmfStateValue;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.collect.ImmutableCollection.Builder;
 import com.google.common.collect.ImmutableSet;
@@ -596,7 +595,7 @@ public class StateSystem implements ITmfStateSystemBuilder {
         if (isDisposed) {
             throw new StateSystemDisposedException();
         }
-        try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "StateSystem:SingleQuery", //$NON-NLS-1$
+        try (ScopeLog log = new ScopeLog(LOGGER, Level.FINER, "StateSystem:SingleQuery", //$NON-NLS-1$
                 "ssid", this.getSSID(), //$NON-NLS-1$
                 "ts", t, //$NON-NLS-1$
                 "attribute", attributeQuark)) { //$NON-NLS-1$

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/TransientState.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/TransientState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson
  * Copyright (c) 2010, 2011 École Polytechnique de Montréal
  * Copyright (c) 2010, 2011 Alexandre Montplaisir <alexandre.montplaisir@gmail.com>
  *
@@ -30,13 +30,13 @@ import java.util.logging.Logger;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.statesystem.core.backend.IStateHistoryBackend;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateValueTypeException;
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
 import org.eclipse.tracecompass.statesystem.core.interval.TmfStateInterval;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 /**
  * The Transient State is used to build intervals from punctual state changes.
@@ -401,7 +401,7 @@ public class TransientState {
      */
     public Iterable<ITmfStateInterval> query2D(Collection<Integer> quarks, TimeRangeCondition timeCondition) {
         fRWLock.readLock().lock();
-        try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINEST, "TransientState:query2D", //$NON-NLS-1$
+        try (ScopeLog log = new ScopeLog(LOGGER, Level.FINEST, "TransientState:query2D", //$NON-NLS-1$
                 "ssid", fBackend.getSSID(), //$NON-NLS-1$
                 "quarks", quarks, //$NON-NLS-1$
                 "time", timeCondition)) { //$NON-NLS-1$

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/InMemoryBackend.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/InMemoryBackend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 Ericsson
+ * Copyright (c) 2013, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -28,13 +28,14 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.statesystem.core.backend.IStateHistoryBackend;
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
 import org.eclipse.tracecompass.statesystem.core.interval.TmfStateInterval;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
+
 import com.google.common.collect.Iterables;
 
 /**
@@ -214,7 +215,7 @@ public class InMemoryBackend implements IStateHistoryBackend {
     @Override
     public Iterable<@NonNull ITmfStateInterval> query2D(IntegerRangeCondition quarks, TimeRangeCondition times)
             throws TimeRangeException {
-        try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "InMemoryBackend:query2D", //$NON-NLS-1$
+        try (ScopeLog log = new ScopeLog(LOGGER, Level.FINER, "InMemoryBackend:query2D", //$NON-NLS-1$
                 "ssid", getSSID(), //$NON-NLS-1$
                 "quarks", quarks, //$NON-NLS-1$
                 "times", times)) { //$NON-NLS-1$

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HTNode.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HTNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 Ericsson, École Polytechnique de Montréal, and others
+ * Copyright (c) 2010, 2025 Ericsson, École Polytechnique de Montréal, and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -31,13 +31,12 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.internal.statesystem.core.backend.historytree.IHistoryTree.IHTNodeFactory;
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 /**
  * The base class for all the types of nodes that go in the History Tree.
@@ -472,7 +471,7 @@ public abstract class HTNode {
      */
     public HTInterval getRelevantInterval(int key, long t) throws TimeRangeException {
         fRwl.readLock().lock();
-        try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINEST, "HTNode:singleQuery", //$NON-NLS-1$
+        try (ScopeLog log = new ScopeLog(LOGGER, Level.FINEST, "HTNode:singleQuery", //$NON-NLS-1$
                 "time", t, //$NON-NLS-1$
                 "attribute", key)) { //$NON-NLS-1$
             for (int i = getStartIndexFor(t); i < fIntervals.size(); i++) {
@@ -503,7 +502,7 @@ public abstract class HTNode {
      */
     public Iterable<@NonNull HTInterval> iterable2D(IntegerRangeCondition quarks, TimeRangeCondition times) {
         fRwl.readLock().lock();
-        try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINEST, "HTNode:query2D", //$NON-NLS-1$
+        try (ScopeLog log = new ScopeLog(LOGGER, Level.FINEST, "HTNode:query2D", //$NON-NLS-1$
                 "quarks", quarks, //$NON-NLS-1$
                 "times", times)) { //$NON-NLS-1$
             List<@NonNull HTInterval> intervals = new ArrayList<>();

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HT_IO.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HT_IO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson
  * Copyright (c) 2010, 2011 École Polytechnique de Montréal
  * Copyright (c) 2010, 2011 Alexandre Montplaisir <alexandre.montplaisir@gmail.com>
  *
@@ -32,9 +32,9 @@ import java.util.logging.Logger;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.statesystem.core.Activator;
 import org.eclipse.tracecompass.internal.statesystem.core.backend.historytree.IHistoryTree.IHTNodeFactory;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -99,7 +99,7 @@ public class HT_IO {
             HT_IO io = key.fStateHistory;
             int seqNb = key.fSeqNumber;
 
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.FINEST, "Ht_Io:CacheMiss", "seqNum", seqNb); //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceInstant(LOGGER, Level.FINEST, "Ht_Io:CacheMiss", "seqNum", seqNb); //$NON-NLS-1$ //$NON-NLS-2$
 
             HTConfig config = io.fConfig;
             /* Allocate buffer */
@@ -201,7 +201,7 @@ public class HT_IO {
      */
     public @NonNull HTNode readNode(int seqNumber) throws ClosedChannelException {
         /* Do a cache lookup. If it's not present it will be loaded from disk */
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINEST, "Ht_Io:CacheLookup", "seqNum", seqNumber); //$NON-NLS-1$ //$NON-NLS-2$
+        LogUtils.traceInstant(LOGGER, Level.FINEST, "Ht_Io:CacheLookup", "seqNum", seqNumber); //$NON-NLS-1$ //$NON-NLS-2$
         CacheKey key = new CacheKey(this, seqNumber);
         try {
             return Objects.requireNonNull(NODE_CACHE.get(key));

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HistoryTreeBackend.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HistoryTreeBackend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson
  * Copyright (c) 2010, 2011 École Polytechnique de Montréal
  * Copyright (c) 2010, 2011 Alexandre Montplaisir <alexandre.montplaisir@gmail.com>
  *
@@ -24,14 +24,12 @@ import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.internal.statesystem.core.Activator;
@@ -39,6 +37,9 @@ import org.eclipse.tracecompass.statesystem.core.backend.IStateHistoryBackend;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -174,7 +175,7 @@ public class HistoryTreeBackend implements IStateHistoryBackend {
      */
     @VisibleForTesting
     protected @NonNull IHistoryTree initializeSHT(@NonNull HTConfig conf) throws IOException {
-        TraceCompassLogUtils.traceObjectCreation(LOGGER, Level.FINER, this);
+        LogUtils.traceObjectCreation(LOGGER, Level.FINER, this);
         return HistoryTreeFactory.createHistoryTree(conf);
     }
 
@@ -262,8 +263,8 @@ public class HistoryTreeBackend implements IStateHistoryBackend {
     @Override
     public void dispose() {
         if (fFinishedBuilding) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, "HistoryTreeBackend:ClosingFile", "size", getSHT().getFileSize()); //$NON-NLS-1$ //$NON-NLS-2$
-            TraceCompassLogUtils.traceObjectDestruction(LOGGER, Level.FINER, this);
+            LogUtils.traceInstant(LOGGER, Level.FINE, "HistoryTreeBackend:ClosingFile", "size", getSHT().getFileSize()); //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceObjectDestruction(LOGGER, Level.FINER, this);
             getSHT().closeFile();
         } else {
             /*
@@ -361,7 +362,7 @@ public class HistoryTreeBackend implements IStateHistoryBackend {
                 "ssid", getSSID(), //$NON-NLS-1$
                 "quarks", quarks, //$NON-NLS-1$
                 "timeCondition", times).build()) { //$NON-NLS-1$
-            return () -> new HistoryTreeBackendIterator(getSHT(), quarks, times, reverse, log);
+            return () -> new HistoryTreeBackendIterator(getSHT(), quarks, times, reverse, Objects.requireNonNull(log));
         }
     }
 

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HistoryTreeBackendIterator.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/HistoryTreeBackendIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016, 2022 Ericsson
+ * Copyright (c) 2012, 2016, 2025 Ericsson
  * Copyright (c) 2010, 2011 École Polytechnique de Montréal
  * Copyright (c) 2010, 2011 Alexandre Montplaisir <alexandre.montplaisir@gmail.com>
  *
@@ -28,11 +28,11 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 class HistoryTreeBackendIterator implements Iterator<@NonNull ITmfStateInterval> {
     private static final @NonNull Logger LOGGER = TraceCompassLog.getLogger(HistoryTreeBackendIterator.class);

--- a/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/ThreadedHistoryTreeBackend.java
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core/src/org/eclipse/tracecompass/internal/statesystem/core/backend/historytree/ThreadedHistoryTreeBackend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson
  * Copyright (c) 2010, 2011 École Polytechnique de Montréal
  * Copyright (c) 2010, 2011 Alexandre Montplaisir <alexandre.montplaisir@gmail.com>
  *
@@ -25,7 +25,6 @@ import java.util.logging.Logger;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.collect.BufferedBlockingQueue;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.internal.statesystem.core.Activator;
@@ -33,6 +32,7 @@ import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedE
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
 import org.eclipse.tracecompass.statesystem.core.statevalue.TmfStateValue;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.collect.Iterables;
 
@@ -297,7 +297,7 @@ public final class ThreadedHistoryTreeBackend extends HistoryTreeBackend
     @Override
     public Iterable<@NonNull ITmfStateInterval> query2D(IntegerRangeCondition quarks, TimeRangeCondition times, boolean reverse)
             throws TimeRangeException {
-        try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINEST, "ThreadedHistoryTreeBackend:query2D", //$NON-NLS-1$
+        try (ScopeLog log = new ScopeLog(LOGGER, Level.FINEST, "ThreadedHistoryTreeBackend:query2D", //$NON-NLS-1$
                 "ssid", getSSID(), //$NON-NLS-1$
                 "quarks", quarks, //$NON-NLS-1$
                 "timeCondition", times)) { //$NON-NLS-1$

--- a/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
@@ -145,5 +145,6 @@ Import-Package: com.google.common.annotations,
  org.antlr.runtime,
  org.antlr.runtime.tree,
  org.apache.commons.io,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.tmf.core

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/request/TmfRequestExecutor.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/request/TmfRequestExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 Ericsson
+ * Copyright (c) 2009, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -30,12 +30,12 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.tmf.core.TmfCoreTracer;
 import org.eclipse.tracecompass.internal.tmf.core.component.TmfEventThread;
 import org.eclipse.tracecompass.tmf.core.request.ITmfEventRequest.ExecutionType;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 /**
  * The request scheduler works with 5 slots with a specific time. It has 4 slots
@@ -138,7 +138,7 @@ public class TmfRequestExecutor implements Executor {
 
         // We are expecting MyEventThread:s
         if (!(command instanceof TmfEventThread)) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, "RequestExecutor:NotATmfEventThread", "cmd", command.toString()); //$NON-NLS-1$ //$NON-NLS-2$
+            LogUtils.traceInstant(LOGGER, Level.WARNING, "RequestExecutor:NotATmfEventThread", "cmd", command.toString()); //$NON-NLS-1$ //$NON-NLS-2$
             return;
         }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/statesystem/backends/partial/PartialInMemoryBackend.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/internal/tmf/core/statesystem/backends/partial/PartialInMemoryBackend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 École Polytechnique de Montréal
+ * Copyright (c) 2022, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -23,13 +23,14 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.IntegerRangeCondition;
 import org.eclipse.tracecompass.internal.provisional.datastore.core.condition.TimeRangeCondition;
 import org.eclipse.tracecompass.statesystem.core.backend.IPartialStateHistoryBackend;
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
 import org.eclipse.tracecompass.statesystem.core.interval.TmfStateInterval;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
+
 import com.google.common.collect.Iterables;
 
 /**
@@ -222,7 +223,7 @@ public class PartialInMemoryBackend implements IPartialStateHistoryBackend {
     @Override
     public Iterable<@NonNull ITmfStateInterval> query2D(IntegerRangeCondition quarks, TimeRangeCondition times)
             throws TimeRangeException {
-        try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "InMemoryBackend:query2D", //$NON-NLS-1$
+        try (ScopeLog log = new ScopeLog(LOGGER, Level.FINER, "InMemoryBackend:query2D", //$NON-NLS-1$
                 "ssid", getSSID(), //$NON-NLS-1$
                 "quarks", quarks, //$NON-NLS-1$
                 "times", times)) { //$NON-NLS-1$

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/TmfAbstractAnalysisModule.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/analysis/TmfAbstractAnalysisModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 École Polytechnique de Montréal
+ * Copyright (c) 2013, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -40,8 +40,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.tmf.core.Activator;
 import org.eclipse.tracecompass.internal.tmf.core.TmfCoreTracer;
 import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement;
@@ -54,6 +52,8 @@ import org.eclipse.tracecompass.tmf.core.signal.TmfTraceClosedSignal;
 import org.eclipse.tracecompass.tmf.core.signal.TmfTraceSelectedSignal;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 /**
  * Base class that analysis modules main class may extend. It provides default
@@ -338,7 +338,7 @@ public abstract class TmfAbstractAnalysisModule extends TmfComponent
     }
 
     private void execute(final ITmfTrace trace) {
-        try (FlowScopeLog analysisLog = new FlowScopeLogBuilder(LOGGER, Level.FINE, "TmfAbstractAnalysis:scheduling", "name", getName()).setCategory(getId()).build()) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        try (FlowScopeLog analysisLog = new FlowScopeLogBuilder(LOGGER, Level.FINE, "TmfAbstractAnalysis:scheduling", "name", getName()).setCategory(getId()).build()) { //$NON-NLS-1$ //$NON-NLS-2$
             /*
              * TODO: The analysis in a job should be done at the analysis
              * manager level instead of depending on this abstract class

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/MultiAspect.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/event/aspect/MultiAspect.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Ericsson
+ * Copyright (c) 2017, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -22,9 +22,9 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 import com.google.common.collect.Iterables;
 
@@ -79,14 +79,14 @@ public class MultiAspect<T> implements ITmfEventAspect<T> {
         if (names.size() != 1) {
             StringJoiner sj = new StringJoiner(", "); //$NON-NLS-1$
             names.forEach(sj::add);
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, "Aspects do not have the same name: ", sj.toString()); //$NON-NLS-1$ );
+            LogUtils.traceInstant(LOGGER, Level.WARNING, "Aspects do not have the same name: ", sj.toString()); //$NON-NLS-1$ );
         }
 
          // Ensure all aspects have the same data type
         if (dataTypes.size() != 1) {
             StringJoiner sj = new StringJoiner(", "); //$NON-NLS-1$
             dataTypes.forEach(dt -> sj.add(dt.toString()));
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, "Aspects do not have the same data type: ", sj.toString()); //$NON-NLS-1$
+            LogUtils.traceInstant(LOGGER, Level.WARNING, "Aspects do not have the same data type: ", sj.toString()); //$NON-NLS-1$
         }
 
         return new MultiAspect<>(Iterables.get(names, 0), aspects);

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/timegraph/AbstractTimeGraphDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/timegraph/AbstractTimeGraphDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Ericsson
+ * Copyright (c) 2018, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -19,8 +19,6 @@ import java.util.logging.Level;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
 import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
@@ -32,6 +30,8 @@ import org.eclipse.tracecompass.tmf.core.response.ITmfResponse.Status;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/AbstractTreeDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/AbstractTreeDataProvider.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2017, 2020 Ericsson
+ * Copyright (c) 2017, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -25,8 +25,6 @@ import java.util.logging.Logger;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
 import org.eclipse.tracecompass.tmf.core.model.AbstractStateSystemAnalysisDataProvider;
@@ -38,6 +36,8 @@ import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBasedTable;

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/xy/AbstractTreeCommonXDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/xy/AbstractTreeCommonXDataProvider.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2017 Ericsson
+ * Copyright (c) 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -18,8 +18,6 @@ import java.util.logging.Level;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.tmf.core.model.TmfXyResponseFactory;
 import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
@@ -32,6 +30,8 @@ import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.ImmutableList;
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/AbstractTmfStateProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/AbstractTmfStateProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -15,6 +15,7 @@
 package org.eclipse.tracecompass.tmf.core.statesystem;
 
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.logging.Level;
@@ -25,8 +26,6 @@ import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.collect.BufferedBlockingQueue;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.tmf.core.Activator;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
@@ -34,6 +33,8 @@ import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.TmfEvent;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfContext;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -144,7 +145,7 @@ public abstract class AbstractTmfStateProvider implements ITmfStateProvider {
             // yet
             // started
             fSafeTime = trace.getStartTime().toNanos() - 1;
-            fEventHandlerThread = new Thread(() -> SafeRunner.run(new EventProcessor(log)), id + " Event Handler"); //$NON-NLS-1$
+            fEventHandlerThread = new Thread(() -> SafeRunner.run(new EventProcessor(Objects.requireNonNull(log))), id + " Event Handler"); //$NON-NLS-1$
         }
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/TmfStateSystemAnalysisModule.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/TmfStateSystemAnalysisModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 École Polytechnique de Montréal
+ * Copyright (c) 2013, 2025 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -35,7 +35,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.internal.tmf.core.Activator;
 import org.eclipse.tracecompass.internal.tmf.core.statesystem.backends.partial.PartialHistoryBackend;
 import org.eclipse.tracecompass.internal.tmf.core.statesystem.backends.partial.PartialInMemoryBackend;
@@ -63,6 +62,7 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfTraceCompleteness;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statistics/TmfStateStatistics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -27,11 +27,11 @@ import java.util.logging.Logger;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
 import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.Lists;
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/symbols/SymbolProviderUtils.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/symbols/SymbolProviderUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 École Polytechnique de Montréal
+ * Copyright (c) 2017, 2025 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 /**
  * Utility class to resolve symbols from providers
@@ -75,7 +75,7 @@ public final class SymbolProviderUtils {
         for (ISymbolProvider provider : providers) {
             TmfResolvedSymbol currentSymbol = func.apply(provider);
             if (currentSymbol != null) {
-                TraceCompassLogUtils.traceInstant(LOGGER, Level.FINER, "Symbol found", "address", address, "provider", provider, "found symbol", currentSymbol); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
+                LogUtils.traceInstant(LOGGER, Level.FINER, "Symbol found", "address", address, "provider", provider, "found symbol", currentSymbol); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
                 if (resolvedSymbol == null) {
                     resolvedSymbol = currentSymbol;
                 } else {
@@ -84,7 +84,7 @@ public final class SymbolProviderUtils {
             }
         }
         String symbolText = resolvedSymbol != null ? resolvedSymbol.getSymbolName() : "0x" + Long.toHexString(address);//$NON-NLS-1$
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINER, "Symbol returned", "address", address, "symbolText", symbolText); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+        LogUtils.traceInstant(LOGGER, Level.FINER, "Symbol returned", "address", address, "symbolText", symbolText); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
         return symbolText;
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/TmfTraceManager.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/TmfTraceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 Ericsson and others
+ * Copyright (c) 2013, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -47,7 +47,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.tmf.core.Activator;
 import org.eclipse.tracecompass.tmf.core.TmfCommonConstants;
 import org.eclipse.tracecompass.tmf.core.signal.TmfEventFilterAppliedSignal;
@@ -62,6 +61,7 @@ import org.eclipse.tracecompass.tmf.core.signal.TmfWindowRangeUpdatedSignal;
 import org.eclipse.tracecompass.tmf.core.timestamp.ITmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableSet;
@@ -380,7 +380,7 @@ public final class TmfTraceManager {
             String supplementaryFileDir = TmfTraceManager.getSupplementaryFileDir(trace);
             FileUtils.cleanDirectory(new File(supplementaryFileDir));
             // Needed to audit for privacy concerns
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "deleteSupplementaryFiles", supplementaryFileDir); //$NON-NLS-1$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "deleteSupplementaryFiles", supplementaryFileDir); //$NON-NLS-1$
         } catch (IOException e) {
             Activator.logError("Error deleting supplementary files for trace " + trace.getName(), e); //$NON-NLS-1$
         }
@@ -402,7 +402,7 @@ public final class TmfTraceManager {
             String temporaryDirPath = getTemporaryDirPath();
             deleteFolder(parent, temporaryDirPath);
             // Needed to audit for privacy concerns
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "deleteSupplementaryFolder", temporaryDirPath); //$NON-NLS-1$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "deleteSupplementaryFolder", temporaryDirPath); //$NON-NLS-1$
         } catch (IOException e) {
             Activator.logError("Error deleting supplementary folder for trace " + trace.getName(), e); //$NON-NLS-1$
         }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/indexer/checkpoint/TmfCheckpointIndexer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/indexer/checkpoint/TmfCheckpointIndexer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -25,7 +25,6 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.tmf.core.Activator;
 import org.eclipse.tracecompass.internal.tmf.core.Messages;
 import org.eclipse.tracecompass.internal.tmf.core.TmfCoreTracer;
@@ -43,6 +42,7 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTraceKnownSize;
 import org.eclipse.tracecompass.tmf.core.trace.indexer.ITmfTraceIndexer;
 import org.eclipse.tracecompass.tmf.core.trace.location.ITmfLocation;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 /**
  * A simple indexer that manages the trace index as an array of trace
@@ -388,7 +388,7 @@ public class TmfCheckpointIndexer implements ITmfTraceIndexer {
                     setName(Messages.TmfCheckpointIndexer_Indexing + ' ' + fTrace.getName() + " (" + String.format("%,d", nbEvents) + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                     // setName doesn't refresh the UI, setTaskName does
                     long rate = (nbEvents - prevNbEvents) * 4;
-                    TraceCompassLogUtils.traceCounter(LOGGER, Level.FINE, fTrace.getName(), "indexed", nbEvents - prevNbEvents); //$NON-NLS-1$
+                    LogUtils.traceCounter(LOGGER, Level.FINE, fTrace.getName(), "indexed", nbEvents - prevNbEvents); //$NON-NLS-1$
                     subMonitor.setTaskName(String.format("%,d", rate) + " " + Messages.TmfCheckpointIndexer_EventsPerSecond); //$NON-NLS-1$ //$NON-NLS-2$
                 } catch (final InterruptedException e) {
                     return Status.OK_STATUS;

--- a/tmf/org.eclipse.tracecompass.tmf.ui/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/META-INF/MANIFEST.MF
@@ -150,5 +150,6 @@ Import-Package: com.google.common.annotations,
  org.apache.commons.compress.compressors.gzip,
  org.apache.commons.io,
  org.eclipse.emf.common.util,
- org.eclipse.emf.ecore
+ org.eclipse.emf.ecore,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.tmf.ui

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfCommonProjectElement.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfCommonProjectElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 Ericsson, École Polytechnique de Montréal
+ * Copyright (c) 2010, 2025 Ericsson, École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -49,7 +49,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.tmf.ui.Activator;
 import org.eclipse.tracecompass.internal.tmf.ui.editors.ITmfEventsEditorConstants;
 import org.eclipse.tracecompass.tmf.core.TmfCommonConstants;
@@ -58,6 +57,7 @@ import org.eclipse.tracecompass.tmf.core.project.model.TmfTraceType;
 import org.eclipse.tracecompass.tmf.core.project.model.TmfTraceType.TraceElementType;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -718,7 +718,7 @@ public abstract class TmfCommonProjectElement extends TmfProjectModelElement {
             try {
                 resources[i].delete(true, new NullProgressMonitor());
                 // Needed to audit for privacy concerns
-                TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "deleteSupplementaryResources", resources[i].getFullPath().toOSString() ); //$NON-NLS-1$
+                LogUtils.traceInstant(LOGGER, Level.CONFIG, "deleteSupplementaryResources", resources[i].getFullPath().toOSString() ); //$NON-NLS-1$
             } catch (CoreException e) {
                 Activator.getDefault().logError("Error deleting supplementary resource " + resources[i], e); //$NON-NLS-1$
             }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2013, 2019 Ericsson, École Polytechnique de Montréal
+ * Copyright (c) 2013, 2025 Ericsson, École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -49,9 +49,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.internal.tmf.ui.Activator;
 import org.eclipse.tracecompass.internal.tmf.ui.project.model.TmfImportHelper;
 import org.eclipse.tracecompass.tmf.core.TmfCommonConstants;
@@ -64,6 +61,9 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
 import org.eclipse.tracecompass.tmf.ui.editors.TmfEditorInput;
 import org.eclipse.tracecompass.tmf.ui.editors.TmfEventsEditor;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/UpdateTraceBoundsJob.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/UpdateTraceBoundsJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Ericsson and others
+ * Copyright (c) 2017, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -34,12 +34,12 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.tmf.ui.Activator;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfTraceException;
 import org.eclipse.tracecompass.tmf.core.timestamp.ITmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
 /**
  * Update traces bounds, by using supplementary files if they exist or by
@@ -163,7 +163,7 @@ public class UpdateTraceBoundsJob extends Job {
                  */
                 traceElement.setStartTime(TmfTimestamp.BIG_BANG);
                 traceElement.setEndTime(TmfTimestamp.BIG_BANG);
-                TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to read time bounds", "trace", traceElement.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+                LogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to read time bounds", "trace", traceElement.getName()); //$NON-NLS-1$ //$NON-NLS-2$
             } finally {
                 /*
                  * Leave the trace at the same initialization status as
@@ -210,9 +210,9 @@ public class UpdateTraceBoundsJob extends Job {
              */
             newChild.subTask(""); //$NON-NLS-1$
         } catch (IOException e) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to write time bounds to supplementary file", "trace", traceElement.getName(), "supplementary file", folder.getName()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to write time bounds to supplementary file", "trace", traceElement.getName(), "supplementary file", folder.getName()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         } catch (CoreException e) {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to refresh supplementary file", "trace", traceElement.getName(), "supplementary file", folder.getName()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            LogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to refresh supplementary file", "trace", traceElement.getName(), "supplementary file", folder.getName()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         }
     }
 
@@ -253,7 +253,7 @@ public class UpdateTraceBoundsJob extends Job {
                 }
                 traceElement.refreshViewer();
             } catch (IOException e) {
-                TraceCompassLogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to read time bounds", "trace", traceElement.getName(), "bounds file", boundsFile.getAbsoluteFile()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                LogUtils.traceInstant(LOGGER, Level.CONFIG, "Failed to read time bounds", "trace", traceElement.getName(), "bounds file", boundsFile.getAbsoluteFile()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                 if (!boundsFile.delete()) {
                     Activator.getDefault().logError("Failed to delete " + boundsFile); //$NON-NLS-1$
                 }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/tree/AbstractSelectTreeViewer2.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/tree/AbstractSelectTreeViewer2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Ericsson, Draeger Auriga
+ * Copyright (c) 2017, 2025 Ericsson, Draeger Auriga
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -48,8 +49,6 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
 import org.eclipse.tracecompass.internal.tmf.ui.Activator;
 import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderManager;
@@ -73,6 +72,8 @@ import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.ui.viewers.ILegendImageProvider2;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.dialogs.MultiTreePatternFilter;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.dialogs.TriStateFilteredCheckboxTree;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -323,7 +324,7 @@ public abstract class AbstractSelectTreeViewer2 extends AbstractTmfTreeViewer {
             } else {
                 fCheckboxTree.setFilterText(""); //$NON-NLS-1$
             }
-            refreshTree(refreshTree);
+            refreshTree(Objects.requireNonNull(refreshTree));
         }
     }
 
@@ -342,7 +343,7 @@ public abstract class AbstractSelectTreeViewer2 extends AbstractTmfTreeViewer {
     protected void setCheckedElements(Object[] checkedElements) {
         try (FlowScopeLog checkedElementsFlow = new FlowScopeLogBuilder(LOGGER, Level.FINE, getClass().getSimpleName() + "#setCheckedElements()").setCategory("setChecked").build()) { //$NON-NLS-1$ //$NON-NLS-2$
             internalSetCheckedElements(checkedElements);
-            refreshTree(checkedElementsFlow);
+            refreshTree(Objects.requireNonNull(checkedElementsFlow));
         }
     }
 

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/tree/AbstractTmfTreeViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/tree/AbstractTmfTreeViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 École Polytechnique de Montréal and others.
+ * Copyright (c) 2014, 2025 École Polytechnique de Montréal and others.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -57,7 +57,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.internal.tmf.ui.viewers.tree.TreeUtil;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.signal.TmfSignalHandler;
@@ -65,6 +64,7 @@ import org.eclipse.tracecompass.tmf.core.signal.TmfTraceClosedSignal;
 import org.eclipse.tracecompass.tmf.core.signal.TmfWindowRangeUpdatedSignal;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.ui.viewers.TmfTimeViewer;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 /**
  * Abstract class for viewers who will display data using a TreeViewer. It

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/xychart/linechart/TmfCommonXAxisChartViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/viewers/xychart/linechart/TmfCommonXAxisChartViewer.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2017, 2020 Ericsson, Draeger, Auriga and others
+ * Copyright (c) 2017, 2025 Ericsson, Draeger, Auriga and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -49,9 +49,6 @@ import org.eclipse.swtchart.LineStyle;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.model.DoubleArraySeriesModel;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.TmfFilterAppliedSignal;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.TraceCompassFilter;
 import org.eclipse.tracecompass.internal.provisional.tmf.ui.viewers.xychart.BaseXYPresentationProvider;
@@ -82,6 +79,9 @@ import org.eclipse.tracecompass.tmf.ui.signal.TmfTimeViewAlignmentSignal;
 import org.eclipse.tracecompass.tmf.ui.viewers.xychart.AxisRange;
 import org.eclipse.tracecompass.tmf.ui.viewers.xychart.TmfChartTimeStampFormat;
 import org.eclipse.tracecompass.tmf.ui.viewers.xychart.TmfXYChartViewer;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -299,7 +299,7 @@ public abstract class TmfCommonXAxisChartViewer extends TmfXYChartViewer {
                     return;
                 }
                 try (FlowScopeLog scope = new FlowScopeLogBuilder(LOGGER, Level.FINE, "CommonXLineChart:CreatingUpdateThread").setParentScope(parentScope).build()) { //$NON-NLS-1$
-                    newUpdateThread(trace, scope);
+                    newUpdateThread(trace, Objects.requireNonNull(scope));
                 }
             });
         }
@@ -338,7 +338,7 @@ public abstract class TmfCommonXAxisChartViewer extends TmfXYChartViewer {
                     dataProvider = initializeDataProvider(fTrace);
                 }
                 if (dataProvider == null) {
-                    TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, "Data provider for this viewer is not available"); //$NON-NLS-1$
+                    LogUtils.traceInstant(LOGGER, Level.WARNING, "Data provider for this viewer is not available"); //$NON-NLS-1$
                     return;
                 }
                 try {
@@ -362,7 +362,7 @@ public abstract class TmfCommonXAxisChartViewer extends TmfXYChartViewer {
         }
 
         public void cancel() {
-            TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, "CommonXLineChart:UpdateThreadCanceled"); //$NON-NLS-1$
+            LogUtils.traceInstant(LOGGER, Level.FINE, "CommonXLineChart:UpdateThreadCanceled"); //$NON-NLS-1$
             fMonitor.setCanceled(true);
         }
 
@@ -395,7 +395,7 @@ public abstract class TmfCommonXAxisChartViewer extends TmfXYChartViewer {
                     isComplete = true;
                 } else if (status == ITmfResponse.Status.FAILED || status == ITmfResponse.Status.CANCELLED) {
                     /* Error occurred, log and return */
-                    TraceCompassLogUtils.traceInstant(LOGGER, Level.WARNING, response.getStatusMessage());
+                    LogUtils.traceInstant(LOGGER, Level.WARNING, response.getStatusMessage());
                     isComplete = true;
                 } else {
                     /**
@@ -409,7 +409,7 @@ public abstract class TmfCommonXAxisChartViewer extends TmfXYChartViewer {
                          * InterruptedException is throw by Thread.Sleep and we
                          * should retry querying the data provider
                          **/
-                        TraceCompassLogUtils.traceInstant(LOGGER, Level.INFO, e.getMessage());
+                        LogUtils.traceInstant(LOGGER, Level.INFO, e.getMessage());
                         Thread.currentThread().interrupt();
                     }
                 }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/timegraph/AbstractStateSystemTimeGraphView.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/timegraph/AbstractStateSystemTimeGraphView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Ericsson
+ * Copyright (c) 2015, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -40,7 +40,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.provisional.tmf.ui.widgets.ViewFilterDialog;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
@@ -54,6 +53,8 @@ import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.ITimeEvent;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.ITimeGraphEntry;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry.Sampling;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
@@ -156,7 +157,7 @@ public abstract class AbstractStateSystemTimeGraphView extends AbstractTimeGraph
                     getTimeGraphViewer().setMarkers(markers);
                 });
             } else {
-                TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, "TimeGraphView:ZoomThreadCanceled"); //$NON-NLS-1$
+                LogUtils.traceInstant(LOGGER, Level.FINE, "TimeGraphView:ZoomThreadCanceled"); //$NON-NLS-1$
             }
         }
 
@@ -206,7 +207,7 @@ public abstract class AbstractStateSystemTimeGraphView extends AbstractTimeGraph
         private void doZoom(final ITmfStateSystem ss, final List<ILinkEvent> links, final List<IMarkerEvent> markers, long resolution, final @NonNull IProgressMonitor monitor, final long start, final long end, Sampling sampling,
                 Iterable<@NonNull TimeGraphEntry> entries, @NonNull Map<@NonNull Integer, @NonNull Predicate<@NonNull Multimap<@NonNull String, @NonNull Object>>> predicates, Map<TimeGraphEntry, List<ITimeEvent>> gaps) {
             queryFullStates(ss, start, end, resolution, monitor, (@NonNull List<List<ITmfStateInterval>> fullStates, @Nullable List<ITmfStateInterval> prevFullState) -> {
-                try (TraceCompassLogUtils.ScopeLog scope = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStates");) { //$NON-NLS-1$
+                try (ScopeLog scope = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStates");) { //$NON-NLS-1$
 
                     for (TimeGraphEntry entry : entries) {
                         if (!sampling.equals(entry.getSampling())) {
@@ -215,11 +216,11 @@ public abstract class AbstractStateSystemTimeGraphView extends AbstractTimeGraph
                     }
                 }
                 /* Refresh the arrows when zooming */
-                try (TraceCompassLogUtils.ScopeLog linksLogger1 = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingLinks")) { //$NON-NLS-1$
+                try (ScopeLog linksLogger1 = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingLinks")) { //$NON-NLS-1$
                     links.addAll(getLinkList(ss, fullStates, prevFullState, monitor));
                 }
                 /* Refresh the view-specific markers when zooming */
-                try (TraceCompassLogUtils.ScopeLog linksLogger2 = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingMarkers")) { //$NON-NLS-1$
+                try (ScopeLog linksLogger2 = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingMarkers")) { //$NON-NLS-1$
                     markers.addAll(getViewMarkerList(ss, fullStates, prevFullState, monitor));
                 }
                 refresh();
@@ -263,7 +264,7 @@ public abstract class AbstractStateSystemTimeGraphView extends AbstractTimeGraph
 
         private void doBgSearch(ITmfStateSystem ss, int resolution, @NonNull IProgressMonitor monitor, Map<TimeGraphEntry, List<ITimeEvent>> gaps,
                 @NonNull Map<@NonNull Integer, @NonNull Predicate<@NonNull Multimap<@NonNull String, @NonNull Object>>> predicates) {
-            try (TraceCompassLogUtils.ScopeLog poc = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINE, "TimegraphBgSearch")) { //$NON-NLS-1$
+            try (ScopeLog poc = new ScopeLog(LOGGER, Level.FINE, "TimegraphBgSearch")) { //$NON-NLS-1$
 
                 ViewFilterDialog timeEventFilterDialog = getViewFilterDialog();
                 boolean hasActiveSavedFilters = timeEventFilterDialog.hasActiveSavedFilters();

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/timegraph/AbstractTimeGraphView.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/timegraph/AbstractTimeGraphView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 Ericsson, École Polytechnique de Montréal and others
+ * Copyright (c) 2012, 2025 Ericsson, École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -100,9 +100,6 @@ import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filter.parser.FilterCu;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filter.parser.IFilterStrings;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filters.TmfFilterAppliedSignal;
@@ -179,6 +176,10 @@ import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry.Sa
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.TimeGraphControl;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.Utils;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.Utils.TimeFormat;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.IPartListener2;
@@ -707,7 +708,7 @@ public abstract class AbstractTimeGraphView extends TmfView implements ITmfTimeA
                             fEntries, entry -> !sampling.equals(entry.getSampling()))));
 
             List<ILinkEvent> computedLinks;
-            try (TraceCompassLogUtils.ScopeLog linkLog = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingLinks")) { //$NON-NLS-1$
+            try (ScopeLog linkLog = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingLinks")) { //$NON-NLS-1$
                 /* Refresh the arrows when zooming */
                 computedLinks = getLinkList(zoomStartTime, zoomEndTime, resolution, monitor);
                 ViewFilterDialog filterDialog = getViewFilterDialog();
@@ -721,7 +722,7 @@ public abstract class AbstractTimeGraphView extends TmfView implements ITmfTimeA
             }
             List<ILinkEvent> links = computedLinks;
             /* Refresh the view-specific markers when zooming */
-            try (TraceCompassLogUtils.ScopeLog markerLoglog = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingMarkers")) { //$NON-NLS-1$
+            try (ScopeLog markerLoglog = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingMarkers")) { //$NON-NLS-1$
                 List<IMarkerEvent> newMarkers = new ArrayList<>(getViewMarkerList(incorrectSample, zoomStartTime, zoomEndTime, resolution, monitor));
                 /* Refresh the trace-specific markers when zooming */
                 newMarkers.addAll(getTraceMarkerList(zoomStartTime, zoomEndTime, resolution, monitor));
@@ -747,7 +748,7 @@ public abstract class AbstractTimeGraphView extends TmfView implements ITmfTimeA
                 });
 
             }
-            try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStates")) { //$NON-NLS-1$
+            try (ScopeLog log = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStates")) { //$NON-NLS-1$
                 getTimeGraphViewer().setTimeEventFilterApplied(isFilterActive);
 
                 boolean hasSavedFilter = fTimeEventFilterDialog != null && fTimeEventFilterDialog.hasActiveSavedFilters();
@@ -764,7 +765,7 @@ public abstract class AbstractTimeGraphView extends TmfView implements ITmfTimeA
             }
             if (isFilterActive && Thread.currentThread() == fZoomThread) {
                 /* Do a full filter search as a second pass */
-                try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStatesFullSearch")) { //$NON-NLS-1$
+                try (ScopeLog log = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStatesFullSearch")) { //$NON-NLS-1$
                     for (TimeGraphEntry entry : fEntries) {
                         if (monitor.isCanceled()) {
                             return;
@@ -1880,7 +1881,7 @@ public abstract class AbstractTimeGraphView extends TmfView implements ITmfTimeA
         }
         fTrace = trace;
 
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, "TimeGraphView:LoadingTrace", "trace", trace.getName(), "viewId", getViewId()); //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
+        LogUtils.traceInstant(LOGGER, Level.FINE, "TimeGraphView:LoadingTrace", "trace", trace.getName(), "viewId", getViewId()); //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
 
         restoreViewContext();
         applyHideEmptyRowsFilterContext();
@@ -1936,7 +1937,7 @@ public abstract class AbstractTimeGraphView extends TmfView implements ITmfTimeA
                     Job buildJob = new Job(getTitle() + Messages.AbstractTimeGraphView_BuildJob) {
                         @Override
                         protected IStatus run(IProgressMonitor monitor) {
-                            new BuildRunnable(trace, viewTrace, parentLogger).run(monitor);
+                            new BuildRunnable(trace, viewTrace, Objects.requireNonNull(parentLogger)).run(monitor);
                             monitor.done();
                             return Status.OK_STATUS;
                         }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/dialogs/TriStateFilteredCheckboxTree.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/dialogs/TriStateFilteredCheckboxTree.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Ericsson
+ * Copyright (c) 2018, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -27,9 +27,9 @@ import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 import org.eclipse.ui.dialogs.PatternFilter;
 import org.eclipse.ui.progress.WorkbenchJob;
 

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/model/TimeGraphEntry.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/model/TimeGraphEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Ericsson, École Polytechnique de Montréal
+ * Copyright (c) 2012, 2025 Ericsson, École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -31,12 +31,12 @@ import java.util.regex.Pattern;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.swt.SWT;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
 import org.eclipse.tracecompass.internal.tmf.ui.widgets.timegraph.model.TimeGraphLineEntry;
 import org.eclipse.tracecompass.tmf.core.model.ICoreElementResolver;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.ITimeGraphEntryModel;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphEntryModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -403,7 +403,7 @@ public class TimeGraphEntry implements ITimeGraphEntry, ICoreElementResolver {
      * @since 4.2
      */
     public void updateZoomedEvent(ITimeEvent event) {
-        try (TraceCompassLogUtils.ScopeLog poc = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINE, "UpdateZoomedEvent")) { //$NON-NLS-1$
+        try (ScopeLog poc = new ScopeLog(LOGGER, Level.FINE, "UpdateZoomedEvent")) { //$NON-NLS-1$
 
             long start = getStartTime();
             long end = getEndTime();

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2007, 2024 Intel Corporation and others
+ * Copyright (c) 2007, 2025 Intel Corporation and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -90,8 +90,6 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.common.core.math.SaturatedArithmetic;
 import org.eclipse.tracecompass.internal.provisional.tmf.ui.model.IStylePresentationProvider;
 import org.eclipse.tracecompass.internal.provisional.tmf.ui.widgets.timegraph.ITimeGraphStylePresentationProvider;
@@ -141,6 +139,8 @@ import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.ITimeEvent;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.ITimeGraphEntry;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.MarkerEvent;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.collect.Iterables;
 
@@ -2254,7 +2254,7 @@ public class TimeGraphControl extends TimeGraphBaseControl
             }
         }
         gc.setClipping((Rectangle) null);
-        TraceCompassLogUtils.traceCounter(LOGGER, Level.FINER, fDrawMarkersCountLabel, size);
+        LogUtils.traceCounter(LOGGER, Level.FINER, fDrawMarkersCountLabel, size);
     }
 
     /**
@@ -2390,7 +2390,7 @@ public class TimeGraphControl extends TimeGraphBaseControl
             Item item = items[i];
             drawItem(item, bounds, timeProvider, i, nameSpace, gc);
         }
-        TraceCompassLogUtils.traceCounter(LOGGER, Level.FINER, fDrawItemsCountLabel, bottomIndex - topIndex);
+        LogUtils.traceCounter(LOGGER, Level.FINER, fDrawItemsCountLabel, bottomIndex - topIndex);
 
         if (gc == null) {
             return;
@@ -2610,7 +2610,7 @@ public class TimeGraphControl extends TimeGraphBaseControl
             drawLink(event, bounds, timeProvider, nameSpace, gc);
         }
         gc.setClipping((Rectangle) null);
-        TraceCompassLogUtils.traceCounter(LOGGER, Level.FINER, fDrawLinksCountLabel, size);
+        LogUtils.traceCounter(LOGGER, Level.FINER, fDrawLinksCountLabel, size);
     }
 
     /**


### PR DESCRIPTION
### What it does

Deprecate TraceCompassLogUtils and TraceCompassMonitorManager.

Replace all use of TraceCompassLogUtils with LogUtils from the
trace-event-logger library.

Update all targets to include the trace-event-logger jar from Maven.

Add trace-event-logger plug-in to RCP feature and releng-site.

### How to test

Unit tests.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
