### PR TITLE
releng: Fix legacy files for trace-event-logger and JustJ

### DIFF
--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="10.2.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="10.2.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
@@ -144,6 +144,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.ecf.filetransfer.httpclient5.feature"/>
       <feature id="org.eclipse.tracecompass.tmf.cli"/>
       <feature id="org.eclipse.equinox.executable"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped" installMode="root"/>
    </features>
 
    <configurations>
@@ -158,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="10.2.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="10.2.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
@@ -144,6 +144,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.ecf.filetransfer.httpclient5.feature"/>
       <feature id="org.eclipse.tracecompass.tmf.cli"/>
       <feature id="org.eclipse.equinox.executable"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped" installMode="root"/>
    </features>
 
    <configurations>
@@ -158,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="10.2.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="10.2.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
@@ -144,6 +144,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.ecf.filetransfer.httpclient45.feature"/>
       <feature id="org.eclipse.tracecompass.tmf.cli"/>
       <feature id="org.eclipse.equinox.executable"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped" installMode="root"/>
    </features>
 
    <configurations>
@@ -158,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.30/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.30/feature.xml
@@ -673,4 +673,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.tracecompass.trace-event-logger"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.32/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.32/feature.xml
@@ -433,4 +433,8 @@
          id="org.eclipse.osgi.services"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.tracecompass.trace-event-logger"
+         version="0.0.0"/>
+
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.33/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.33/feature.xml
@@ -437,4 +437,8 @@
          id="org.tukaani.xz"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.tracecompass.trace-event-logger"
+         version="0.0.0"/>
+
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy/feature.xml
@@ -463,4 +463,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.tracecompass.trace-event-logger"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/releng/org.eclipse.tracecompass.releng-site/legacy/category.xml
+++ b/releng/org.eclipse.tracecompass.releng-site/legacy/category.xml
@@ -37,6 +37,7 @@
    <feature url="features/org.eclipse.tracecompass.tmf.cli.source_0.0.0.qualifier.jar" id="org.eclipse.tracecompass.tmf.cli.source" version="0.0.0"/>
    <bundle id="org.eclipse.tracecompass.common.core"/>
    <bundle id="org.eclipse.tracecompass.common.core.source"/>
+   <bundle id="org.eclipse.tracecompass.trace-event-logger"/>
    <bundle id="org.apache.commons.lang3"/>
    <bundle id="org.json"/>
    <category-def name="Trace Compass" label="Trace Compass Main Features"/>


### PR DESCRIPTION
### What it does

Add trace-event-logger plug-in to legacy feature.xml files

Add JustJ feature to legacy tracing.product files

Add trace-event-logger bundle to legacy releng-site category.xml file

### How to test

Build with older targets.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
