### PR TITLE
Remove deprecated APIs for 10.0 release

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/META-INF/MANIFEST.MF
+++ b/ctf/org.eclipse.tracecompass.ctf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 4.7.0.qualifier
+Bundle-Version: 5.0.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.ctf.core;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/IntegerDeclaration.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/IntegerDeclaration.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.math.BigInteger;
 import java.nio.ByteOrder;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -138,100 +137,6 @@ public final class IntegerDeclaration extends Declaration implements ISimpleData
     // ------------------------------------------------------------------------
     // Constructors
     // ------------------------------------------------------------------------
-
-    /**
-     * Factory, some common types cached
-     *
-     * @deprecated use
-     *             {@link #createDeclaration(int, boolean, int, ByteOrder, Encoding, String, long, String)}
-     *             instead
-     *
-     * @param len
-     *            The length in bits
-     * @param signed
-     *            Is the integer signed? false == unsigned
-     * @param base
-     *            The base (10-16 are most common)
-     * @param byteOrder
-     *            Big-endian little-endian or other
-     * @param encoding
-     *            ascii, utf8 or none.
-     * @param clock
-     *            The clock path, can be null
-     * @param alignment
-     *            The minimum alignment. Should be >= 1
-     * @return the integer declaration
-     * @deprecated use
-     *             {@link #createDeclaration(int, boolean, int, ByteOrder, Encoding, String, long, String)}
-     */
-    @Deprecated
-    public static IntegerDeclaration createDeclaration(int len, boolean signed, int base,
-            @Nullable ByteOrder byteOrder, Encoding encoding, String clock, long alignment) {
-        if (encoding.equals(Encoding.NONE) && (clock.equals("")) && base == BASE_10 && byteOrder != null) { //$NON-NLS-1$
-            if (alignment == BYTE_ALIGN) {
-                switch (len) {
-                case SIZE_8:
-                    return signed ? INT_8_DECL : UINT_8_DECL;
-                case SIZE_16:
-                    if (!signed) {
-                        if (isBigEndian(byteOrder)) {
-                            return UINT_16B_DECL;
-                        }
-                        return UINT_16L_DECL;
-                    }
-                    break;
-                case SIZE_32:
-                    if (signed) {
-                        if (isBigEndian(byteOrder)) {
-                            return INT_32B_DECL;
-                        }
-                        return INT_32L_DECL;
-                    }
-                    if (isBigEndian(byteOrder)) {
-                        return UINT_32B_DECL;
-                    }
-                    return UINT_32L_DECL;
-                case SIZE_64:
-                    if (signed) {
-                        if (isBigEndian(byteOrder)) {
-                            return INT_64B_DECL;
-                        }
-                        return INT_64L_DECL;
-                    }
-                    if (isBigEndian(byteOrder)) {
-                        return UINT_64B_DECL;
-                    }
-                    return UINT_64L_DECL;
-
-                default:
-
-                }
-
-            } else if (alignment == 1) {
-                switch (len) {
-                case SIZE_5:
-                    if (!signed) {
-                        if (isBigEndian(byteOrder)) {
-                            return UINT_5B_DECL;
-                        }
-                        return UINT_5L_DECL;
-                    }
-                    break;
-                case SIZE_27:
-                    if (!signed) {
-                        if (isBigEndian(byteOrder)) {
-                            return UINT_27B_DECL;
-                        }
-                        return UINT_27L_DECL;
-                    }
-                    break;
-                default:
-                    break;
-                }
-            }
-        }
-        return new IntegerDeclaration(len, signed, base, byteOrder, encoding, clock, alignment);
-    }
 
     /**
      * Alternate create method for CTF2 integers which have roles

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core/META-INF/MANIFEST.MF
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 4.6.0.qualifier
+Bundle-Version: 5.0.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.ctf.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tmf.ctf.core.Activator

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/trace/CtfTmfTrace.java
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/trace/CtfTmfTrace.java
@@ -110,15 +110,6 @@ public class CtfTmfTrace extends TmfTrace
     // -------------------------------------------
 
     /**
-     * Clock offset property
-     *
-     * @since 1.2
-     * @deprecated use {@link CTFTrace#CLOCK_OFFSET} instead
-     */
-    @Deprecated
-    public static final String CLOCK_OFFSET = "clock_offset"; //$NON-NLS-1$
-
-    /**
      * Default cache size for CTF traces
      */
     protected static final int DEFAULT_CACHE_SIZE = 50000;

