### PR TITLE
Resolve "SWT Resource was not properly disposed" for "Statistics"

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/piecharts/PieChartViewerStateNoContentSelected.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/piecharts/PieChartViewerStateNoContentSelected.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Ericsson
+ * Copyright (c) 2015, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *   Alexis Cabana-Loriaux - Initial API and implementation
+ *   Alexander Fedorov (ArSysOp) - fix "SWT Resource was not properly disposed"
  *
  *******************************************************************************/
 
@@ -43,13 +44,7 @@ public class PieChartViewerStateNoContentSelected implements IPieChartViewerStat
             synchronized (context) {
                 if (!context.isDisposed()) {
                     // Have to get rid of the time-range PieChart
-                    if (context.getTimeRangePC() != null) {
-                        if (!context.getTimeRangePC().isDisposed()) {
-                            context.getTimeRangePC().dispose();
-                        }
-                        context.setTimeRangePC(null);
-                    }
-
+                    context.disposeTimeRangePC();
                     context.updateGlobalPieChart();
                     // update the global chart so it takes all the place
                     context.getGlobalPC().getLegend().setPosition(SWT.RIGHT);

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/piecharts/TmfPieChartViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/piecharts/TmfPieChartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Ericsson
+ * Copyright (c) 2015, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *   Alexis Cabana-Loriaux - Initial API and implementation
+ *   Alexander Fedorov (ArSysOp) - fix "SWT Resource was not properly disposed"
  *
  *******************************************************************************/
 
@@ -442,17 +443,11 @@ public class TmfPieChartViewer extends Composite {
         if (isDisposed()) {
             return;
         }
-
-        if (getGlobalPC() != null && !getGlobalPC().isDisposed()) {
-            getGlobalPC().dispose();
-        }
+        disposeGlobalPC();
         fGlobalPC = new TmfPieChart(this, SWT.NONE);
         getGlobalPC().getTitle().setText(fGlobalPCname);
         getGlobalPC().getAxisSet().getXAxis(0).getTitle().setText(""); //Hide the title over the legend //$NON-NLS-1$
-        if (getTimeRangePC() != null && !getTimeRangePC().isDisposed()) {
-            getTimeRangePC().dispose();
-            fTimeRangePC = null;
-        }
+        disposeTimeRangePC();
         layout();
         setCurrentState(new PieChartViewerStateNoContentSelected(this));
     }
@@ -582,4 +577,26 @@ public class TmfPieChartViewer extends Composite {
             pieChart.redraw();
         }
     }
+
+    @Override
+    public void dispose() {
+        disposeGlobalPC();
+        disposeTimeRangePC();
+        super.dispose();
+    }
+
+    void disposeGlobalPC() {
+        if (fGlobalPC != null && !fGlobalPC.isDisposed()) {
+            fGlobalPC.dispose();
+            fGlobalPC = null;
+        }
+    }
+
+    void disposeTimeRangePC() {
+        if (fTimeRangePC != null && !fTimeRangePC.isDisposed()) {
+            fTimeRangePC.dispose();
+            fTimeRangePC = null;
+        }
+    }
+
 }

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/statistics/TmfStatisticsViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/statistics/TmfStatisticsViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Ericsson
+ * Copyright (c) 2012, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -13,6 +13,7 @@
  *   Alexandre Montplaisir - Port to ITmfStatistics provider
  *   Patrick Tasse - Support selection range
  *   Bernd Hufmann - Fix range selection updates
+ *   Alexander Fedorov (ArSysOp) - fix "SWT Resource was not properly disposed"
  *******************************************************************************/
 
 package org.eclipse.tracecompass.internal.tmf.ui.viewers.statistics;
@@ -186,7 +187,7 @@ public class TmfStatisticsViewer extends TmfViewer {
 
         // Clean the model for this viewer
         TmfStatisticsTreeManager.removeStatTreeRoot(getTreeID());
-        fPieChartViewer.reinitializeCharts();
+        fPieChartViewer.dispose();
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
* implement dispose for `TmfPieChartViewer`
* use `dispose` properly

### What it does

The PR introduces proper handling of SWT resources for "Statistics" view

### How to test

Open "Statistics" view, do something, close it: the console should have no "SWT Resource was not properly disposed" initiated from `TmfStatisticsViewer` should be present.

### Follow-ups

I plan to fix similar problems for other views

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
