### PR TITLE
releng: Build with tracecompass-e4.35 target by default

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -23,10 +23,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven
@@ -38,8 +38,8 @@ jobs:
       with:
        run: >- 
         mvn -B -Pctf-grammar -Pbuild-rcp ${{ inputs.maven-opts }}
-        -Djdk.version=17 
-        -Djdk.release=17
+        -Djdk.version=21
+        -Djdk.release=21
         ${{ inputs.maven-goals }}
     - name: Upload logs
       uses: actions/upload-artifact@v4

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testArgLine></testArgLine>
 
-    <jdk.version>17</jdk.version>
-    <jdk.release>17</jdk.release>
+    <jdk.version>21</jdk.version>
+    <jdk.release>21</jdk.release>
 
     <skip-tc-core-tests>false</skip-tc-core-tests>
     <skip-short-tc-ui-tests>false</skip-short-tc-ui-tests>
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
-    <target-platform>tracecompass-e4.34</target-platform>
+    <target-platform>tracecompass-e4.35</target-platform>
     <help-docs-eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.23</help-docs-eclipserun-repo>
 
     <rcptt-version>2.5.4</rcptt-version>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.34/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.34/feature.xml
@@ -442,26 +442,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.jxpath"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.commons-beanutils"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.collections"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.jdom"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.launchbar.core"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.tracecompass.trace-event-logger"
          version="0.0.0"/>
 


### PR DESCRIPTION
### What it does

Change JDK version to Java 21 in main pom.xml.

Change JDK version to Java 21 in ci-base.yml github workflow.

### How to test

Build with default target.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
