### PR TITLE
tmf: Support hideOutput extension point element for data providers

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.linuxtools.tmf.core.analysis.exsd
+++ b/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.linuxtools.tmf.core.analysis.exsd
@@ -314,7 +314,7 @@
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="analysis_module" type="string" use="required">
+         <attribute name="analysis_module" type="string">
             <annotation>
                <documentation>
                   The analysis ID of the output to be hidden.
@@ -326,7 +326,7 @@ Note: this is not consistent with camelCase as it is consistent with the module 
          <attribute name="output" type="string" use="required">
             <annotation>
                <documentation>
-                  An ID for the output to be hidden. For example, for a view, it would be the view ID.
+                  An ID for the output to be hidden. For example, for a view, it would be the view ID. For a data provider, it would be the data provider ID.
                </documentation>
             </annotation>
          </attribute>

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/component/DataProviderConstants.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/component/DataProviderConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Ericsson
+ * Copyright (c) 2019, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -25,7 +25,13 @@ public class DataProviderConstants {
      */
     public static final String ID_SEPARATOR = ":"; //$NON-NLS-1$
 
-    private DataProviderConstants() {
+    /**
+     * Separator between base analysis ID and config ID in secondary ID
+     * @since 9.6
+     */
+    public static final String CONFIG_SEPARATOR = "+"; //$NON-NLS-1$
+
+   private DataProviderConstants() {
         // Empty constructor
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Ericsson
+ * Copyright (c) 2024, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -13,6 +13,7 @@ package org.eclipse.tracecompass.tmf.core.config;
 
 import java.util.List;
 
+import org.eclipse.tracecompass.tmf.core.component.DataProviderConstants;
 import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderManager;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
@@ -33,17 +34,21 @@ public interface ITmfDataProviderConfigurator {
     /**
      * Prepares a data provider based on input parameters and returns its
      * corresponding data provider descriptor.
-     *
+     * <p>
      * The input configuration instance will have default parameters (e.g. name,
      * description or sourceTypeId) and custom parameters which are described by
      * the corresponding {@link ITmfConfigurationSourceType#getSchemaFile()} or
      * by the list of
      * {@link ITmfConfigurationSourceType#getConfigParamDescriptors()}.
-     *
+     * <p>
      * The data provider descriptor shall return the parent data provider ID
      * through {@link IDataProviderDescriptor#getParentId()}, as well as the
      * creation configuration through
      * {@link IDataProviderDescriptor#getConfiguration()}.
+     * <p>
+     * The created data provider's ID and any created analysis module's ID should be
+     * appended with {@link DataProviderConstants#CONFIG_SEPARATOR} followed
+     * by the configuration ID.
      *
      * @param trace
      *            The trace (or experiment) instance


### PR DESCRIPTION
### What it does

Define constant DataProviderConstants.CONFIG_SEPARATOR.

Describe use of CONFIG_SEPARATOR in ITmfDataProviderConfigurator's createDataProviderDescriptors() method.

In DataProviderManager.getAvailableProviders(), filter-out data provider descriptors that are hidden by org.eclipse.linuxtools.tmf.core.analysis extension point's hideOutput element, ignoring any configuration id suffix. Extract the analysisId from the provider id's secondary id.

Describe use of data provider id as possible value of org.eclipse.linuxtools.tmf.core.analysis extension point's hideOutput element's output attribute.

Change org.eclipse.linuxtools.tmf.core.analysis extension point's hideOutput element's analysis_module attribute to be optional. This will enable hiding of data provider configurators.

### How to test

Define data provider outputId's in the hideOutput extension point element.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
