### PR TITLE
Use the current size in segment store 

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreTableDataProvider.java
@@ -327,9 +327,9 @@ public class SegmentStoreTableDataProvider extends AbstractTmfTableDataProvider 
     public TmfModelResponse<TmfTreeModel<TmfTreeDataModel>> fetchTree(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
         if (fSegmentProvider instanceof IAnalysisModule) {
             ((IAnalysisModule) fSegmentProvider).waitForCompletion();
-            ISegmentStore<ISegment> segmentStore = fSegmentProvider.getSegmentStore();
-            fSegmentStoreSize = segmentStore != null ? segmentStore.size() : 0;
         }
+        ISegmentStore<ISegment> segmentStore = fSegmentProvider.getSegmentStore();
+        fSegmentStoreSize = segmentStore != null ? segmentStore.size() : 0;
         List<TmfTreeDataModel> model = new ArrayList<>();
         for (ISegmentAspect aspect : ISegmentStoreProvider.getBaseSegmentAspects()) {
             synchronized (fAspectToIdMap) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Set the size of the segment store even if the provider doesn't implement `IAnalysisModule`. This change was made to support cases where `SegmentStoreTableDataProvider` is used with classes that do not implement `IAnalysisModule`.

Before this change:

Only analysis modules implementing `IAnalysisModule` will have their segment count recorded. Otherwise, the segment count will be treated as 0, resulting in no rows being displayed in the virtual table.

### How to test

Everything should work the same as before. Only the possibility to use other classes is added.

### Follow-ups

No follow-ups.

### Review checklist

As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
