### PR TITLE
tmf.core: Introduce arbitrary/abstract data provider

### DIFF
--- a/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/DataProviderManagerTest.java
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/DataProviderManagerTest.java
@@ -415,17 +415,45 @@ public class DataProviderManagerTest {
     public void testGetter() {
         ITmfTrace trace = fKernelTrace;
         assertNotNull(trace);
-        ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp = DataProviderManager.getInstance().getExistingDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
-        assertNull(dp);
-        dp = DataProviderManager.getInstance().getOrCreateDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
-        assertNotNull(dp);
-        ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp2 = DataProviderManager.getInstance().getExistingDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
-        assertNotNull(dp2);
-        assertTrue(dp == dp2);
-        ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp3 = DataProviderManager.getInstance().getOrCreateDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
-        assertNotNull(dp3);
-        assertTrue(dp == dp3);
-        assertTrue(dp == dp2);
+        try {
+            ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp = DataProviderManager.getInstance().getExistingDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNull(dp);
+            dp = DataProviderManager.getInstance().getOrCreateDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNotNull(dp);
+            ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp2 = DataProviderManager.getInstance().getExistingDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNotNull(dp2);
+            assertTrue(dp == dp2);
+            ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp3 = DataProviderManager.getInstance().getOrCreateDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNotNull(dp3);
+            assertTrue(dp == dp3);
+            assertTrue(dp == dp2);
+        } finally {
+            DataProviderManager.getInstance().removeDataProvider(trace, CPU_USAGE_DP_ID);
+        }
+    }
+
+    /**
+     * Test different get methods
+     */
+    @Test
+    public void testGetterNew() {
+        ITmfTrace trace = fKernelTrace;
+        assertNotNull(trace);
+        try {
+            ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp = DataProviderManager.getInstance().fetchExistingDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNull(dp);
+            dp = DataProviderManager.getInstance().fetchOrCreateDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNotNull(dp);
+            ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp2 = DataProviderManager.getInstance().fetchExistingDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNotNull(dp2);
+            assertTrue(dp == dp2);
+            ITmfTreeXYDataProvider<@NonNull ITmfTreeDataModel> dp3 = DataProviderManager.getInstance().fetchOrCreateDataProvider(trace, CPU_USAGE_DP_ID, ITmfTreeXYDataProvider.class);
+            assertNotNull(dp3);
+            assertTrue(dp == dp3);
+            assertTrue(dp == dp2);
+        } finally {
+            DataProviderManager.getInstance().removeDataProvider(trace, CPU_USAGE_DP_ID);
+        }
     }
 
     /**

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderFactory.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Ericsson
+ * Copyright (c) 2017, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.tmf.core.config.ITmfDataProviderConfigurator;
+import org.eclipse.tracecompass.tmf.core.model.ITmfDataProvider;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataProvider;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
@@ -40,11 +41,28 @@ public interface IDataProviderFactory extends IAdaptable {
      *            A trace
      * @return {@link ITmfTreeDataProvider} that can be use for the given trace
      * @since 4.0
+     * @deprecated As of version 9.7, use {@link #createDataProvider(ITmfTrace)} instead
      */
-    @Nullable ITmfTreeDataProvider<? extends ITmfTreeDataModel> createProvider(@NonNull ITmfTrace trace);
+    @Deprecated(since = "9.7", forRemoval = true)
+    @Nullable default ITmfTreeDataProvider<? extends ITmfTreeDataModel> createProvider(@NonNull ITmfTrace trace) {
+        return null;
+    }
 
     /**
-     * Create a {@link ITmfTreeDataProvider} for the given trace. If this factory
+     * Create a {@link ITmfDataProvider} for the given trace. If this factory
+     * does not know how to handle the given trace it will return null
+     *
+     * @param trace
+     *            A trace
+     * @return {@link ITmfDataProvider} that can be use for the given trace
+     * @since 9.7
+     */
+    @Nullable default ITmfDataProvider createDataProvider(@NonNull ITmfTrace trace) {
+        return createProvider(trace);
+    }
+
+    /**
+D     * Create a {@link ITmfTreeDataProvider} for the given trace. If this factory
      * does not know how to handle the given trace it will return null. The
      * resulting provider should have an ID that is an aggregate of the provider's
      * own ID and the secondaryId as such: <provider ID>:<secondaryId>
@@ -59,9 +77,32 @@ public interface IDataProviderFactory extends IAdaptable {
      *         ID <provider ID>:<secondaryId>, or <code>null</code> if no provider
      *         is available for this trace and ID
      * @since 4.0
+     * @deprecated As of version 9.7, use {@link #createDataProvider(ITmfTrace)} instead
      */
+    @Deprecated(since = "9.7", forRemoval = true)
     default @Nullable ITmfTreeDataProvider<? extends ITmfTreeDataModel> createProvider(@NonNull ITmfTrace trace, @NonNull String secondaryId) {
         return createProvider(trace);
+    }
+
+    /**
+     * Create a {@link ITmfDataProvider} for the given trace. If this factory
+     * does not know how to handle the given trace it will return null. The
+     * resulting provider should have an ID that is an aggregate of the provider's
+     * own ID and the secondaryId as such: <provider ID>:<secondaryId>
+     *
+     * @param trace
+     *            A trace
+     * @param secondaryId
+     *            Additional ID to identify different instances of the same
+     *            provider, for instance, when the same provider can be used for
+     *            different analysis modules
+     * @return {@link ITmfDataProvider} that can be use for the given trace with
+     *         ID <provider ID>:<secondaryId>, or <code>null</code> if no provider
+     *         is available for this trace and ID
+     * @since 9.7
+     */
+    default @Nullable ITmfDataProvider createDataProvider(@NonNull ITmfTrace trace, @NonNull String secondaryId) {
+        return createProvider(trace, secondaryId);
     }
 
     /**

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/ITmfDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/ITmfDataProvider.java
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.tmf.core.model;
+
+/**
+ * Base interface that each data provider has to implement.
+ *
+ * Each data provider needs to provide at least one fetch method, that is
+ * typical for this data provider type and which returns @link TmfModelResponse}
+ * with a defined serializable model.
+ *
+ * <p>
+ * Example interface:
+ * <pre>{@code
+ * public ICustomDataProvider implements ITmfDataProvider {
+ *   TmfModelResponse<CustomModel> fetchCustomData(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor);
+ * }
+ * }</pre>
+ * </p>
+ * Example implementation:
+ * <pre>{@code
+ *  public class CustomModel {
+ *    private final String fValue = value;
+ *    public CustomModel(String value) {
+ *      fValue = value;
+ *    }
+ *    String getValue() {
+ *      return fValue;
+ *    }
+ *  }
+ *
+ *  public class CustomDataProvider implements ICustomDataProvider {
+ *    // ITmfDataProvider
+ *    public String getId() {
+ *      return "customId";
+ *    }
+ *    public void dispose() {}
+ *
+ *    // ICustomDataProvider
+ *    TmfModelResponse<CustomModel> fetchCustomData(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
+ *        CustomModel model = new CustomModel("my data");
+ *        return new TmfModelResponse<>(model, ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+ *    }
+ *  }
+ * }</pre>
+ *
+ *
+ * @since 9.7
+ * @author Matthew Khouzam
+ * @auther Bernd Hufmann
+ *
+ */
+public interface ITmfDataProvider {
+    /**
+     * This method return the extension point ID of this provider
+     *
+     * @return The ID
+     */
+    String getId();
+
+    /**
+     * Dispose of the provider to avoid resource leakage.
+     */
+    public default void dispose() {
+        // Do nothing for now
+    }
+}

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/ITmfTreeDataProvider.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.model.ITmfDataProvider;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 
 /**
@@ -26,7 +27,7 @@ import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
  *            Tree model extending {@link ITmfTreeDataModel}
  * @since 4.0
  */
-public interface ITmfTreeDataProvider<T extends ITmfTreeDataModel> {
+public interface ITmfTreeDataProvider<T extends ITmfTreeDataModel> extends ITmfDataProvider{
 
     /**
      * This methods computes a tree model. Then, it returns a
@@ -42,19 +43,6 @@ public interface ITmfTreeDataProvider<T extends ITmfTreeDataModel> {
      * @since 5.0
      */
     TmfModelResponse<TmfTreeModel<T>> fetchTree(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor);
-
-    /**
-     * This method return the extension point ID of this provider
-     *
-     * @return The ID
-     */
-    String getId();
-
-    /**
-     * Dispose of the provider to avoid resource leakage.
-     *
-     * @since 4.0
-     */
-    public default void dispose() {
-    }
 }
+
+


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->

This is the first step in having arbitrary data providers. With this PR arbitrary data providers that are not instances of `ITmfTreeDataProvider` can be created by `IDataProviderFactory` implementations and through the `DataProviderManager`. This helps with project such as report and other timeless or non-tree based views.

This PR adds new methods to `IDataProviderFactory` to create provider returning only this new `ITmfDataProvider` interface. It deprecate existing `createProvider` methods in `IDataProviderFactory` in favour of the new interfaces. The default implementations make sure that existing implementations will still work until they are migrated to the new methods.

It also add new methods to fetch and create data providers implementing `ITmfDataProvider` interface to the `DataProviderManager`. Deprecate existing get and create methods for data providers in `DataProviderManager` in favour of the new APIs.

- [Added] base data provider `ITmfDataProvider` interface
- [Added] `IDataProviderFactory.createDataProvider(ITmfTrace)` and `IDataProviderFactory.createDataProvider(ITmfTrace, String)`
- [Added] `DataProviderManager.fetchExistingDataProvider(ITmfTrace, String, Class)` and `DataProviderManager.fetchOrCreateDataProvider(ITmfTrace, String, Class)`
- [Deprecated] `IDataProviderFactory.createProvider(ITmfTrace)` and `IDataProviderFactory.createProvider(ITmfTrace, String)`
- [Deprecated] `DataProviderManager.getExistingDataProvider(ITmfTrace, String, Class)` and `DataProviderManager.getOrCreateDataProvider(ITmfTrace, String, Class)`

### How to test

All CI needs to run successful which will verify that existing data provider factory implementation work without changing to the new APIs, because every data provider is based on this.

For reports, a patch needs to be based on it and designed for reports at the moment, but other views can use it. 

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

- In future releases, e.g. for 11.3.0, migrate all existing data provider factories to the new APIs
- Remove deprecated APIs for 12.0.0 (Eclipse 2026.06) release

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
Base other views on this patch #242 , for example.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Matthew Khouzam <matthew.khouzam@ericsson.com>
Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>