### PR TITLE
releng: Add a legacy category.xml file for support of older targets

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -20,11 +20,11 @@ jobs:
     timeout-minutes: 90
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -42,7 +42,7 @@ jobs:
         -Djdk.release=17
         ${{ inputs.maven-goals }}
     - name: Upload logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: build logs
@@ -50,7 +50,7 @@ jobs:
           */*tests/screenshots/*.jpeg
           */*tests/target/work/data/.metadata/.log
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: test results

--- a/releng/org.eclipse.tracecompass.releng-site/legacy/category.xml
+++ b/releng/org.eclipse.tracecompass.releng-site/legacy/category.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <description>
+      Nightly builds of Trace Compass project.
+   </description>
+   <feature url="features/org.eclipse.tracecompass.btf_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.btf" version="0.0.0">
+      <category name="Trace Compass"/>
+   </feature>
+   <feature url="features/org.eclipse.tracecompass.lttng2.kernel_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.lttng2.kernel" version="0.0.0">
+      <category name="Trace Compass"/>
+   </feature>
+   <feature url="features/org.eclipse.tracecompass.lttng2.ust_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.lttng2.ust" version="0.0.0">
+      <category name="Trace Compass"/>
+   </feature>
+   <feature url="features/org.eclipse.tracecompass.gdbtrace_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.gdbtrace" version="0.0.0">
+      <category name="Trace Compass"/>
+   </feature>
+   <feature url="features/org.eclipse.tracecompass.tmf.pcap_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.pcap" version="0.0.0">
+      <category name="Trace Compass"/>
+   </feature>
+   <feature url="features/org.eclipse.tracecompass.jsontrace_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.jsontrace" version="0.0.0">
+      <category name="Trace Compass"/>
+   </feature>
+   <feature url="features/org.eclipse.tracecompass.tmf.cli_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.cli" version="0.0.0">
+      <category name="Trace Compass"/>
+   </feature>
+   <feature url="features/org.eclipse.tracecompass.testing_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.testing" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.tmf.remote_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.remote" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.btf.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.btf.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.lttng2.kernel.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.lttng2.kernel.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.lttng2.ust.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.lttng2.ust.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.gdbtrace.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.gdbtrace.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.tmf.remote.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.remote.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.tmf.pcap.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.pcap.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.testing.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.testing.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.jsontrace.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.jsontrace.source" version="0.0.0"/>
+   <feature url="features/org.eclipse.tracecompass.tmf.cli.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.cli.source" version="0.0.0"/>
+   <bundle id="org.eclipse.tracecompass.common.core"/>
+   <bundle id="org.eclipse.tracecompass.common.core.source"/>
+   <bundle id="org.apache.commons.lang3"/>
+   <bundle id="org.json"/>
+   <category-def name="Trace Compass" label="Trace Compass Main Features"/>
+</site>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Add a legacy category.xml file for support of older targets
For example, 2021-06/e4.20 needs a different category.xml file due different name of json plugin.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run build for 2021-06/e4.20 target in repo (use Java 17):
```sh
cp -f rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product rcp/org.eclipse.tracecompass.rcp.product/
cp -f releng/org.eclipse.tracecompass.slf4j.binding.simple.properties/legacy/MANIFEST.MF releng/org.eclipse.tracecompass.slf4j.binding.simple.properties/META-INF
cp -f rcp/org.eclipse.tracecompass.rcp/legacy/feature.xml rcp/org.eclipse.tracecompass.rcp/
cp -f releng/org.eclipse.tracecompass.releng-site/legacy/category.xml releng/org.eclipse.tracecompass.releng-site/
mvn clean install -Dtarget-platform=tracecompass-e4.20 -Djdk.version=11 -Djdk.release=11 -Dtycho-use-project-settings=false -DskipTests=true -Dslf4j-bundle=org.slf4j.binding.simple -Dslf4j-version=1.7.30 -Drequired-maven-version=3.8 -Dtycho-version=2.7.5 -Dtycho-extras-version=2.7.5
```
Includes a commit to upgrade github artifacts to v4 in CI workflow in order to have a successful build.

### Follow-ups
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>