### PR TITLE
tmf: Add API to remove data provider instance from dp manager

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
@@ -362,6 +362,28 @@ public class DataProviderManager {
     }
 
     /**
+     * Remove a data provider from the instances by Id. This method will also dispose
+     * the data provider.
+     *
+     * @param trace
+     *            The trace for which to remove the data provider
+     * @param id
+     *            The id of the data provider to remove
+     * @since 9.6
+     */
+    public void removeDataProvider(ITmfTrace trace, String id) {
+        Iterator<ITmfTreeDataProvider<? extends ITmfTreeDataModel>> iter = fInstances.get(trace).iterator();
+        while (iter.hasNext()) {
+            ITmfTreeDataProvider<? extends ITmfTreeDataModel> dp = iter.next();
+            if (dp.getId().equals(id)) {
+                dp.dispose();
+                iter.remove();
+            }
+            break;
+        }
+    }
+
+    /**
      * Get all registered data provider factories.
      *
      * @return a collection of existing data provider factories


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

fixes #253.

[Added] API to remove data provider instance from dp manager

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Unit Test was added. 

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
