### PR TITLE
Mark `name` attributes for `org.eclipse.linuxtools.tmf.core` extension point as translatable

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.linuxtools.tmf.core.tracetype.exsd
+++ b/tmf/org.eclipse.tracecompass.tmf.core/schema/org.eclipse.linuxtools.tmf.core.tracetype.exsd
@@ -63,6 +63,9 @@
                <documentation>
                   a translatable name that will be used in the UI for this category
                </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
             </annotation>
          </attribute>
       </complexType>
@@ -82,6 +85,9 @@
                <documentation>
                   The type name as it is displayed to the end user.
                </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
             </annotation>
          </attribute>
          <attribute name="category" type="string">
@@ -138,6 +144,9 @@
                <documentation>
                   The type name as it is displayed to the end user.
                </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
             </annotation>
          </attribute>
          <attribute name="category" type="string">


### PR DESCRIPTION
Names of
* category
* type
* experiment 

are user-visible string and should have corresponding metadata to help PDE control its values.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
PDE doesn't trigger on non-externalized name attribute.
This PR adds "translatable" metadata for `name` attribute to the extension point schema 

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
After applying this change (and restarting IDE) PDE should recognize mentioned attributes as translatable
(use "Plug-in Tools -> Externalize String" from the project context menu)

<img width="955" height="273" alt="image" src="https://github.com/user-attachments/assets/25fcc8bd-042d-4c61-832c-00b81e2356e6" />


### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
I would say that this PR introduces technical debt, it is rather will help to resolve existing one with not translated names.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
