### PR TITLE
releng: Fix SWTBot tests for 4.36 platform

### DIFF
--- a/releng/org.eclipse.tracecompass.integration.swtbot.tests/src/org/eclipse/tracecompass/integration/swtbot/tests/projectexplorer/ProjectExplorerTracesFolderTest.java
+++ b/releng/org.eclipse.tracecompass.integration.swtbot.tests/src/org/eclipse/tracecompass/integration/swtbot/tests/projectexplorer/ProjectExplorerTracesFolderTest.java
@@ -13,10 +13,12 @@ package org.eclipse.tracecompass.integration.swtbot.tests.projectexplorer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -91,6 +93,7 @@ public class ProjectExplorerTracesFolderTest {
 
     private static final String PROP_LAST_MODIFIED_PROPERTY = "last modified";
     private static final String TEXT_EDITOR_ID = "org.eclipse.ui.DefaultTextEditor";
+    private static final String GENERIC_EDITOR_ID = "org.eclipse.ui.genericeditor.GenericEditor";
 
     private static final String GENERIC_CTF_TRACE_TYPE = "Common Trace Format : Generic CTF Trace";
     private static final String LTTNG_KERNEL_TRACE_TYPE = "Common Trace Format : Linux Kernel Trace";
@@ -1524,7 +1527,7 @@ public class ProjectExplorerTracesFolderTest {
             // If there is no trace type, make sure it can be opened with the text editor
             fBot.waitUntil(ConditionHelpers.isEditorOpened(fBot, traceName));
             SWTBotEditor editor = fBot.editorByTitle(traceName);
-            assertEquals(TEXT_EDITOR_ID, editor.getReference().getId());
+            assertTrue(editor.getReference().getId(), Arrays.asList(TEXT_EDITOR_ID, GENERIC_EDITOR_ID).contains(editor.getReference().getId()));
         }
         checkTraceLinked(traceItem, (importOptionFlags & ImportTraceWizardPage.OPTION_CREATE_LINKS_IN_WORKSPACE) != 0);
     }

--- a/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/src/org/eclipse/tracecompass/tmf/ui/swtbot/tests/views/TimeGraphViewTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/src/org/eclipse/tracecompass/tmf/ui/swtbot/tests/views/TimeGraphViewTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2017, 2020 Ericsson
+ * Copyright (c) 2017, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -329,7 +329,7 @@ public class TimeGraphViewTest {
         resetTimeRange();
         Rectangle bounds = fBounds;
 
-        ImageHelper ref = ImageHelper.grabImage(bounds);
+        ImageHelper ref = ImageHelper.waitForNewImage(bounds, null);
 
         // Set the widths to 0.25
 
@@ -550,7 +550,7 @@ public class TimeGraphViewTest {
         resetTimeRange();
         Rectangle bounds = fBounds;
 
-        ImageHelper ref = ImageHelper.grabImage(bounds);
+        ImageHelper ref = ImageHelper.waitForNewImage(bounds, null);
 
         // Set the widths to 0.25
 
@@ -721,7 +721,7 @@ public class TimeGraphViewTest {
         SWTBotTimeGraph timegraph = fTimeGraph;
         Rectangle bounds = fBounds;
 
-        ImageHelper ref = ImageHelper.grabImage(bounds);
+        ImageHelper ref = ImageHelper.waitForNewImage(bounds, null);
 
         fireKeyAndWait(timegraph, bounds, false, '+', SWT.CTRL);
         fireKeyAndWait(timegraph, bounds, false, '-', SWT.CTRL);
@@ -1088,7 +1088,7 @@ public class TimeGraphViewTest {
 
         Rectangle bounds = fBounds;
 
-        ImageHelper ref = ImageHelper.grabImage(bounds);
+        ImageHelper ref = ImageHelper.waitForNewImage(bounds, null);
 
         timegraph.setFocus();
         // Move mouse to middle of the timegraph


### PR DESCRIPTION
### What it does

The default editor for unrecognized files is now the Generic Editor.

Wait for stable reference image in TimeGraphViewTest.

### How to test

Build SWTBot tests.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
