### PR TITLE
tmf: Exit loop only when match was found when removing data provider

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
@@ -378,8 +378,8 @@ public class DataProviderManager {
             if (dp.getId().equals(id)) {
                 dp.dispose();
                 iter.remove();
+                break;
             }
-            break;
         }
     }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
Exit loop only when match was found when removing data provider.  The code in PR (#254) exited the loop after the first iteration.

fixes #253.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Successful CI.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
