### PR TITLE
tmf.core: Add event type children to histogram data provider

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/eventdensity/EventDensityViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/eventdensity/EventDensityViewer.java
@@ -56,6 +56,6 @@ public class EventDensityViewer extends TmfFilteredXYChartViewer {
 
     @Override
     public @NonNull OutputElementStyle getSeriesStyle(@NonNull Long seriesId) {
-        return getPresentationProvider().getSeriesStyle(seriesId, StyleProperties.SeriesType.BAR, DEFAULT_SERIES_WIDTH);
+        return getPresentationProvider().getSeriesStyle(seriesId, StyleProperties.SeriesType.AREA, DEFAULT_SERIES_WIDTH);
     }
 }


### PR DESCRIPTION


[Added] lines in histogram

Change-Id: I142886fe9fa8e154ef2825a5a01c4f51a48385ea

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

- Add individual event type histogram support to HistogramDataProvider
- Track event type IDs in fEventTypeIds map
- Extend fetchTree() to include event type children from statistics
- Extend fetchXY() to handle event type histogram requests
- Add getEventTypeHistogram() method for per-type density data
- Change EventDensityViewer to use AREA chart style
<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Open a trace. It will have all the event types. This allows users to view histogram density per event type in addition to total and lost events.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->





note: this commit was made with the assistance of Claude Sonnet 4
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
