### PR TITLE
linux: set auto-expand-level in ResourcesStatusDataProvider

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/resourcesstatus/ResourcesStatusDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/resourcesstatus/ResourcesStatusDataProvider.java
@@ -274,7 +274,11 @@ public class ResourcesStatusDataProvider extends AbstractTimeGraphDataProvider<@
         }
         Collections.sort(builder, COMPARATOR);
 
-        return new TmfTreeModel<>(Collections.emptyList(), ImmutableList.copyOf(builder));
+        TmfTreeModel.Builder<@NonNull ResourcesEntryModel> treeModelBuilder = new TmfTreeModel.Builder<@NonNull ResourcesEntryModel>()
+                .setAutoExpandLevel(1) // only expand top level
+                .setEntries(ImmutableList.copyOf(builder));
+
+        return treeModelBuilder.build();
     }
 
     private static long getCpuFrequency(@NonNull ITmfStateSystem ss, int cpuQuark, @NonNull String freqAttribute) throws StateSystemDisposedException {


### PR DESCRIPTION
Note: The classic Eclipse UI has been doing this in the UI code without that setting (see ResourcesView).

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
linux: set auto-expand-level in ResourcesStatusDataProvider

Setting the auto-expand-level to 1 of the returned TmfTreeModel when calling fetchTree() will indicate to the clients that only the top-level should be expanded and their children supposed to be collapsed.

With this trace server clients can apply this new setting and it fixes FE issue https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/801.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Run server with this change and run theia-trace-extension change https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1202.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
