### PR TITLE
tmf: Fix IAxisDomain toString() and Javadoc

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/IAxisDomain.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/IAxisDomain.java
@@ -17,7 +17,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 
 /**
- * Shows the available values of X axis.
+ * Shows the available values of an axis.
  *
  * @author Siwei Zhang
  * @since 10.1
@@ -28,7 +28,7 @@ public sealed interface IAxisDomain permits IAxisDomain.Categorical, IAxisDomain
      * Categorical axis domain (e.g., names or labels).
      *
      * @param categories
-     *            the category labels for the X axis
+     *            the category labels for the axis
      */
     record Categorical(List<String> categories) implements IAxisDomain {
         @Override
@@ -49,7 +49,7 @@ public sealed interface IAxisDomain permits IAxisDomain.Categorical, IAxisDomain
 
         @Override
         public String toString() {
-            return "AxisDomain.Categorical{categories=" + categories + "}"; //$NON-NLS-1$ //$NON-NLS-2$
+            return "IAxisDomain.Categorical{categories=" + categories + "}"; //$NON-NLS-1$ //$NON-NLS-2$
         }
     }
 
@@ -81,7 +81,7 @@ public sealed interface IAxisDomain permits IAxisDomain.Categorical, IAxisDomain
 
         @Override
         public String toString() {
-            return "AxisDomain.TimeRange{start=" + start + ", end=" + end + "}"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            return "IAxisDomain.Range{start=" + start + ", end=" + end + "}"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         }
     }
 }


### PR DESCRIPTION
### What it does

Change Range.toString() to use "Range" instead of "TimeRange".

Change both toString() to use "IAxisDomain" instead of "AxisDomain".

Change Javadoc to refer to generic axis instead of only X axis.

### How to test

Select an AxisDomain variable in debug mode Variables view.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
