### PR TITLE
Fix CLabel and Scale not respecting global themes in TimeGraphLegend

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/css/org.eclipse.tracecompass.tmf.ui.dark.css
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/css/org.eclipse.tracecompass.tmf.ui.dark.css
@@ -102,6 +102,11 @@ IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-tracecompass-tmf-ui {
 		'org.eclipse.tracecompass.tmf.ui.color.eventtable.highlight=0,128,0'
 }
 
+.CLabelThemeTag, Scale {
+	background-color:'#org-eclipse-ui-workbench-DARK_BACKGROUND'; 
+	    color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
+}
+
 TimeGraphControl {
 	background-color:#353636;
 	color:#eeeeee

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/dialogs/TimeGraphLegend.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/dialogs/TimeGraphLegend.java
@@ -391,6 +391,7 @@ public class TimeGraphLegend extends TitleAreaDialog {
             });
 
             fBar.setLayoutData(GridDataFactory.swtDefaults().hint(30, 20).create());
+
             CLabel label = new CLabel(this, SWT.NONE) {
                 @Override
                 protected String shortenText(GC gc, String t, int w) {
@@ -402,6 +403,9 @@ public class TimeGraphLegend extends TitleAreaDialog {
             label.setData(LEGEND_ENTRY_KEY, name);
             label.setText(name);
             label.setLayoutData(GridDataFactory.fillDefaults().hint(160, SWT.DEFAULT).align(SWT.FILL, SWT.CENTER).grab(true, false).create());
+            //Without this the class created by overriding CLabel with @Override won't inherit theming
+            label.setData("org.eclipse.e4.ui.css.CssClassName", "CLabelThemeTag"); //$NON-NLS-1$ //$NON-NLS-2$
+
             fScale = new Scale(this, SWT.NONE);
             if (si.getStyleMap().get(StyleProperties.WIDTH) instanceof Integer) {
                 fScale.setMinimum(1);


### PR DESCRIPTION
### What it does

When a new CLabel class is created with Override it stops inheriting Eclipse global theming. Scale also fails to inherit global theming. 

### How to test

-Open any view containing TimeGraphLegend.java with dark theming enabled 

### Follow-ups

NA

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Theo Dann-Muirhead - theo.dann-muirhead.xd@renesas.com
