### PR TITLE
tmf.ctf: Re-initialize start and endtime after transform is applied

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/TmfTrace.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/TmfTrace.java
@@ -222,6 +222,24 @@ public abstract class TmfTrace extends TmfEventProvider implements ITmfTrace, IT
         return new TmfCheckpointIndexer(this, interval);
     }
 
+    /**
+     * Reset indexer. It dispose the old indexer and creates a new one.
+     *
+     * Subclasses might want to reset the start and end time of the trace if
+     * needed.
+     *
+     * Note: Only call this when there is no trace reading is ongoing. Caller
+     * needs to ensure that trace indexing is restarted.
+     *
+     * @since 10.2
+     */
+    public synchronized void resetIndexer() {
+        if (fIndexer != null) {
+            fIndexer.dispose();
+        }
+        fIndexer = createIndexer(fCacheSize);
+    }
+
     // ------------------------------------------------------------------------
     // ITmfTrace - Initializers
     // ------------------------------------------------------------------------

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/experiment/TmfExperiment.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/experiment/TmfExperiment.java
@@ -367,6 +367,9 @@ public class TmfExperiment extends TmfTrace implements ITmfPersistentlyIndexable
                 if (!newTransform.equals(currentTransform)) {
                     TmfTraceManager.deleteSupplementaryFiles(trace);
                     trace.setTimestampTransform(newTransform);
+                    if (trace instanceof TmfTrace tmfTrace) {
+                        tmfTrace.resetIndexer();
+                    }
                 }
             });
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

tmf.ctf: Re-initialize start and endtime after transform is applied

With this the start and endtime is correct when opening the experiment that has automatically applied timestamp transformation applied.

fixes #323

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Follow steps in #323 and verify that start and end times of both traces in the experiment are correct when listing the experiment from the python client.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

Update `TraceManagerService.instantiateTrace()` to not start indexing of trace during experiment creation. The trace will be indexed when experiment is indexed. 

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
