### PR TITLE
fix: trace server does not notify the client when the state system is…

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProvider.java
@@ -345,6 +345,10 @@ public class FlameChartDataProvider extends AbstractTmfTraceDataProvider impleme
             boolean complete = fcProvider.isComplete();
             CallStackSeries callstack = fcProvider.getCallStackSeries();
             if (callstack == null) {
+                // Explicitly tell the client that the analysis is completed to prevent further polling
+                if (complete) {
+                    return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), Collections.emptyList()), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+                }
                 return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), Collections.emptyList()), ITmfResponse.Status.RUNNING, CommonStatusMessage.RUNNING);
             }
             long start = getTrace().getStartTime().getValue();


### PR DESCRIPTION
… empty and the analysis is completed, resulting in infinite polling on the client side.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Adds a condition check on whether or not the analysis is complete and return a sufficient response to the client.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Run trace server (incubator) in debug mode with Eclipse IDE
- Run theia-trace-extension locally
- Load a valid UST trace without any entry or exit calls (i.e. empty)
- Open Flame Chart view
- Should show an infinite analysis running loader

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

n/a

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
