### PR TITLE
tmf: Add hideDataProvider extension point element

### DIFF
--- a/releng/org.eclipse.tracecompass.integration.core.tests/build.properties
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/build.properties
@@ -14,4 +14,5 @@ bin.includes = META-INF/,\
                .,\
                plugin.properties,\
                about.html,\
-               build.properties
+               build.properties,\
+               plugin.xml

--- a/releng/org.eclipse.tracecompass.integration.core.tests/plugin.xml
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/plugin.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.tracecompass.tmf.core.dataprovider">
+      <dataProviderFactory
+            class="org.eclipse.tracecompass.integration.core.tests.dataproviders.HiddenDataProviderFactory"
+            id="org.eclipse.tracecompass.integration.core.tests.hidden.dataprovider">
+      </dataProviderFactory>
+      <hideDataProvider
+            idRegex="org.eclipse.tracecompass.integration.core.tests.hidden.dataprovider"
+            tracetype="*">
+      </hideDataProvider>
+   </extension>
+
+</plugin>

--- a/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/HiddenDataProviderFactory.java
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/HiddenDataProviderFactory.java
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.integration.core.tests.dataproviders;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+/**
+ * Hidden data provider factory
+ */
+public class HiddenDataProviderFactory implements IDataProviderFactory {
+
+    private static final String ID = "org.eclipse.tracecompass.integration.core.tests.hidden.dataprovider";
+    private static final String NAME = "Hidden";
+    private static final String DESCRIPTION = "Hidden data provider for integration tests";
+    private static final IDataProviderDescriptor DESCRIPTOR = new DataProviderDescriptor.Builder()
+            .setId(ID)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setProviderType(ProviderType.NONE)
+            .build();
+
+    /**
+     * Constructor
+     */
+    public HiddenDataProviderFactory() {
+        System.out.println("HiddenDataProviderFactory()");
+    }
+
+    @Override
+    public @Nullable ITmfTreeDataProvider<? extends ITmfTreeDataModel> createProvider(@NonNull ITmfTrace trace) {
+        return null;
+    }
+
+    @Override
+    public @NonNull Collection<IDataProviderDescriptor> getDescriptors(@NonNull ITmfTrace trace) {
+        return Arrays.asList(DESCRIPTOR);
+    }
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.tracecompass.tmf.core.dataprovider.exsd
+++ b/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.tracecompass.tmf.core.dataprovider.exsd
@@ -17,8 +17,9 @@
          </appinfo>
       </annotation>
       <complexType>
-         <sequence minOccurs="1" maxOccurs="unbounded">
+         <sequence minOccurs="0" maxOccurs="unbounded">
             <element ref="dataProviderFactory"/>
+            <element ref="hideDataProvider"/>
          </sequence>
          <attribute name="point" type="string" use="required">
             <annotation>
@@ -69,6 +70,30 @@
       </complexType>
    </element>
 
+   <element name="hideDataProvider">
+      <annotation>
+         <documentation>
+            Hide data providers with id matching the given regex for an optionally given trace type. Can be overridden by dataprovider.ini configuration file.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="idRegex" type="string" use="required">
+            <annotation>
+               <documentation>
+                  A regular expression for matching data provider IDs to be hidden.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="tracetype" type="string">
+            <annotation>
+               <documentation>
+                  The optional trace type ID of the data providers to be hidden. If empty, absent or *, the data provider will be hidden for all trace types.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
    <annotation>
       <appinfo>
          <meta.section type="since"/>
@@ -100,7 +125,7 @@
          <meta.section type="copyright"/>
       </appinfo>
       <documentation>
-         Copyright (c) 2017 Ericsson
+         Copyright (c) 2017, 2025 Ericsson
 
 All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at &amp;lt;a href=&amp;quot;https://www.eclipse.org/legal/epl-2.0/&amp;quot;&amp;gt;https://www.eclipse.org/legal/epl-2.0/&amp;lt;/a&amp;gt;
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/component/DataProviderConstants.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/component/DataProviderConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Ericsson
+ * Copyright (c) 2019, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -24,6 +24,12 @@ public class DataProviderConstants {
      * Separator between data provider ID and secondary ID
      */
     public static final String ID_SEPARATOR = ":"; //$NON-NLS-1$
+
+    /**
+     * Separator between base analysis ID and config ID in secondary ID
+     * @since 9.6
+     */
+    public static final String CONFIG_SEPARATOR = "+"; //$NON-NLS-1$
 
     private DataProviderConstants() {
         // Empty constructor

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfDataProviderConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Ericsson
+ * Copyright (c) 2024, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -13,6 +13,7 @@ package org.eclipse.tracecompass.tmf.core.config;
 
 import java.util.List;
 
+import org.eclipse.tracecompass.tmf.core.component.DataProviderConstants;
 import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderManager;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
@@ -33,17 +34,21 @@ public interface ITmfDataProviderConfigurator {
     /**
      * Prepares a data provider based on input parameters and returns its
      * corresponding data provider descriptor.
-     *
+     * <p>
      * The input configuration instance will have default parameters (e.g. name,
      * description or sourceTypeId) and custom parameters which are described by
      * the corresponding {@link ITmfConfigurationSourceType#getSchemaFile()} or
      * by the list of
      * {@link ITmfConfigurationSourceType#getConfigParamDescriptors()}.
-     *
+     * <p>
      * The data provider descriptor shall return the parent data provider ID
      * through {@link IDataProviderDescriptor#getParentId()}, as well as the
      * creation configuration through
      * {@link IDataProviderDescriptor#getConfiguration()}.
+     * <p>
+     * The created data provider's ID and any created analysis module's ID should be
+     * appended with {@link DataProviderConstants#CONFIG_SEPARATOR} followed
+     * by the configuration ID.
      *
      * @param trace
      *            The trace (or experiment) instance

--- a/tmf/org.eclipse.tracecompass.tmf.core/templates/dataprovider.ini
+++ b/tmf/org.eclipse.tracecompass.tmf.core/templates/dataprovider.ini
@@ -1,0 +1,15 @@
+# data provider configuration
+#
+# Add these lines to augment or override the hideDataProvider elements from
+# the org.eclipse.tracecompass.tmf.core.dataprovider extension point.
+#
+# To hide additional data providers:
+# hide:idRegex:tracetype
+#
+# To override the extension point and show hidden data providers:
+# show:idRegex:tracetype
+#
+# where:
+# idRegex is a regular expression to be matched against the data provider id
+# tracetype is the trace type id, omit or use * to apply for all trace types
+#


### PR DESCRIPTION
### What it does

Add hideDataProvider element with idRegex and tracetype attributes to
the org.eclipse.tracecompass.tmf.core.dataprovider extension point.

Add dataprovider.ini configuration file template to be stored in the
o.e.tc.tmf.core plug-in state location.

In DataProviderManager methods, filter-out data provider descriptors and
factories that are hidden by the hideDataProvider element, or the
dataprovider.ini configuration file, but that are not shown by the
configuration file. Note that factories cannot be hidden for a specific
trace type.

Define constant DataProviderConstants.CONFIG_SEPARATOR.

Describe use of CONFIG_SEPARATOR in ITmfDataProviderConfigurator's
createDataProviderDescriptors() method.

### How to test

Add hideDataProvider element in org.eclipse.tracecompass.tmf.core.dataprovider extension to any plugin.xml, with idRegex for a specific or all trace types. Check matching data providers are not returned by getAvailableProviders().

Add hide or show settings to <workspace>/.metadata/.plugins/org.eclipse.tracecompass.tmf.core/dataprovider.ini. Check hide matching data providers are not returned, and show matching data providers are returned despite being hidden by hideDataProvider element.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
