### PR TITLE
releng: Add e4.36 and update eStaging targets for 2025-06 M1

### DIFF
--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -287,7 +287,7 @@
 
    <plugin
          id="org.mortbay.jasper.apache-jsp"
-         version="9.0.96"/>
+         version="0.0.0"/>
 
    <plugin
          id="com.google.guava.failureaccess"
@@ -407,7 +407,7 @@
 
    <plugin
          id="org.mortbay.jasper.apache-el"
-         version="9.0.96"/>
+         version="0.0.0"/>
 
    <plugin
          id="jakarta.el-api"

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.20.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.20.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.20" sequenceNumber="21">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.20" sequenceNumber="22">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.21.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.21.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.21" sequenceNumber="23">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.21" sequenceNumber="24">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.22.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.22.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.22" sequenceNumber="23">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.22" sequenceNumber="24">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.23.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.23.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.23" sequenceNumber="21">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.23" sequenceNumber="22">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.24.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.24.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.24" sequenceNumber="21">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.24" sequenceNumber="22">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.25.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.25.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.25" sequenceNumber="20">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.25" sequenceNumber="21">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.26.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.26.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.26" sequenceNumber="15">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.26" sequenceNumber="16">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.27.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.27.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.27" sequenceNumber="13">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.27" sequenceNumber="14">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.28.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.28.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.28" sequenceNumber="14">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.28" sequenceNumber="15">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.29.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.29.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.29" sequenceNumber="10">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.29" sequenceNumber="11">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.30.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.30.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.30" sequenceNumber="10">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.30" sequenceNumber="11">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.31.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.31.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.31" sequenceNumber="10">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.31" sequenceNumber="11">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/1/updates/release/17.0.14/"/>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.33.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.33.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.33" sequenceNumber="8">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.33" sequenceNumber="9">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.34.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.34.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.34" sequenceNumber="9">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.34" sequenceNumber="10">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.35.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.35.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.35" sequenceNumber="9">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.35" sequenceNumber="10">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -41,7 +41,7 @@
 <unit id="org.apache.commons.lang" version="0.0.0"/>
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
-<unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
+<unit id="org.mortbay.jasper.apache-jsp" version="9.0.96"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.36.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.36.target
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.32" sequenceNumber="10">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.36" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
+<repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
 <unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -11,7 +11,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/releases/11.6/cdt-11.6.0/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.0/cdt-12.0.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -24,7 +24,7 @@
 <unit id="bcprov" version="0.0.0"/>
 <unit id="ch.qos.logback.classic" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
-<unit id="com.google.guava" version="33.2.0.jre"/>
+<unit id="com.google.guava" version="33.4.6.jre"/>
 <unit id="jakarta.activation-api" version="1.2.2"/>
 <unit id="jakarta.annotation-api" version="1.3.5"/>
 <unit id="jakarta.el-api" version="5.0.1"/>
@@ -37,14 +37,15 @@
 <unit id="org.apache.commons.cli" version="0.0.0"/>
 <unit id="org.apache.commons.commons-compress" version="0.0.0"/>
 <unit id="org.apache.commons.commons-io" version="0.0.0"/>
+<unit id="org.apache.commons.jxpath" version="0.0.0"/>
 <unit id="org.apache.commons.lang" version="0.0.0"/>
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
-<unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
+<unit id="org.mortbay.jasper.apache-jsp" version="9.0.102"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.32.0/"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202504030806/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -72,7 +73,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.32/R-4.32-202406010610/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.36-I-builds/I20250403-1800/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -82,11 +83,18 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.34.0/R-3.34.0-20240527184929/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.38.0/S-3.38M1-20250408014054/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.38.0/"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202504011014/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/rt/ecf/3.15.5/site.p2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
@@ -104,7 +112,7 @@
     </dependencies>
 </location>
 </locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 <launcherArgs>
 <vmArgs>-Xms40m
 -Xmx512M</vmArgs>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="250">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="251">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -24,7 +24,7 @@
 <unit id="bcprov" version="0.0.0"/>
 <unit id="ch.qos.logback.classic" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
-<unit id="com.google.guava" version="33.4.0.jre"/>
+<unit id="com.google.guava" version="33.4.6.jre"/>
 <unit id="jakarta.activation-api" version="1.2.2"/>
 <unit id="jakarta.annotation-api" version="1.3.5"/>
 <unit id="jakarta.el-api" version="5.0.1"/>
@@ -41,11 +41,11 @@
 <unit id="org.apache.commons.lang" version="0.0.0"/>
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
-<unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
+<unit id="org.mortbay.jasper.apache-jsp" version="9.0.102"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0/"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202504030806/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -73,7 +73,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.35/R-4.35-202502280140/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.36-I-builds/I20250403-1800/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -83,11 +83,11 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.37.0/R-3.37.0-20250303081219/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.38.0/S-3.38M1-20250408014054/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.41.0/"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202504011014/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.eclipse.tracecompass</groupId>
             <artifactId>trace-event-logger</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### What it does

Add e4.36 and update eStaging targets for 2025-06 M1

Specify fixed version of org.mortbay.jasper.apache-jsp in the target files instead of the RCP feature.xml. Update e4.35 target for this, but not older targets since they have their own legacy version of the RCP feature.xml.

Upgrade trace-event-logger library version to 0.4.1 for all targets.

### How to test

Build

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
