### PR TITLE
Add entry-tree parameter to collapse children

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 Ericsson
+ * Copyright (c) 2020, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.TableColumnDescriptor;
@@ -42,11 +41,11 @@ public class TmfTreeModelTest {
     private static final String TOOLTIP_PREFIX = "tooltip";
     private static final String LABEL_PREFIX = "label";
     private static final String TEST_SCOPE = "scope";
-    private static List<@NonNull ITmfTreeDataModel> fTestEntries = new ArrayList<>();
-    private static List<@NonNull String> fTestHeaders = new ArrayList<>();
-    private static List<@NonNull String> fExpectedEmptyTooltips = new ArrayList<>();
-    private static List<@NonNull String> fExpectedTooltips = new ArrayList<>();
-    private static List<@NonNull ITableColumnDescriptor> fTestDescriptors = new ArrayList<>();
+    private static List<ITmfTreeDataModel> fTestEntries = new ArrayList<>();
+    private static List<String> fTestHeaders = new ArrayList<>();
+    private static List<String> fExpectedEmptyTooltips = new ArrayList<>();
+    private static List<String> fExpectedTooltips = new ArrayList<>();
+    private static List<ITableColumnDescriptor> fTestDescriptors = new ArrayList<>();
 
     /**
      * Run once
@@ -82,14 +81,14 @@ public class TmfTreeModelTest {
      */
     @Test
     public void testTmfTreeModelConstructor() {
-        TmfTreeModel<@NonNull ITmfTreeDataModel> testInstance = new TmfTreeModel<>(fTestHeaders, fTestEntries);
+        TmfTreeModel<ITmfTreeDataModel> testInstance = new TmfTreeModel<>(fTestHeaders, fTestEntries);
         verifyInstance(testInstance, fExpectedEmptyTooltips, null);
 
         testInstance = new TmfTreeModel<>(fTestHeaders, fTestEntries, TEST_SCOPE);
         verifyInstance(testInstance, fExpectedEmptyTooltips, TEST_SCOPE);
     }
 
-    private static void verifyInstance(TmfTreeModel<@NonNull ITmfTreeDataModel> testInstance, List<String> tooltips, @Nullable String scope) {
+    private static void verifyInstance(TmfTreeModel<ITmfTreeDataModel> testInstance, List<String> tooltips, @Nullable String scope) {
         assertEquals("Incorrect list of entries", fTestEntries, testInstance.getEntries());
         assertEquals("Incorrect list of entries", fTestHeaders, testInstance.getHeaders());
 
@@ -110,9 +109,9 @@ public class TmfTreeModelTest {
     @SuppressWarnings("javadoc")
     @Test
     public void testTmfTreeModelConstructor2() {
-        TmfTreeModel.Builder<@NonNull ITmfTreeDataModel> builder = new TmfTreeModel.Builder<>();
+        TmfTreeModel.Builder<ITmfTreeDataModel> builder = new TmfTreeModel.Builder<>();
         builder.setColumnDescriptors(fTestDescriptors).setEntries(fTestEntries);
-        TmfTreeModel<@NonNull ITmfTreeDataModel> testInstance = builder.build();
+        TmfTreeModel<ITmfTreeDataModel> testInstance = builder.build();
         verifyInstance(testInstance, fExpectedTooltips, null);
 
         builder = new TmfTreeModel.Builder<>();

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/src/org/eclipse/tracecompass/tmf/core/tests/model/tree/TmfTreeModelTest.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020, 2025 Ericsson
+ * Copyright (c) 2020 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -41,6 +41,8 @@ public class TmfTreeModelTest {
     private static final String TOOLTIP_PREFIX = "tooltip";
     private static final String LABEL_PREFIX = "label";
     private static final String TEST_SCOPE = "scope";
+    private static final int ALL_LEVELS = -1;
+    private static final int TEST_LEVEL = 1;
     private static List<ITmfTreeDataModel> fTestEntries = new ArrayList<>();
     private static List<String> fTestHeaders = new ArrayList<>();
     private static List<String> fExpectedEmptyTooltips = new ArrayList<>();
@@ -82,13 +84,13 @@ public class TmfTreeModelTest {
     @Test
     public void testTmfTreeModelConstructor() {
         TmfTreeModel<ITmfTreeDataModel> testInstance = new TmfTreeModel<>(fTestHeaders, fTestEntries);
-        verifyInstance(testInstance, fExpectedEmptyTooltips, null);
+        verifyInstance(testInstance, fExpectedEmptyTooltips, null, ALL_LEVELS);
 
         testInstance = new TmfTreeModel<>(fTestHeaders, fTestEntries, TEST_SCOPE);
-        verifyInstance(testInstance, fExpectedEmptyTooltips, TEST_SCOPE);
+        verifyInstance(testInstance, fExpectedEmptyTooltips, TEST_SCOPE, ALL_LEVELS);
     }
 
-    private static void verifyInstance(TmfTreeModel<ITmfTreeDataModel> testInstance, List<String> tooltips, @Nullable String scope) {
+    private static void verifyInstance(TmfTreeModel<ITmfTreeDataModel> testInstance, List<String> tooltips, @Nullable String scope, int autoExpandLevel) {
         assertEquals("Incorrect list of entries", fTestEntries, testInstance.getEntries());
         assertEquals("Incorrect list of entries", fTestHeaders, testInstance.getHeaders());
 
@@ -101,6 +103,7 @@ public class TmfTreeModelTest {
             assertEquals("Incorrect Collumn descriptor header tooltip", tooltips.get(i), columnDescriptors.get(i).getTooltip());
         }
         assertEquals("Incorrect scope", scope, testInstance.getScope());
+        assertEquals("Incorrect autoExpandLevel", autoExpandLevel, testInstance.getAutoExpandLevel());
     }
 
     /**
@@ -112,13 +115,17 @@ public class TmfTreeModelTest {
         TmfTreeModel.Builder<ITmfTreeDataModel> builder = new TmfTreeModel.Builder<>();
         builder.setColumnDescriptors(fTestDescriptors).setEntries(fTestEntries);
         TmfTreeModel<ITmfTreeDataModel> testInstance = builder.build();
-        verifyInstance(testInstance, fExpectedTooltips, null);
+        verifyInstance(testInstance, fExpectedTooltips, null, ALL_LEVELS);
 
         builder = new TmfTreeModel.Builder<>();
         builder.setColumnDescriptors(fTestDescriptors).setEntries(fTestEntries).setScope(TEST_SCOPE);
-
         testInstance = builder.build();
-        verifyInstance(testInstance, fExpectedTooltips, TEST_SCOPE);
+        verifyInstance(testInstance, fExpectedTooltips, TEST_SCOPE, ALL_LEVELS);
+
+        builder = new TmfTreeModel.Builder<>();
+        builder.setColumnDescriptors(fTestDescriptors).setEntries(fTestEntries).setScope(TEST_SCOPE).setAutoExpandLevel(TEST_LEVEL);
+        testInstance = builder.build();
+        verifyInstance(testInstance, fExpectedTooltips, TEST_SCOPE, TEST_LEVEL);
 
         builder = new TmfTreeModel.Builder<>();
         testInstance = builder.build();

--- a/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
+++ b/tmf/org.eclipse.tracecompass.tmf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 10.0.0.qualifier
+Bundle-Version: 10.1.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tmf.core.Activator

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeCompositeDataProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeCompositeDataProvider.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2017, 2021 Ericsson
+ * Copyright (c) 2017, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -106,6 +106,7 @@ public class TmfTreeCompositeDataProvider<M extends ITmfTreeDataModel, P extends
         boolean isComplete = true;
         List<Entry<M, Object>> entries = new ArrayList<>();
         List<ITableColumnDescriptor> columnDescriptor = null;
+        int autoExpandLevel = TmfTreeModel.ALL_LEVELS;
 
         Table<Object, Long, @NonNull M> scopedEntries = HashBasedTable.create();
         for (P dataProvider : fProviders) {
@@ -155,6 +156,8 @@ public class TmfTreeCompositeDataProvider<M extends ITmfTreeDataModel, P extends
                 if (columnDescriptor == null) {
                     columnDescriptor = model.getColumnDescriptors();
                 }
+                // All autoExpandLevel are supposed to be the same
+                autoExpandLevel = model.getAutoExpandLevel();
             }
             if (monitor != null && monitor.isCanceled()) {
                 return new TmfModelResponse<>(null, ITmfResponse.Status.CANCELLED, CommonStatusMessage.TASK_CANCELLED);
@@ -166,7 +169,8 @@ public class TmfTreeCompositeDataProvider<M extends ITmfTreeDataModel, P extends
             columnDescriptor = Collections.emptyList();
         }
         treeModelBuilder.setColumnDescriptors(columnDescriptor)
-                        .setEntries(Lists.transform(entries, e -> e.getKey()));
+                        .setEntries(Lists.transform(entries, e -> e.getKey()))
+                        .setAutoExpandLevel(autoExpandLevel);
 
         if (isComplete) {
             return new TmfModelResponse<>(treeModelBuilder.build(), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeModel.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/tree/TmfTreeModel.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019 Ericsson
+ * Copyright (c) 2019, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -31,10 +31,23 @@ import org.eclipse.tracecompass.tmf.core.model.ITableColumnDescriptor;
  * @since 5.0
  */
 public class TmfTreeModel<T extends ITmfTreeDataModel> {
+
+    /**
+     * Expand level to indicate that all tree levels are expanded. (default)
+     *
+     * @since 10.1
+     */
+    public static final int ALL_LEVELS = -1;
+
     private List<String> fHeaders;
     private List<ITableColumnDescriptor> fColumnDescriptors;
     private List<T> fEntries;
     private @Nullable String fScope;
+
+    /**
+     * Indicates which level of the tree should be expanded.
+     */
+    private int fAutoExpandLevel = ALL_LEVELS;
 
     /**
      * Constructor
@@ -88,6 +101,7 @@ public class TmfTreeModel<T extends ITmfTreeDataModel> {
         fColumnDescriptors = builder.fColumnDescriptors;
         fEntries = builder.fEntries;
         fScope = builder.fScope;
+        fAutoExpandLevel = builder.fAutoExpandLevel;
     }
 
     /**
@@ -119,6 +133,36 @@ public class TmfTreeModel<T extends ITmfTreeDataModel> {
     }
 
     /**
+     * Returns the auto-expand level.
+     *
+     * @return non-negative level, or <code>ALL_LEVELS</code> if all levels of
+     *         the tree are expanded automatically
+     * @see #setAutoExpandLevel
+     * @since 10.1
+     */
+    public int getAutoExpandLevel() {
+        return fAutoExpandLevel;
+    }
+
+    /**
+     * Sets the auto-expand level to be used for the input of the tree. The
+     * value 0 means that there is no auto-expand; 1 means that top-level
+     * elements are expanded, but not their children; 2 means that top-level
+     * elements are expanded, and their children, but not grand-children; and so
+     * on.
+     * <p>
+     * The value {@link #ALL_LEVELS} means that all subtrees should be expanded.
+     * </p>
+     *
+     * @param autoExpandLevel
+     *            The auto expand level to set
+     * @since 10.1
+     */
+    public void setAutoExpandLevel(int autoExpandLevel) {
+        this.fAutoExpandLevel = autoExpandLevel;
+    }
+
+    /**
      *
      * A builder class to build instances implementing interface
      * {@link TmfTreeModel}
@@ -131,6 +175,7 @@ public class TmfTreeModel<T extends ITmfTreeDataModel> {
         private List<ITableColumnDescriptor> fColumnDescriptors = new ArrayList<>();
         private List<T> fEntries;
         private @Nullable String fScope;
+        private int fAutoExpandLevel = ALL_LEVELS;
 
         /**
          * Constructor
@@ -172,6 +217,20 @@ public class TmfTreeModel<T extends ITmfTreeDataModel> {
          */
         public Builder<T> setScope(String scope) {
             fScope = scope;
+            return this;
+        }
+
+        /**
+         * Sets which level of the tree should be expanded
+         *
+         * @param autoExpandLevel
+         *            expand level of the tree model
+         * @return this {@link Builder} object
+         * @see TmfTreeModel#setAutoExpandLevel(int)
+         * @since 10.1
+         */
+        public Builder<T> setAutoExpandLevel(int autoExpandLevel) {
+            fAutoExpandLevel = autoExpandLevel;
             return this;
         }
 


### PR DESCRIPTION
### What it does

tmf: Add auto-expand level in TmfTreeModel

The auto-expand level is supposed to be used for the input of the tree. The value 0 means that there is no auto-expand; 1 means that top-level elements are expanded, but not their children; 2 means that top-level elements are expanded, and their children, but not grand-children; and so on.

The value -1 means that all subtrees should be expanded (default).

Contributes to fix https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/801

### How to test

Run updated unit test.

### Follow-ups

Related incubator PR.
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/196

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Hriday Panchasara <hriday.panchasara@ericsson.com>
Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>

