### PR TITLE
releng: Build with tracecompass-e4.36 target by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
-    <target-platform>tracecompass-e4.35</target-platform>
+    <target-platform>tracecompass-e4.36</target-platform>
     <help-docs-eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.23</help-docs-eclipserun-repo>
 
     <rcptt-version>2.5.4</rcptt-version>

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -238,10 +238,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.jxpath"
-         version="0.0.0"/>
-
-   <plugin
          id="com.sun.jna"
          version="0.0.0"/>
 
@@ -294,7 +290,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.logging"
+         id="org.apache.commons.commons-logging"
          version="0.0.0"/>
 
    <plugin
@@ -442,23 +438,11 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.jxpath"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.commons-beanutils"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.collections"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.jdom"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.launchbar.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.github.weisj.jsvg"
          version="0.0.0"/>
 
    <plugin

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.35/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.35/feature.xml
@@ -238,6 +238,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.apache.commons.jxpath"
+         version="0.0.0"/>
+
+   <plugin
          id="com.sun.jna"
          version="0.0.0"/>
 
@@ -290,7 +294,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.commons-logging"
+         id="org.apache.commons.logging"
          version="0.0.0"/>
 
    <plugin
@@ -438,11 +442,23 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.launchbar.core"
+         id="org.apache.commons.jxpath"
          version="0.0.0"/>
 
    <plugin
-         id="com.github.weisj.jsvg"
+         id="org.apache.commons.commons-beanutils"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.collections"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.jdom"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.launchbar.core"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
### What it does

releng: Build with tracecompass-e4.36 target by default

### How to test

Build without specifying target. Check 4.36 target is used.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
