### PR TITLE
releng: Enable automatic update in the RCP for 11.1 release

### DIFF
--- a/rcp/org.eclipse.tracecompass.rcp.branding/plugin_customization.ini
+++ b/rcp/org.eclipse.tracecompass.rcp.branding/plugin_customization.ini
@@ -2,3 +2,6 @@ org.eclipse.e4.ui.css.swt.theme/themeid=org.eclipse.e4.ui.css.theme.e4_default
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
 org.eclipse.ui/defaultPerspectiveId=org.eclipse.linuxtools.lttng2.kernel.ui.perspective
 org.eclipse.help/HELP_DATA=help_data.xml
+# check for updates every time Trace Compass starts. This should only be done in stable releases.
+# https://bugs.eclipse.org/bugs/show_bug.cgi?id=499247
+org.eclipse.equinox.p2.ui.sdk.scheduler/enabled=true

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
@@ -159,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
@@ -159,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
@@ -159,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
@@ -160,7 +160,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>


### PR DESCRIPTION
### What it does

releng: Enable automatic update in the RCP for 11.1 release

### How to test

Run Eclipse and wait for automatic update.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