--- a/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 9.7.0.qualifier
+Bundle-Version: 10.0.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tmf.core.Activator

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/component/DataProviderConstants.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/component/DataProviderConstants.java
@@ -27,7 +27,7 @@ public class DataProviderConstants {
 
     /**
      * Separator between base analysis ID and config ID in secondary ID
-     * @since 9.7
+     * @since 10.0
      */
     public static final String CONFIG_SEPARATOR = "+"; //$NON-NLS-1$
 

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/DataProviderManager.java
@@ -221,9 +221,9 @@ public class DataProviderManager {
      *         input parameter.
      * @since 8.0
      *
-     * @deprecated As of version 9.7, use {@link #fetchOrCreateDataProvider(ITmfTrace, String, Class)} instead
+     * @deprecated As of version 10.0, use {@link #fetchOrCreateDataProvider(ITmfTrace, String, Class)} instead
      */
-    @Deprecated(since = "9.7", forRemoval = true)
+    @Deprecated(since = "10.0", forRemoval = true)
     public synchronized @Nullable <T extends ITmfTreeDataProvider<? extends ITmfTreeDataModel>> T getOrCreateDataProvider(@NonNull ITmfTrace trace, String id, Class<T> dataProviderClass) {
         return fetchOrCreateDataProvider(trace, id, dataProviderClass);
     }
@@ -245,7 +245,7 @@ public class DataProviderManager {
      *            Returned data provider must extend this class
      * @return the data provider or null if no data provider is found for the
      *         input parameter.
-     * @since 9.7
+     * @since 10.0
      */
     public synchronized @Nullable <T extends ITmfDataProvider> T fetchOrCreateDataProvider(@NonNull ITmfTrace trace, String id, Class<T> dataProviderClass) {
         ITmfDataProvider dataProvider = fetchExistingDataProvider(trace, id, dataProviderClass);
@@ -292,9 +292,9 @@ public class DataProviderManager {
      *            Returned data provider must extend this class
      * @return the data provider or null
      * @since 8.0
-     * @deprecated As of version 9.7, use {@link #fetchExistingDataProvider(ITmfTrace, String, Class)} instead
+     * @deprecated As of version 10.0, use {@link #fetchExistingDataProvider(ITmfTrace, String, Class)} instead
      */
-    @Deprecated(since = "9.7", forRemoval = true)
+    @Deprecated(since = "10.0", forRemoval = true)
     public synchronized @Nullable <T extends ITmfTreeDataProvider<? extends ITmfTreeDataModel>> T getExistingDataProvider(@NonNull ITmfTrace trace, String id, Class<T> dataProviderClass) {
         return fetchExistingDataProvider(trace, id, dataProviderClass);
     }
@@ -318,7 +318,7 @@ public class DataProviderManager {
      * @param dataProviderClass
      *            Returned data provider must extend this class
      * @return the data provider or null
-     * @since 9.7
+     * @since 10.0
      */
     public synchronized @Nullable <T extends ITmfDataProvider> T fetchExistingDataProvider(@NonNull ITmfTrace trace, String id, Class<T> dataProviderClass) {
         for (ITmfDataProvider dataProvider : fInstances.get(trace)) {
@@ -372,7 +372,7 @@ public class DataProviderManager {
      * @param configuration
      *            a configuration used to create data providers (and descriptors)
      * @return list of the available providers for this trace / experiment
-     * @since 9.7
+     * @since 10.0
      */
     public List<IDataProviderDescriptor> getAvailableProviders(@Nullable ITmfTrace trace, @Nullable ITmfConfiguration configuration) {
         if (trace == null || configuration == null) {
@@ -450,7 +450,7 @@ public class DataProviderManager {
      *            The trace for which to remove the data provider
      * @param id
      *            The id of the data provider to remove
-     * @since 9.7
+     * @since 10.0
      */
     public void removeDataProvider(ITmfTrace trace, String id) {
         Iterator<ITmfDataProvider> iter = fInstances.get(trace).iterator();

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderFactory.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/dataprovider/IDataProviderFactory.java
@@ -41,9 +41,9 @@ public interface IDataProviderFactory extends IAdaptable {
      *            A trace
      * @return {@link ITmfTreeDataProvider} that can be use for the given trace
      * @since 4.0
-     * @deprecated As of version 9.7, use {@link #createDataProvider(ITmfTrace)} instead
+     * @deprecated As of version 10.0, use {@link #createDataProvider(ITmfTrace)} instead
      */
-    @Deprecated(since = "9.7", forRemoval = true)
+    @Deprecated(since = "10.0", forRemoval = true)
     @Nullable default ITmfTreeDataProvider<? extends ITmfTreeDataModel> createProvider(@NonNull ITmfTrace trace) {
         return null;
     }
@@ -55,7 +55,7 @@ public interface IDataProviderFactory extends IAdaptable {
      * @param trace
      *            A trace
      * @return {@link ITmfDataProvider} that can be use for the given trace
-     * @since 9.7
+     * @since 10.0
      */
     @Nullable default ITmfDataProvider createDataProvider(@NonNull ITmfTrace trace) {
         return createProvider(trace);
@@ -77,9 +77,9 @@ D     * Create a {@link ITmfTreeDataProvider} for the given trace. If this facto
      *         ID <provider ID>:<secondaryId>, or <code>null</code> if no provider
      *         is available for this trace and ID
      * @since 4.0
-     * @deprecated As of version 9.7, use {@link #createDataProvider(ITmfTrace)} instead
+     * @deprecated As of version 10.0, use {@link #createDataProvider(ITmfTrace)} instead
      */
-    @Deprecated(since = "9.7", forRemoval = true)
+    @Deprecated(since = "10.0", forRemoval = true)
     default @Nullable ITmfTreeDataProvider<? extends ITmfTreeDataModel> createProvider(@NonNull ITmfTrace trace, @NonNull String secondaryId) {
         return createProvider(trace);
     }
@@ -99,7 +99,7 @@ D     * Create a {@link ITmfTreeDataProvider} for the given trace. If this facto
      * @return {@link ITmfDataProvider} that can be use for the given trace with
      *         ID <provider ID>:<secondaryId>, or <code>null</code> if no provider
      *         is available for this trace and ID
-     * @since 9.7
+     * @since 10.0
      */
     default @Nullable ITmfDataProvider createDataProvider(@NonNull ITmfTrace trace, @NonNull String secondaryId) {
         return createProvider(trace, secondaryId);

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/ITmfDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/ITmfDataProvider.java
@@ -54,7 +54,7 @@ package org.eclipse.tracecompass.tmf.core.model;
  * }</pre>
  *
  *
- * @since 9.7
+ * @since 10.0
  * @author Matthew Khouzam
  * @auther Bernd Hufmann
  *


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

- Remove deprecated APIs as preparation for 10.0 Trace Compass release. 
   - org.eclipse.tracecompass.ctf.core (major version: 5.0.0)
   - org.eclipse.tracecompass.tmf.ctf.core (major version: 5.0.0)
- Increment major version org.eclipse.tracecompass.tmf.core to 10.0
  - Due to API breakage is reported by API tool due to new ITmfDataProvider parent interface. 
  - Update related `@since` and `@Deprecated` annotations and related comments to 10.0. 

All known extensions of ITmfTreeDataProvider still work despite this reported API breakage.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Successful CI. Successful build and execution of incubator features.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups
N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
