### PR TITLE
releng: Build with tracecompass-e4.37 target by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
-    <target-platform>tracecompass-e4.36</target-platform>
+    <target-platform>tracecompass-e4.37</target-platform>
     <help-docs-eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.23</help-docs-eclipserun-repo>
 
     <rcptt-version>2.5.4</rcptt-version>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.36/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.36/feature.xml
@@ -386,6 +386,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="com.sun.el.javax.el"
+         version="0.0.0"/>
+
+   <plugin
          id="com.ibm.icu"
          version="0.0.0"/>
 


### PR DESCRIPTION
### What it does

releng: Build with tracecompass-e4.37 target by default

### How to test

Build without specifying target. Check 4.37 platform is used.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
