### PR TITLE
linux+callstack: Fix failing callstack

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernel/KernelThreadInformationProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernel/KernelThreadInformationProvider.java
@@ -617,6 +617,9 @@ public final class KernelThreadInformationProvider {
         Map<Integer, String> quarkToThreadIds = new HashMap<>();
         for (Integer threadId : threadIds) {
             int threadQuark = ss.optQuarkAbsolute(Attributes.THREADS, threadId.toString());
+            if (threadQuark == ITmfStateSystem.INVALID_ATTRIBUTE) {
+                continue;
+            }
             quarkToThreadIds.put(threadQuark, threadId.toString());
             int syscallQuark = ss.optQuarkRelative(threadQuark, Attributes.SYSTEM_CALL);
             if (syscallQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {


### PR DESCRIPTION
The callstack fails if a kernel trace which has the same host id is opened alongside the ust trace and it was taken without containing the thread ids of the ust trace.

### What it does

Ignore thread ids that were not found when querying kernel statuses instead of throwing an error.

### How to test

Open up an cyg profile lttng ust trace alongside a kernel trace that does not contain any event with the tid of the program.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
