### PR TITLE
tmf.config: deprecate create/update methods with parameter map

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core.tests/src/org/eclipse/tracecompass/tmf/analysis/xml/core/tests/config/XmlConfigurationSourceTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core.tests/src/org/eclipse/tracecompass/tmf/analysis/xml/core/tests/config/XmlConfigurationSourceTest.java
@@ -121,7 +121,7 @@ public class XmlConfigurationSourceTest {
     @Test
     public void testConstructor() throws TmfConfigurationException {
         // Make sure that an xml file is loaded
-        ITmfConfiguration config =  sfXmlConfigSource.create(VALID_PARAM);
+        ITmfConfiguration config =  sfXmlConfigSource.create(createConfig("valid params", VALID_PARAM));
 
         XmlConfigurationSource instance = new XmlConfigurationSource();
         List<ITmfConfiguration> configurations = instance.getConfigurations();
@@ -155,7 +155,7 @@ public class XmlConfigurationSourceTest {
         // Test missing path
         Map<String, Object> param = Collections.emptyMap();
         try {
-            sfXmlConfigSource.create(param);
+            sfXmlConfigSource.create(createConfig("empty params", param));
         } catch (TmfConfigurationException e) {
             // success
             assertEquals(EXPECTED_MESSAGE_NO_PATH, e.getMessage());
@@ -164,7 +164,7 @@ public class XmlConfigurationSourceTest {
         // Test XML file doesn't exist
         param = ImmutableMap.of(EXPECTED_KEY_NAME, XmlUtils.getXmlFilesPath().append(UNKNOWN_TYPE).toOSString());
         try {
-            sfXmlConfigSource.create(param);
+            sfXmlConfigSource.create(createConfig("xml not exists params", param));
         } catch (TmfConfigurationException e) {
             // success
             assertEquals(EXPECTED_MESSAGE_FILE_NOT_FOUND, e.getMessage());
@@ -172,13 +172,13 @@ public class XmlConfigurationSourceTest {
 
         // Test invalid XML file
         try {
-            sfXmlConfigSource.create(INVALID_PARAM);
+            sfXmlConfigSource.create(createConfig("invalid params", INVALID_PARAM));
         } catch (TmfConfigurationException e) {
             // success
         }
 
         try {
-            ITmfConfiguration config = sfXmlConfigSource.create(VALID_PARAM);
+            ITmfConfiguration config = sfXmlConfigSource.create(createConfig("valid params", VALID_PARAM));
             validateConfig(PATH_TO_VALID_FILE, config);
         } catch (TmfConfigurationException e) {
             fail();
@@ -248,7 +248,7 @@ public class XmlConfigurationSourceTest {
         // Test missing path
         Map<String, Object> param = Collections.emptyMap();
         try {
-            sfXmlConfigSource.update(config.getId(), param);
+            sfXmlConfigSource.update(config.getId(), createConfig("missing path params", param));
         } catch (TmfConfigurationException e) {
             // success
             assertEquals(EXPECTED_MESSAGE_NO_PATH, e.getMessage());
@@ -256,7 +256,7 @@ public class XmlConfigurationSourceTest {
 
         // Test config doesn't exist
         try {
-            sfXmlConfigSource.update(UNKNOWN_TYPE, param);
+            sfXmlConfigSource.update(UNKNOWN_TYPE, createConfig("config doesn't exists params", param));
         } catch (TmfConfigurationException e) {
             // success
             assertEquals(EXPECTED_MESSAGE_INVALID_CONFIG, e.getMessage());
@@ -265,7 +265,7 @@ public class XmlConfigurationSourceTest {
         // Test XML file doesn't exist
         param = ImmutableMap.of(EXPECTED_KEY_NAME, XmlUtils.getXmlFilesPath().append(UNKNOWN_TYPE).toOSString());
         try {
-            sfXmlConfigSource.update(config.getId(), param);
+            sfXmlConfigSource.update(config.getId(), createConfig("xml file doesn't exists params", param));
         } catch (TmfConfigurationException e) {
             // success
             assertEquals(EXPECTED_MESSAGE_FILE_NOT_FOUND, e.getMessage());
@@ -273,7 +273,7 @@ public class XmlConfigurationSourceTest {
 
         // Test invalid XML file
         try {
-            sfXmlConfigSource.update(EXPECTED_CONFIG_ID, INVALID_PARAM);
+            sfXmlConfigSource.update(EXPECTED_CONFIG_ID, createConfig("invalid params", INVALID_PARAM));
         } catch (TmfConfigurationException e) {
             // success
 
@@ -281,13 +281,13 @@ public class XmlConfigurationSourceTest {
 
         // Test file name mismatch... not allowed to use different xmlfile name
         try {
-            sfXmlConfigSource.update(config.getId(), VALID_PARAM2);
+            sfXmlConfigSource.update(config.getId(), createConfig("valid params 2", VALID_PARAM2));
         } catch (TmfConfigurationException e) {
             assertEquals(EXPECTED_MESSAGE_FILE_MISMATCH, e.getMessage());
         }
 
         try {
-            ITmfConfiguration configUpdated = sfXmlConfigSource.update(config.getId(), VALID_PARAM);
+            ITmfConfiguration configUpdated = sfXmlConfigSource.update(config.getId(), createConfig("valid params", VALID_PARAM));
             validateConfig(PATH_TO_VALID_FILE, configUpdated);
         } catch (TmfConfigurationException e) {
             fail();
@@ -333,7 +333,7 @@ public class XmlConfigurationSourceTest {
     private static ITmfConfiguration createConfig(String path) {
         Map<String, Object> param = ImmutableMap.of("path", path);
         try {
-            return sfXmlConfigSource.create(param);
+            return sfXmlConfigSource.create(createConfig("valid params with path", param));
         } catch (TmfConfigurationException e) {
             // Nothing to do
         }
@@ -354,5 +354,15 @@ public class XmlConfigurationSourceTest {
         File file = path.toFile();
         assertTrue(file.exists());
         return Objects.requireNonNull(file.getAbsolutePath());
+    }
+
+    private static ITmfConfiguration createConfig(String name, Map<String, Object> param) {
+        return new TmfConfiguration.Builder()
+                .setName(name)
+                .setDescription(name + " description")
+                .setSourceTypeId(XML_ANALYSIS_TYPE_ID)
+                .setParameters(param)
+                .build();
+
     }
 }

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSource.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/config/ITmfConfigurationSource.java
@@ -41,7 +41,9 @@ public interface ITmfConfigurationSource {
      * @return a new {@link ITmfConfiguration} if successful
      * @throws TmfConfigurationException
      *             If the creation of the configuration fails
+     * @deprecated As of version 10.0, use {@link #create(ITmfConfiguration)} instead
      */
+    @Deprecated(since = "10.0", forRemoval = true)
     ITmfConfiguration create(Map<String, Object> parameters) throws TmfConfigurationException;
 
     /**
@@ -78,7 +80,9 @@ public interface ITmfConfigurationSource {
      * @return a new {@link ITmfConfiguration} if successful
      * @throws TmfConfigurationException
      *             If the update of the configuration fails
+     * @deprecated As of version 10.0, use {@link #update(String, ITmfConfiguration)} instead
      */
+    @Deprecated(since = "10.0", forRemoval = true)
     ITmfConfiguration update(String id, Map<String, Object> parameters) throws TmfConfigurationException;
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
Use the corresponding methods with ITmfConfiguration instead. Update unit tests for that.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Successful CI.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

Remove deprecated API after waiting period.

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
