### PR TITLE
xml: Don't return duplicate data provider descriptors from xml manager

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core/src/org/eclipse/tracecompass/internal/tmf/analysis/xml/core/output/XmlDataProviderManager.java
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core/src/org/eclipse/tracecompass/internal/tmf/analysis/xml/core/output/XmlDataProviderManager.java
@@ -14,6 +14,7 @@ package org.eclipse.tracecompass.internal.tmf.analysis.xml.core.output;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -374,6 +375,7 @@ public class XmlDataProviderManager {
      */
     public List<IDataProviderDescriptor> getXmlDataProviderDescriptors(ITmfTrace trace, Set<OutputType> types) {
         List<IDataProviderDescriptor> descriptors = new ArrayList<>();
+        Set<String> existingDps = new HashSet<>();
         for (ITmfTrace tr : TmfTraceManager.getTraceSetWithExperiment(trace)) {
             Map<String, IAnalysisModuleHelper> modules = TmfAnalysisManager.getAnalysisModules(tr.getClass());
             for (OutputType viewType : types) {
@@ -392,11 +394,12 @@ public class XmlDataProviderManager {
                         builder.setProviderType(ProviderType.TIME_GRAPH);
                     }
                     for (String id : element.getAnalyses()) {
-                        if (modules.containsKey(id)) {
+                        if (modules.containsKey(id) && !existingDps.contains(elemId)) {
                             String analysisName = Objects.requireNonNull(modules.get(id)).getName();
                             builder.setName(analysisName + ": " + label); //$NON-NLS-1$
                             builder.setDescription(label + " provided by Analysis module: " + analysisName); //$NON-NLS-1$
                             descriptors.add(builder.build());
+                            existingDps.add(elemId);
                             break;
                         }
                     }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Fixes duplicate XML driven data providers for experiments with multiple traces of the same type (e.g. LTTng kernel)

Fixes #290 and https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/1204

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

1. Create experiment with 2 kernel traces
2. Open that experiment

`Futex Content Analysis : Scenario` will be listed for each kernel trace in the AVAILABLE VIEWS view.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups
N/A

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
