### PR TITLE
linux.core: : Add IRQ handlers instead of generic IRQs

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IrqEntryHandler.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IrqEntryHandler.java
@@ -45,12 +45,12 @@ public class IrqEntryHandler extends KernelEventHandler {
             return;
         }
         Integer irqId = ((Long) event.getContent().getField(getLayout().fieldIrq()).getValue()).intValue();
-
+        String name = event.getContent().getField(getLayout().fieldName()).getValue().toString();
         /*
          * Mark this IRQ as active in the resource tree. The state value = the
          * CPU on which this IRQ is sitting
          */
-        int quark = ss.getQuarkRelativeAndAdd(KernelEventHandlerUtils.getNodeIRQs(cpu, ss), irqId.toString());
+        int quark = ss.getQuarkRelativeAndAdd(KernelEventHandlerUtils.getNodeIRQs(cpu, ss), irqId.toString()+"/"+name);
 
         long timestamp = KernelEventHandlerUtils.getTimestamp(event);
         ss.modifyAttribute(timestamp, cpu.intValue(), quark);
@@ -64,7 +64,7 @@ public class IrqEntryHandler extends KernelEventHandler {
         ss.modifyAttribute(timestamp, StateValues.CPU_STATUS_IRQ_VALUE.unboxValue(), quark);
 
         /* Update the aggregate IRQ entry to set it to this CPU */
-        int aggregateQuark = ss.getQuarkAbsoluteAndAdd(Attributes.IRQS, irqId.toString());
+        int aggregateQuark = ss.getQuarkAbsoluteAndAdd(Attributes.IRQS, irqId.toString()+"/"+name);
         ss.modifyAttribute(timestamp, cpu, aggregateQuark);
     }
 

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IrqExitHandler.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IrqExitHandler.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.tracecompass.internal.analysis.os.linux.core.kernel.handlers;
 
+import java.util.List;
+
 import org.eclipse.tracecompass.analysis.os.linux.core.trace.IKernelAnalysisEventLayout;
 import org.eclipse.tracecompass.internal.analysis.os.linux.core.kernel.Attributes;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
@@ -43,8 +45,18 @@ public class IrqExitHandler extends KernelEventHandler {
         }
         int currentThreadNode = KernelEventHandlerUtils.getCurrentThreadNode(cpu, ss);
         Integer irqId = ((Long) event.getContent().getField(getLayout().fieldIrq()).getValue()).intValue();
+        List<Integer> subAttrs = ss.getSubAttributes(KernelEventHandlerUtils.getNodeIRQs(cpu, ss),false);
+        String irqPrefix = irqId.toString()+"/"; //$NON-NLS-1$
+        List<Integer> quarks = subAttrs.stream().filter(iquark -> ss.getAttributeName(iquark).startsWith(irqPrefix)).toList();
+        int quark =-1;
+        for (int quarkCandidate : quarks) {
+            if (ss.queryOngoing(quarkCandidate) != null) {
+                quark = quarkCandidate;
+                break;
+            }
+        }
+        String name = ss.getAttributeName(quark);
         /* Put this IRQ back to inactive in the resource tree */
-        int quark = ss.getQuarkRelativeAndAdd(KernelEventHandlerUtils.getNodeIRQs(cpu, ss), irqId.toString());
         long timestamp = KernelEventHandlerUtils.getTimestamp(event);
         ss.modifyAttribute(timestamp, (Object) null, quark);
 
@@ -55,7 +67,7 @@ public class IrqExitHandler extends KernelEventHandler {
         KernelEventHandlerUtils.updateCpuStatus(timestamp, cpu, ss);
 
         /* Update the aggregate IRQ entry to set it to this CPU */
-        int aggregateQuark = ss.getQuarkAbsoluteAndAdd(Attributes.IRQS, irqId.toString());
+        int aggregateQuark = ss.getQuarkAbsoluteAndAdd(Attributes.IRQS, name);
         /* Update the aggregate IRQ entry to set it to a running CPU */
         Integer prevCpu = KernelEventHandlerUtils.getCpuForIrq(ss, irqId);
         ss.modifyAttribute(timestamp, prevCpu, aggregateQuark);

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/resourcesstatus/ResourcesStatusDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/resourcesstatus/ResourcesStatusDataProvider.java
@@ -313,11 +313,12 @@ public class ResourcesStatusDataProvider extends AbstractTimeGraphDataProvider<@
             ResourcesEntryModel cpuEntry, List<Integer> irqQuarks, Type type, List<ResourcesEntryModel> builder) {
         for (Integer irqQuark : irqQuarks) {
             String resourceName = ssq.getAttributeName(irqQuark);
-            int resourceId = Integer.parseInt(resourceName);
+            String[] resourceNames = resourceName.split("/"); //$NON-NLS-1$
+            int resourceId = Integer.parseInt(resourceNames[0]);
             long irqId = getId(irqQuark);
 
             builder.add(new ResourcesEntryModel(irqId, cpuEntry.getId(),
-                    computeEntryName(type, resourceId), startTime, endTime, resourceId, type));
+                    computeEntryName(type, resourceName), startTime, endTime, resourceId, type));
 
             fEntryModelTypes.put(irqQuark, type);
 
@@ -333,7 +334,7 @@ public class ResourcesStatusDataProvider extends AbstractTimeGraphDataProvider<@
             long aggregateId = getId(aggregateQuark);
             if (!Iterables.any(builder, entry -> entry.getId() == aggregateId)) {
                 builder.add(new ResourcesEntryModel(aggregateId, cpuEntry.getParentId(),
-                        computeEntryName(type, resourceId),
+                        computeEntryName(type, resourceName),
                         startTime, endTime, resourceId, type));
             }
             fEntryModelTypes.put(aggregateQuark, type);
@@ -350,9 +351,9 @@ public class ResourcesStatusDataProvider extends AbstractTimeGraphDataProvider<@
         }
     }
 
-    private static @NonNull List<@NonNull String> computeEntryName(Type type, int id) {
+    private static @NonNull List<@NonNull String> computeEntryName(Type type, Object id) {
         if (type == Type.SOFT_IRQ) {
-            return Collections.singletonList(type.toString() + ' ' + id + ' ' + SoftIrqLabelProvider.getSoftIrq(id));
+            return Collections.singletonList(type.toString() + ' ' + id + ' ' + SoftIrqLabelProvider.getSoftIrq(Integer.parseInt((String) id)));
         } else if (type == Type.CURRENT_THREAD) {
             String threadEntryName = NLS.bind(Messages.ThreadEntry, id);
             if (threadEntryName != null) {


### PR DESCRIPTION
Currently, the Resources view only shows IRQs as a single entity. This makes it harder to distinguish which handler is actually running, especially in cases where multiple IRQ handlers are mapped to the same lane.

This change updates the view to display IRQ handlers instead of just the IRQ, providing finer granularity and improving readability when a single lane contains multiple handlers.

Benefits:
* Clearer visualization of interrupt activity.
* Easier to identify which handler is active at a given time.
* Better distinction when multiple handlers share one IRQ lane.

[Added] Add handlers to IRQs in resources views

Change-Id: I131790ec6dad3b28328abea0c5d84b280a7b196e

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
