### PR TITLE
callStack: Add markers to instant events

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/CallStackTestBase2.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/CallStackTestBase2.java
@@ -47,13 +47,25 @@ public class CallStackTestBase2 {
     private CallStackAnalysisStub fModule;
     private KernelAnalysisModuleStub fKernelModule;
 
+    private final String fCallstackFile;
+
+
+    protected CallStackTestBase2(String callstackFile) {
+        fCallstackFile = callstackFile;
+    }
+
+    public CallStackTestBase2() {
+        fCallstackFile = CALLSTACK_FILE;
+    }
+
+
     /**
      * Setup the trace for the tests
      */
     @Before
     public void setUp() {
         TmfXmlTraceStub trace = new TmfXmlTraceStubNs();
-        IPath filePath = ActivatorTest.getAbsoluteFilePath(CALLSTACK_FILE);
+        IPath filePath = ActivatorTest.getAbsoluteFilePath(fCallstackFile);
         IStatus status = trace.validate(null, filePath.toOSString());
         if (!status.isOK()) {
             fail(status.getException().getMessage());

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs2/CallStackProviderStub.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs2/CallStackProviderStub.java
@@ -11,14 +11,19 @@
 
 package org.eclipse.tracecompass.analysis.profiling.core.tests.stubs2;
 
+import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
+
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.profiling.core.callstack.CallStackStateProvider;
+import org.eclipse.tracecompass.analysis.profiling.core.instrumented.InstrumentedCallStackAnalysis;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
 import org.eclipse.tracecompass.statesystem.core.statevalue.ITmfStateValue;
 import org.eclipse.tracecompass.statesystem.core.statevalue.TmfStateValue;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEventField;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
 
 /**
  * A call stack state provider stub
@@ -95,5 +100,50 @@ public class CallStackProviderStub extends CallStackStateProvider {
             return Integer.parseInt((String) field.getValue());
         }
         return CallStackStateProvider.UNKNOWN_PID;
+    }
+
+    @Override
+    protected void eventHandle(ITmfEvent event) {
+        if (!considerEvent(event)) {
+            return;
+        }
+        // Handle instant events
+        ITmfEventField phField = event.getContent().getField("ph");
+        if (phField != null && "i".equals(phField.getValue())) {
+            handleInstant(event);
+            return;
+        }
+        // Call parent for regular entry/exit events
+        super.eventHandle(event);
+    }
+
+    private void handleInstant(@NonNull ITmfEvent event) {
+        super.addMarker(event);
+
+        ITmfStateSystemBuilder ss = checkNotNull(getStateSystemBuilder());
+        long timestamp = event.getTimestamp().toNanos();
+        Object contents = event.getContent().getFieldValue( String.class,"name");
+        String toStore = (contents != null ? contents.toString() : "");
+
+        String processName = getProcessName(event);
+        int processId = getProcessId(event);
+        if (processName == null) {
+            processName = (processId == UNKNOWN_PID) ? UNKNOWN : Integer.toString(processId);
+        }
+        int processQuark = ss.getQuarkAbsoluteAndAdd(PROCESSES, processName);
+        ss.updateOngoingState(TmfStateValue.newValueInt(processId), processQuark);
+
+        String threadName = getThreadName(event);
+        long threadId = getThreadId(event);
+        if (threadName == null) {
+            threadName = Long.toString(threadId);
+        }
+        int threadQuark = ss.getQuarkRelativeAndAdd(processQuark, threadName);
+        ss.updateOngoingState(TmfStateValue.newValueLong(threadId), threadQuark);
+
+        int callStackQuark = ss.getQuarkRelativeAndAdd(threadQuark, InstrumentedCallStackAnalysis.ANNOTATIONS);
+        ss.pushAttribute(timestamp, toStore, callStackQuark);
+        return;
+
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/traces/callstackIevents.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/traces/callstackIevents.xml
@@ -1,0 +1,232 @@
+<!-- ***************************************************************************
+* Copyright (c) 2016 École Polytechnique de Montréal
+*
+* All rights reserved. This program and the accompanying materials are
+* made available under the terms of the Eclipse Public License 2.0 which
+* accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/*\1 SPDX-License-Identifier: EPL-2.0
+*************************************************************************** -->
+<!-- This is the layout of a callstack trace that looks like this:
+*
+* where 1e2 means at timestamp 1, entry of function named op2
+*   and 10x means at timestamp 10, exit of the function
+*
+* pid1 ___ tid2   1e1 +++++++++++++ 10x1 12e4+++++++++++ 20x
+*      |             3e2+++++++7x
+*      |               4e3++5x
+*      |__ tid3      3e2 +++++++++++++++++++++++++++++++ 20x
+*                       5e3++6x  7e2++++++++13x
+*
+* pid5 ___ tid6   1e1 +++++++++++++++++++++++++++++++++++++++ 20x
+*      |            2e3 +++++++++7x 8e2+++11x 12e4+++++++++++ 20x
+*      |                4e1++6x      9e3+10x
+*      |__ tid7   1e5 ++++++++++++++++++++++++++++++++++ 20x
+*                      2e2 +++ 6x  9e2 ++++ 13x 15e2 ++ 19x
+*                                   10e3 + 11x
+************************************************************************** -->
+<trace>
+<event timestamp="1" name="entry">
+<field name="op" type="string" value="op1" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="1" name="entry">
+<field name="op" type="string" value="op1" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="1" name="entry">
+<field name="op" type="string" value="op5" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="2" name="entry">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="2" name="entry">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="3" name="entry">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="3" name="entry">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="3" />
+</event>
+<event timestamp="4" name="entry">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="4" name="entry">
+<field name="op" type="string" value="op1" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="5" name="exit">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="5" name="entry">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="3" />
+</event>
+<event timestamp="6" name="exit">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="3" />
+</event>
+<event timestamp="6" name="exit">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="6" name="exit">
+<field name="op" type="string" value="op1" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="7" name="exit">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="7" name="exit">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="7" name="entry">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="3" />
+</event>
+<event timestamp="8" name="entry">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="9" name="entry">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="9" name="entry">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="10" name="entry">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="10" name="exit">
+<field name="op" type="string" value="op1" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="10" name="exit">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="11" name="exit">
+<field name="op" type="string" value="op3" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="11" name="exit">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="12" name="entry">
+<field name="op" type="string" value="op4" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="12" name="entry">
+<field name="op" type="string" value="op4" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="13" name="exit">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="3" />
+</event>
+<event timestamp="13" name="exit">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="15" name="entry">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="15" name="instant_event">
+<field name="ph" value="i" type="string" />
+<field name="tid" value="3" type="string" />
+<field name="pid" type="string" value="1" />
+<field name="name" value="HistoryTreeBackend:ClosingFile" type="string" />
+</event>
+<event timestamp="16" name="instant_event">
+<field name="ph" value="i" type="string" />
+<field name="tid" value="2" type="string" />
+<field name="pid" type="string" value="1" />
+<field name="name" value="InstantEvent1" type="string" />
+</event>
+<event timestamp="17" name="instant_event">
+<field name="ph" value="i" type="string" />
+<field name="tid" value="6" type="string" />
+<field name="pid" type="string" value="5" />
+<field name="name" value="InstantEvent2" type="string" />
+</event>
+<event timestamp="18" name="instant_event">
+<field name="ph" value="i" type="string" />
+<field name="tid" value="2" type="string" />
+<field name="pid" type="string" value="1" />
+<field name="name" value="InstantEvent3" type="string" />
+</event>
+<event timestamp="19" name="exit">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+<event timestamp="20" name="exit">
+<field name="op" type="string" value="op2" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="3" />
+</event>
+<event timestamp="20" name="exit">
+<field name="op" type="string" value="op4" />
+<field name="pid" type="string" value="1" />
+<field name="tid" type="string" value="2" />
+</event>
+<event timestamp="20" name="exit">
+<field name="op" type="string" value="op4" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="20" name="exit">
+<field name="op" type="string" value="op1" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="6" />
+</event>
+<event timestamp="20" name="exit">
+<field name="op" type="string" value="op5" />
+<field name="pid" type="string" value="5" />
+<field name="tid" type="string" value="7" />
+</event>
+</trace>

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/callstack/CallStackAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/callstack/CallStackAnalysis.java
@@ -54,6 +54,13 @@ public abstract class CallStackAnalysis extends TmfStateSystemAnalysisModule imp
      */
     public static final String CALL_STACK = "CallStack"; //$NON-NLS-1$
 
+    /**
+     * Annotations string state attribute
+     *
+     * @since 2.6
+     */
+    public static final String ANNOTATIONS = "Markers"; //$NON-NLS-1$
+
     private static final String[] DEFAULT_PROCESSES_PATTERN = new String[] { CallStackStateProvider.PROCESSES, "*" }; //$NON-NLS-1$
 
     private static final String[] DEFAULT_THREADS_PATTERN = new String[] { "*" }; //$NON-NLS-1$

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/callstack/CallStackStateProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/callstack/CallStackStateProvider.java
@@ -277,4 +277,15 @@ public abstract class CallStackStateProvider extends AbstractTmfStateProvider {
         /* Override to provide a thread name */
         return null;
     }
+
+    /**
+     * Add an event as a marker to the Annotations attribute
+     *
+     * @param event
+     *            The event to add as a marker
+     * @since 2.6
+     */
+    protected void addMarker(ITmfEvent event) {
+        // Do nothing, this is a placeholder for overriding.
+    }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/instrumented/InstrumentedCallStackAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/instrumented/InstrumentedCallStackAnalysis.java
@@ -67,6 +67,13 @@ public abstract class InstrumentedCallStackAnalysis extends TmfStateSystemAnalys
     /** CallStack stack-attribute */
     public static final String CALL_STACK = "CallStack"; //$NON-NLS-1$
 
+    /**
+     * Annotations string state attribute
+     *
+     * @since 2.6
+     */
+    public static final String ANNOTATIONS = "Markers"; //$NON-NLS-1$
+
     private @Nullable CallStackSeries fCallStacks;
 
     private final CallGraphAnalysis fCallGraph;

--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/widgets/timegraph/widgets/TimeGraphControl.java
@@ -2361,9 +2361,14 @@ public class TimeGraphControl extends TimeGraphBaseControl
         gc.setAlpha(OPAQUE);
         String label = marker.getLabel();
         if (fLabelsVisible && label != null && marker.getEntry() != null) {
-            label = label.substring(0, Math.min(label.indexOf('\n') != -1 ? label.indexOf('\n') : label.length(), MAX_LABEL_LENGTH));
-            gc.setForeground(color);
-            Utils.drawText(gc, label, rect.x - gc.textExtent(label).x, rect.y, true);
+            StyleManager styleManager = getStyleManager();
+            OutputElementStyle elementStyle = getElementStyle(marker);
+            Object symbolType = (elementStyle != null) ? styleManager.getStyle(elementStyle, StyleProperties.SYMBOL_TYPE) : null;
+            if (symbolType == null || symbolType == SymbolType.NONE) {
+                label = label.substring(0, Math.min(label.indexOf('\n') != -1 ? label.indexOf('\n') : label.length(), MAX_LABEL_LENGTH));
+                gc.setForeground(color);
+                Utils.drawText(gc, label, rect.x - gc.textExtent(label).x, rect.y, true);
+            }
         }
     }
 


### PR DESCRIPTION
### What it does
- Display Markers as instant events
- Add annotations functionalities to FlameChartDataProvider  and CallStackDataProvider
- Implement instant event handler inside CallStackProviderStub
- Add unit tests

### How to test

- run the incubator https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/255
- load trace.json from logger repo

### Follow-ups

This is a drat to improve.

### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
