### PR TITLE
tmf: Move bookmark toggle marker to the background

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/TimeGraphViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/TimeGraphViewer.java
@@ -2498,7 +2498,7 @@ public class TimeGraphViewer extends Viewer implements ITimeDataProvider, IMarke
                         if (dialog.open() == Window.OK) {
                             final String label = dialog.getValue();
                             final RGBA rgba = dialog.getColorValue();
-                            IMarkerEvent bookmark = new MarkerEvent(null, time, duration, IMarkerEvent.BOOKMARKS, rgba, label, true);
+                            IMarkerEvent bookmark = new MarkerEvent(null, time, duration, IMarkerEvent.BOOKMARKS, rgba, label, false);
                             fBookmarks.add(bookmark);
                             updateMarkerList();
                             updateMarkerActions();


### PR DESCRIPTION
### What it does

This PR moves the bookmark toggle marker to the background by reordering its rendering. This change improves visualization and representation by preventing the marker from overlapping other UI elements, ensuring a cleaner and more intuitive display.

### How to test

1. Open a trace in Trace Compass.
2. Add a bookmark to a specific event.
3. Observe the placement of the bookmark toggle marker.
4. Verify that the marker is correctly displayed in the background, without interfering with other visual elements.

### Follow-ups

- If any UI inconsistencies arise due to the reordering, additional refinements may be required.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template.
