### PR TITLE
jsontrace: add events path to sorting job

### DIFF
--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/src/org/eclipse/tracecompass/jsontrace/core/tests/JsonTraceTest.java
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/src/org/eclipse/tracecompass/jsontrace/core/tests/JsonTraceTest.java
@@ -26,12 +26,17 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfContext;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.junit.Test;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
 /**
  * Test generic Json trace
  *
  * @author Simon Delisle
  */
 public class JsonTraceTest {
+
+    private final Gson gson = new Gson();
 
     /**
      * Test the unsorted json trace
@@ -45,7 +50,7 @@ public class JsonTraceTest {
         long nbEvents = 5;
         ITmfTimestamp startTime = TmfTimestamp.fromNanos(1);
         ITmfTimestamp endTime = TmfTimestamp.fromNanos(5);
-        testJsonTrace(path, nbEvents, startTime, endTime);
+        testJsonTrace(path, nbEvents, startTime, endTime, "{\"events\":[]}");
     }
 
     /**
@@ -60,10 +65,59 @@ public class JsonTraceTest {
         long nbEvents = 5;
         ITmfTimestamp startTime = TmfTimestamp.fromNanos(1);
         ITmfTimestamp endTime = TmfTimestamp.fromNanos(5);
-        testJsonTrace(path, nbEvents, startTime, endTime);
+        testJsonTrace(path, nbEvents, startTime, endTime, "{\"events\":[]}");
     }
 
-    private static void testJsonTrace(String path, long expectedNbEvents, ITmfTimestamp startTime, ITmfTimestamp endTime)
+    /**
+     * Test the json trace with metadata
+     *
+     * @throws TmfTraceException
+     *             If there is a problem while initializing the trace
+     */
+    @Test
+    public void testMetadataBeginTrace() throws TmfTraceException {
+        String path = "traces/traceMetadataBegin.json"; //$NON-NLS-1$
+        long nbEvents = 6;
+        ITmfTimestamp startTime = TmfTimestamp.fromNanos(1730000000000L);
+        ITmfTimestamp endTime = TmfTimestamp.fromNanos(1730000005000L);
+        testJsonTrace(path, nbEvents, startTime, endTime,
+                "{\"events\":[], \"metadata\":{\"source\":\"sensor-A\",\"version\":1,\"generatedAt\":\"2025-10-23T12:00:00Z\"}}");
+    }
+
+    /**
+     * Test the json trace with metadata
+     *
+     * @throws TmfTraceException
+     *             If there is a problem while initializing the trace
+     */
+    @Test
+    public void testMetadataEndTrace() throws TmfTraceException {
+        String path = "traces/traceMetadataEnd.json"; //$NON-NLS-1$
+        long nbEvents = 5;
+        ITmfTimestamp startTime = TmfTimestamp.fromNanos(1730000000000L);
+        ITmfTimestamp endTime = TmfTimestamp.fromNanos(1730000004000L);
+        testJsonTrace(path, nbEvents, startTime, endTime,
+                "{\"events\":[], \"metadata\":{\"source\":\"sensor-A\",\"version\":1,\"generatedAt\":\"2025-10-23T12:00:00Z\"}}");
+    }
+
+    /**
+     * Test the json trace with metadata
+     *
+     * @throws TmfTraceException
+     *             If there is a problem while initializing the trace
+     */
+    @Test
+    public void testMetadataBeginEndTrace() throws TmfTraceException {
+        String path = "traces/traceMetadataBeginEnd.json"; //$NON-NLS-1$
+        long nbEvents = 5;
+        ITmfTimestamp startTime = TmfTimestamp.fromNanos(1730000000000L);
+        ITmfTimestamp endTime = TmfTimestamp.fromNanos(1730000004000L);
+        testJsonTrace(path, nbEvents, startTime, endTime,
+                "{\"events\":[], \"metadataStart\":{\"source\":\"sensor-A\",\"version\":1,\"generatedAt\":\"2025-10-23T12:00:00Z\"},"
+                + "\"metadataEnd\":{\"checksum\":\"abc123\",\"recordCount\":5,\"processedAt\":\"2025-10-23T12:05:00Z\"}}");
+    }
+
+    private void testJsonTrace(String path, long expectedNbEvents, ITmfTimestamp startTime, ITmfTimestamp endTime, String metadata)
             throws TmfTraceException {
         ITmfTrace trace = new JsonStubTrace();
         try {
@@ -88,9 +142,11 @@ public class JsonTraceTest {
             assertEquals(expectedNbEvents, trace.getNbEvents());
             assertEquals(startTime.toNanos(), trace.getStartTime().toNanos());
             assertEquals(endTime.toNanos(), trace.getEndTime().toNanos());
+            JsonElement expectedElement = gson.fromJson(metadata, JsonElement.class);
+            JsonElement actualElement = gson.fromJson(((JsonStubTrace) trace).fMetadata, JsonElement.class);
+            assertEquals(expectedElement, actualElement);
         } finally {
             trace.dispose();
         }
     }
-
 }

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/src/org/eclipse/tracecompass/jsontrace/core/tests/stub/JsonStubTrace.java
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/src/org/eclipse/tracecompass/jsontrace/core/tests/stub/JsonStubTrace.java
@@ -48,6 +48,10 @@ public class JsonStubTrace extends JsonTrace {
 
     private static final String TIMESTAMP_KEY = "timestamp"; //$NON-NLS-1$
     private Gson GSON = new Gson();
+    /**
+     * metadata string
+     */
+    public String fMetadata;
 
     @Override
     public void initTrace(IResource resource, String path, Class<? extends ITmfEvent> type) throws TmfTraceException {
@@ -80,11 +84,10 @@ public class JsonStubTrace extends JsonTrace {
 
     @Override
     public IStatus validate(IProject project, String path) {
-        // Slow, but meh, it's a unit test and this is more readable.
-        if (path.matches("traces/.*sortedTrace.json")) { //$NON-NLS-1$
+        if (path.matches("traces/*.json")) { //$NON-NLS-1$
             return new TraceValidationStatus(MAX_CONFIDENCE, "json.trace.stub"); //$NON-NLS-1$
         }
-        return Status.CANCEL_STATUS;
+        return Status.error("Test trace was not validated");
     }
 
     @Override

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/src/org/eclipse/tracecompass/jsontrace/core/tests/stub/JsonStubTraceSortingJob.java
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/src/org/eclipse/tracecompass/jsontrace/core/tests/stub/JsonStubTraceSortingJob.java
@@ -12,6 +12,7 @@
 package org.eclipse.tracecompass.jsontrace.core.tests.stub;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.eclipse.tracecompass.internal.jsontrace.core.job.SortingJob;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
@@ -32,7 +33,7 @@ public class JsonStubTraceSortingJob extends SortingJob {
      *            Trace path
      */
     public JsonStubTraceSortingJob(ITmfTrace trace, String path) {
-        super(trace, path, "\"timestamp\":", 1); //$NON-NLS-1$
+        super(trace, path, "\"timestamp\":", List.of("events")); //$NON-NLS-1$
     }
 
     @Override
@@ -40,4 +41,8 @@ public class JsonStubTraceSortingJob extends SortingJob {
         // No metadata to process
     }
 
+    @Override
+    protected void processMetadataJson(ITmfTrace trace, String metadata) {
+        ((JsonStubTrace) trace).fMetadata = metadata;
+    }
 }

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/traces/traceMetadataBegin.json
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/traces/traceMetadataBegin.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "source": "sensor-A",
+    "version": 1,
+    "generatedAt": "2025-10-23T12:00:00Z"
+  },
+  "events": [
+    {"timestamp": 1730000000000, "eventContent": {"description": "Event 0"}},
+    {"timestamp": 1730000001000, "eventContent": {"description": "Event 1"}},
+    {"timestamp": 1730000002000, "eventContent": {"description": "Event 2"}},
+    {"timestamp": 1730000003000, "eventContent": {"description": "Event 3"}},
+    {"timestamp": 1730000004000, "eventContent": {"description": "Event 4"}},
+	{"timestamp": 1730000005000, "eventContent": {"description": "Event 5"}}
+  ]
+}

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/traces/traceMetadataBeginEnd.json
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/traces/traceMetadataBeginEnd.json
@@ -1,0 +1,19 @@
+{
+  "metadataStart": {
+    "source": "sensor-A",
+    "version": 1,
+    "generatedAt": "2025-10-23T12:00:00Z"
+  },
+  "events": [
+    {"timestamp": 1730000000000, "eventContent": {"description": "Event 0"}},
+    {"timestamp": 1730000001000, "eventContent": {"description": "Event 1"}},
+    {"timestamp": 1730000002000, "eventContent": {"description": "Event 2"}},
+    {"timestamp": 1730000003000, "eventContent": {"description": "Event 3"}},
+    {"timestamp": 1730000004000, "eventContent": {"description": "Event 4"}}
+  ],
+  "metadataEnd": {
+    "checksum": "abc123",
+    "recordCount": 5,
+    "processedAt": "2025-10-23T12:05:00Z"
+  }
+}

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/traces/traceMetadataEnd.json
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/traces/traceMetadataEnd.json
@@ -1,0 +1,14 @@
+{
+  "events": [
+    {"timestamp": 1730000000000, "eventContent": {"description": "Event 0"}},
+    {"timestamp": 1730000001000, "eventContent": {"description": "Event 1"}},
+    {"timestamp": 1730000002000, "eventContent": {"description": "Event 2"}},
+    {"timestamp": 1730000003000, "eventContent": {"description": "Event 3"}},
+    {"timestamp": 1730000004000, "eventContent": {"description": "Event 4"}}
+  ],
+  "metadata": {
+    "source": "sensor-A",
+    "version": 1,
+    "generatedAt": "2025-10-23T12:00:00Z"
+  }
+}

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core/META-INF/MANIFEST.MF
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core/META-INF/MANIFEST.MF
@@ -16,5 +16,6 @@ Require-Bundle: org.eclipse.tracecompass.common.core,
 Export-Package: org.eclipse.tracecompass.internal.jsontrace.core;x-internal:=true,
  org.eclipse.tracecompass.internal.jsontrace.core.job;x-friends:="org.eclipse.tracecompass.jsontrace.core.tests",
  org.eclipse.tracecompass.internal.provisional.jsontrace.core.trace;x-friends:="org.eclipse.tracecompass.jsontrace.core.tests"
-Import-Package: org.eclipse.tracecompass.traceeventlogger
+Import-Package: com.fasterxml.jackson.core,
+ org.eclipse.tracecompass.traceeventlogger
 Bundle-Activator: org.eclipse.tracecompass.internal.jsontrace.core.Activator

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core/src/org/eclipse/tracecompass/internal/jsontrace/core/job/SortingJob.java
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core/src/org/eclipse/tracecompass/internal/jsontrace/core/job/SortingJob.java
@@ -19,6 +19,7 @@ import java.io.PrintWriter;
 import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -40,6 +41,10 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.traceeventlogger.LogUtils;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
 /**
  * On-disk sorting job. It splits a trace into tracelets. Each tracelet is
  * sorted in ram and written to disk, then the tracelets are merged into a big
@@ -54,6 +59,7 @@ public abstract class SortingJob extends Job {
     private static final int CHARS_PER_LINE_ESTIMATE = 50;
     private static final @NonNull Logger LOGGER = TraceCompassLog.getLogger(SortingJob.class);
     private static final int CHUNK_SIZE = 65535;
+    private static final int METADATA_MAX_SIZE = 10000000;
 
     private static final Comparator<PartiallyParsedEvent> EVENT_COMPARATOR = Comparator
             .comparing(PartiallyParsedEvent::getTs);
@@ -78,10 +84,11 @@ public abstract class SortingJob extends Job {
                     end = string.indexOf('}', index);
                 }
                 BigDecimal ts;
-                String number = string.substring(index, end).trim().replace("\"", "");
+                String number = string.substring(index, end).trim().replace("\"", ""); //$NON-NLS-1$ //$NON-NLS-2$
                 if (!number.isEmpty()) {
                     try {
-                        // This may be a bit slow, it can be optimized if need be.
+                        // This may be a bit slow, it can be optimized if need
+                        // be.
                         ts = new BigDecimal(number);
                     } catch (NumberFormatException e) {
                         // Cannot be parsed as a number, set to -1
@@ -102,6 +109,8 @@ public abstract class SortingJob extends Job {
     private final Integer fBracketsToSkip;
     private final String fTsKey;
     private final String fPath;
+    private final List<String> fPathToEvents;
+    private String fMetadata;
     private final ITmfTrace fTrace;
 
     /**
@@ -117,12 +126,36 @@ public abstract class SortingJob extends Job {
      * @param bracketsToSkip
      *            Number of bracket to skip
      */
-    public SortingJob(ITmfTrace trace, String path, String tsKey, int bracketsToSkip) {
+    protected SortingJob(ITmfTrace trace, String path, String tsKey, int bracketsToSkip) {
         super(Messages.SortingJob_description);
         fTrace = trace;
         fPath = path;
         fTsKey = tsKey;
         fBracketsToSkip = bracketsToSkip;
+        fPathToEvents = Collections.emptyList();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param trace
+     *            Trace to sort
+     * @param path
+     *            Trace path
+     * @param tsKey
+     *            Timestamp key, represent the json object key. The value
+     *            associated to this key is the timestamp that will be use to
+     *            sort
+     * @param pathToEvents
+     *            Json key path indicating the events
+     */
+    protected SortingJob(ITmfTrace trace, String path, String tsKey, List<String> pathToEvents) {
+        super(Messages.SortingJob_description);
+        fTrace = trace;
+        fPath = path;
+        fTsKey = tsKey;
+        fBracketsToSkip = -1;
+        fPathToEvents = pathToEvents;
     }
 
     /**
@@ -137,137 +170,40 @@ public abstract class SortingJob extends Job {
     @Override
     protected IStatus run(IProgressMonitor monitor) {
         ITmfTrace trace = fTrace;
+
         IProgressMonitor subMonitor = SubMonitor.convert(monitor, 3);
         if (trace == null) {
             return new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Trace cannot be null"); //$NON-NLS-1$
         }
         String dir = TmfTraceManager.getSupplementaryFileDir(trace);
+
         subMonitor.beginTask(Messages.SortingJob_sorting, (int) (new File(fPath).length() / CHARS_PER_LINE_ESTIMATE));
         subMonitor.subTask(Messages.SortingJob_splitting);
         File tempDir = new File(dir + ".tmp"); //$NON-NLS-1$
         tempDir.mkdirs();
         List<File> tracelings = new ArrayList<>();
         try (BufferedInputStream parser = new BufferedInputStream(new FileInputStream(fPath))) {
-            int data = 0;
-            for (int nbBracket = 0; nbBracket < fBracketsToSkip; nbBracket++) {
-                data = parser.read();
-                while (data != '[') {
-                    data = parser.read();
-                    if (data == -1) {
-                        return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
-                                "Missing symbol \'[\' or \']\' in " + fPath); //$NON-NLS-1$
-                    }
-                }
+            IStatus status = goToEventArray(parser, subMonitor);
+            if (status != null) {
+                return status;
             }
-            List<PartiallyParsedEvent> events = new ArrayList<>(CHUNK_SIZE);
-            String eventString = JsonTrace.readNextEventString(parser::read);
-            if (eventString == null) {
-                return new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Empty event in " + fPath); //$NON-NLS-1$
+            // Split events into chunk and sort them
+            status = splitTrace(parser, subMonitor, tempDir, tracelings);
+            if (status != null) {
+                return status;
             }
-            PartiallyParsedEvent line = new PartiallyParsedEvent(fTsKey, eventString, 0);
-            line.fLine = data + '"' + line.fLine;
-            int cnt = 0;
-            int filen = 0;
-            while (eventString != null) {
-                while (cnt < CHUNK_SIZE) {
-                    events.add(line);
-                    subMonitor.worked(1);
-                    if (subMonitor.isCanceled()) {
-                        return Status.CANCEL_STATUS;
-                    }
-                    eventString = JsonTrace.readNextEventString(parser::read);
-                    if (eventString == null) {
-                        break;
-                    }
-                    line = new PartiallyParsedEvent(fTsKey, eventString, 0);
-                    cnt++;
-                }
-                events.sort(EVENT_COMPARATOR);
-                cnt = 0;
-                File traceling = new File(tempDir + File.separator + "test" + filen + ".json"); //$NON-NLS-1$ //$NON-NLS-2$
-                tracelings.add(traceling);
-                boolean success = traceling.createNewFile();
-                if (!success) {
-                    return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
-                            "Could not create partial file " + traceling.getAbsolutePath()); //$NON-NLS-1$
-                }
-                try (PrintWriter fs = new PrintWriter(traceling)) {
-                    fs.println(OPEN_BRACKET);
-                    for (PartiallyParsedEvent sortedEvent : events) {
-                        fs.println(sortedEvent.fLine + ',');
-                    }
-                    fs.println(CLOSE_BRACKET);
-                }
-                events.clear();
-                filen++;
-                subMonitor.worked(1);
-                if (subMonitor.isCanceled()) {
-                    return Status.CANCEL_STATUS;
-                }
-
-            }
-            subMonitor.subTask(Messages.SortingJob_merging);
-            PriorityQueue<PartiallyParsedEvent> evs = new PriorityQueue<>(EVENT_COMPARATOR);
-            List<BufferedInputStream> parsers = new ArrayList<>();
-            int i = 0;
-            for (File traceling : tracelings) {
-
-                /*
-                 * This resource is added to a priority queue and then removed at the very end.
-                 */
-                BufferedInputStream createParser = new BufferedInputStream(new FileInputStream(traceling));
-                while (data != '[') {
-                    data = createParser.read();
-                    if (data == -1) {
-                        break;
-                    }
-                }
-                eventString = JsonTrace.readNextEventString(createParser::read);
-                PartiallyParsedEvent parse = new PartiallyParsedEvent(fTsKey, eventString, i);
-                evs.add(parse);
-                i++;
-                parsers.add(createParser);
-                subMonitor.worked(1);
-                if (subMonitor.isCanceled()) {
-                    break;
-                }
-            }
-            if (subMonitor.isCanceled()) {
-                return Status.CANCEL_STATUS;
-            }
-
-            processMetadata(trace, dir, parser);
-
-            File file = new File(dir + File.separator + new File(trace.getPath()).getName());
-            boolean success = file.createNewFile();
+            // Merge all the chunks and write all the events into another file
+            File resultTrace = new File(dir + File.separator + new File(trace.getPath()).getName());
+            boolean success = resultTrace.createNewFile();
             if (!success) {
                 return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
-                        "Could not create file " + file.getAbsolutePath()); //$NON-NLS-1$
+                        "Could not create file " + resultTrace.getAbsolutePath()); //$NON-NLS-1$
             }
-            try (PrintWriter tempWriter = new PrintWriter(file)) {
-                tempWriter.println('[');
-                while (!evs.isEmpty()) {
-                    PartiallyParsedEvent sortedEvent = evs.poll();
-                    if (sortedEvent == null) {
-                        break;
-                    }
-                    PartiallyParsedEvent parse = readNextEvent(parsers.get(sortedEvent.fPos), fTsKey, sortedEvent.fPos);
-                    if (parse != null) {
-                        tempWriter.println(sortedEvent.fLine.trim() + ',');
-                        evs.add(parse);
-                    } else {
-                        tempWriter.println(sortedEvent.fLine.trim() + (evs.isEmpty() ? "" : ',')); //$NON-NLS-1$
-                    }
-                    subMonitor.worked(1);
-                    if (subMonitor.isCanceled()) {
-                        return Status.CANCEL_STATUS;
-                    }
-                }
-                tempWriter.println(']');
+            if (!fPathToEvents.isEmpty()) {
+                fMetadata = fMetadata + new String(parser.readNBytes(METADATA_MAX_SIZE), java.nio.charset.StandardCharsets.UTF_8);
             }
-            for (BufferedInputStream tmpParser : parsers) {
-                tmpParser.close();
-            }
+            processMetadata(trace, dir, parser);
+            return mergeChunks(subMonitor, tracelings, resultTrace);
         } catch (IOException e) {
             LogUtils.traceInstant(LOGGER, Level.WARNING, "IOException in sorting job", "trace", fPath, //$NON-NLS-1$ //$NON-NLS-2$
                     "exception", e); //$NON-NLS-1$
@@ -281,11 +217,176 @@ public abstract class SortingJob extends Job {
             } catch (IOException e) {
                 Activator.getInstance().logError(e.getMessage(), e);
             }
-
             subMonitor.done();
         }
-        return Status.OK_STATUS;
+    }
 
+    private IStatus goToEventArray(BufferedInputStream parser, IProgressMonitor monitor) throws IOException {
+        // TODO: When the constructor is removed, remove this condition
+        if (fBracketsToSkip >= 0) {
+            return goToEventArrayBracket(parser);
+        }
+        if (!fPathToEvents.isEmpty()) {
+            return goToEventArrayPath(parser, monitor);
+        }
+        return null;
+    }
+
+    private IStatus goToEventArrayBracket(BufferedInputStream parser) throws IOException {
+        int data = 0;
+        for (int nbBracket = 0; nbBracket < fBracketsToSkip; nbBracket++) {
+            data = parser.read();
+            while (data != '[') {
+                data = parser.read();
+                if (data == -1) {
+                    return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
+                            "Missing symbol \'[\' or \']\' in " + fPath); //$NON-NLS-1$
+                }
+            }
+        }
+        return null;
+    }
+
+    private IStatus goToEventArrayPath(BufferedInputStream parser, IProgressMonitor monitor) throws IOException {
+        JsonFactory factory = new JsonFactory();
+        long byteOffset = 0;
+        try(JsonParser jsonParser = factory.createParser(new File(fPath))) {
+            int depth = 0;
+            while (!jsonParser.isClosed() && jsonParser.currentLocation().getByteOffset() < METADATA_MAX_SIZE) {
+                if (monitor.isCanceled()) {
+                    return Status.CANCEL_STATUS;
+                }
+                JsonToken token = jsonParser.nextToken();
+                if (token == JsonToken.FIELD_NAME) {
+                    String fieldName = jsonParser.currentName();
+                    if (fieldName.equals(fPathToEvents.get(depth))) {
+                        depth += 1;
+                        if (depth == fPathToEvents.size()) {
+                            break;
+                        }
+                    }
+                    jsonParser.nextToken();
+                }
+            }
+            byteOffset = jsonParser.currentLocation().getByteOffset();
+        }
+        fMetadata = new String(parser.readNBytes((int) byteOffset), java.nio.charset.StandardCharsets.UTF_8) + "]"; //$NON-NLS-1$
+        return null;
+    }
+
+    private IStatus splitTrace(BufferedInputStream parser, IProgressMonitor monitor, File tempDirectory, List<File> tracelings) throws IOException {
+        int data = 0;
+        List<PartiallyParsedEvent> events = new ArrayList<>(CHUNK_SIZE);
+        String eventString = JsonTrace.readNextEventString(parser::read);
+        if (eventString == null) {
+            return new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Empty event in " + fPath); //$NON-NLS-1$
+        }
+        PartiallyParsedEvent line = new PartiallyParsedEvent(fTsKey, eventString, 0);
+        line.fLine = data + '"' + line.fLine;
+        int cnt = 0;
+        int filen = 0;
+        while (eventString != null) {
+            while (cnt < CHUNK_SIZE) {
+                events.add(line);
+                monitor.worked(1);
+                if (monitor.isCanceled()) {
+                    return Status.CANCEL_STATUS;
+                }
+                eventString = JsonTrace.readNextEventString(parser::read);
+                if (eventString == null) {
+                    break;
+                }
+                line = new PartiallyParsedEvent(fTsKey, eventString, 0);
+                cnt++;
+            }
+            events.sort(EVENT_COMPARATOR);
+            cnt = 0;
+            File traceling = new File(tempDirectory + File.separator + "test" + filen + ".json"); //$NON-NLS-1$ //$NON-NLS-2$
+            tracelings.add(traceling);
+            boolean success = traceling.createNewFile();
+            if (!success) {
+                return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
+                        "Could not create partial file " + traceling.getAbsolutePath()); //$NON-NLS-1$
+            }
+            try (PrintWriter fs = new PrintWriter(traceling)) {
+                fs.println(OPEN_BRACKET);
+                for (PartiallyParsedEvent sortedEvent : events) {
+                    fs.println(sortedEvent.fLine + ',');
+                }
+                fs.println(CLOSE_BRACKET);
+            }
+            events.clear();
+            filen++;
+            monitor.worked(1);
+            if (monitor.isCanceled()) {
+                return Status.CANCEL_STATUS;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("resource")
+    private IStatus mergeChunks(IProgressMonitor monitor, List<File> tracelings, File resultTrace) throws IOException {
+        monitor.subTask(Messages.SortingJob_merging);
+        PriorityQueue<PartiallyParsedEvent> evs = new PriorityQueue<>(EVENT_COMPARATOR);
+        List<BufferedInputStream> parsers = new ArrayList<>();
+        int i = 0;
+        int data = 0;
+        try {
+            // Initialize parsers
+            for (File traceling : tracelings) {
+                /*
+                 * This resource is added to a priority queue and then removed
+                 * in the finally clause.
+                 */
+                BufferedInputStream createParser = new BufferedInputStream(new FileInputStream(traceling));
+                parsers.add(createParser);
+                while (data != '[') {
+                    data = createParser.read();
+                    if (data == -1) {
+                        break;
+                    }
+                }
+                String eventString = JsonTrace.readNextEventString(createParser::read);
+                PartiallyParsedEvent parse = new PartiallyParsedEvent(fTsKey, eventString, i);
+                evs.add(parse);
+                i++;
+                monitor.worked(1);
+                if (monitor.isCanceled()) {
+                    break;
+                }
+            }
+            if (monitor.isCanceled()) {
+                return Status.CANCEL_STATUS;
+            }
+            // Write the resulting trace
+            try (PrintWriter tempWriter = new PrintWriter(resultTrace)) {
+                tempWriter.println('[');
+                while (!evs.isEmpty()) {
+                    PartiallyParsedEvent sortedEvent = evs.poll();
+                    if (sortedEvent == null) {
+                        break;
+                    }
+                    PartiallyParsedEvent parse = readNextEvent(parsers.get(sortedEvent.fPos), fTsKey, sortedEvent.fPos);
+                    if (parse != null) {
+                        tempWriter.println(sortedEvent.fLine.trim() + ',');
+                        evs.add(parse);
+                    } else {
+                        tempWriter.println(sortedEvent.fLine.trim() + (evs.isEmpty() ? "" : ',')); //$NON-NLS-1$
+                    }
+                    monitor.worked(1);
+                    if (monitor.isCanceled()) {
+                        return Status.CANCEL_STATUS;
+                    }
+                }
+                tempWriter.println(']');
+            }
+        } finally {
+            for (BufferedInputStream tmpParser : parsers) {
+                tmpParser.close();
+            }
+        }
+        return Status.OK_STATUS;
     }
 
     /**
@@ -303,6 +404,20 @@ public abstract class SortingJob extends Job {
      */
     protected void processMetadata(ITmfTrace trace, String dir, BufferedInputStream parser) throws IOException {
         this.processMetadata(trace, dir);
+        this.processMetadataJson(trace, fMetadata);
+    }
+
+    /**
+     * Process whatever metadata that can be found after the event list in the
+     * trace file file
+     *
+     * @param trace
+     *            the trace to be sort
+     * @param metadata
+     *            the string containing everything except all the events
+     */
+    protected void processMetadataJson(ITmfTrace trace, String metadata) {
+        // do nothing
     }
 
     /**
@@ -322,6 +437,5 @@ public abstract class SortingJob extends Job {
             throws IOException {
         String event = JsonTrace.readNextEventString(parser::read);
         return event == null ? null : new PartiallyParsedEvent(key, event, i);
-
     }
 }

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -445,4 +445,8 @@
          id="org.eclipse.tracecompass.trace-event-logger"
          version="0.0.0"/>
 
+   <plugin
+         id="com.fasterxml.jackson.core.jackson-core"
+         version="0.0.0"/>
+
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/pom.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/pom.xml
@@ -87,6 +87,7 @@
                 <plugin id="org.sat4j.pb"/>
                 <plugin id="com.google.gson"/>
                 <plugin id="com.google.guava"/>
+                <plugin id="com.fasterxml.jackson.core.jackson-core"/>
                 <plugin id="org.apache.commons.io"/>
                 <plugin id="org.eclipse.e4.ui.progress"/>
                 <plugin id="org.eclipse.jdt.core"/>

--- a/rcp/org.eclipse.tracecompass.rcp/staging/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/staging/feature.xml
@@ -445,4 +445,8 @@
          id="org.eclipse.tracecompass.trace-event-logger"
          version="0.0.0"/>
 
+   <plugin
+         id="com.fasterxml.jackson.core.jackson-core"
+         version="0.0.0"/>
+
 </feature>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.37.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.37.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.37" sequenceNumber="4">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.37" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -49,6 +49,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.38.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.38.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.38" sequenceNumber="1">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.38" sequenceNumber="2">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.8/"/>
@@ -48,6 +48,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="260">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="261">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.8/"/>
@@ -48,6 +48,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
### What it does

Refactor sorting job, previous implementation was using heuristics to skip to the events. Now everything apart from the events is extracted and treated as metadata using a json path. This fixes #196 where some metadata was put before the events.

New tests were added, json trace test files were generated using OpenAI gpt-5.

### How to test

Currently no trace types uses it, but modifying the trace type implementation to use the sorting job constructor with pathToEvents will use the included feature.

Example using opentracing in OpenTracingSortingJob constructor:

```java
    public OpenTracingSortingJob(ITmfTrace trace, String path) {
        super(trace, path, "\"startTime\":", List.of("data", "spans")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
    }
```

### Follow-ups

Some changes will be added to incubator trace types including openTracing and TraceEvent

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
