### PR TITLE
ctf: improve scope creation

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/scope/LexicalScope.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/scope/LexicalScope.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.tracecompass.ctf.core.event.scope;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -28,7 +28,7 @@ public class LexicalScope implements ILexicalScope {
     private int hash = 0;
     private final @NonNull String fName;
     private final @NonNull String fPath;
-    private final Map<String, ILexicalScope> fChildren = new ConcurrentHashMap<>();
+    private final Map<String, ILexicalScope> fChildren = new HashMap<>();
 
     /**
      * Hidden constructor for the root node only
@@ -38,6 +38,22 @@ public class LexicalScope implements ILexicalScope {
     protected LexicalScope() {
         fPath = ""; //$NON-NLS-1$
         fName = ""; //$NON-NLS-1$
+    }
+
+    /**
+     * Create a scope
+     * @param parent
+     *            The parent node, can be null, but shouldn't
+     * @param name
+     *            the name of the field
+     * @return the scope
+     */
+    public static @NonNull ILexicalScope create(ILexicalScope parent, @NonNull String name) {
+        ILexicalScope child = parent.getChild(name);
+        if( child == null) {
+            child = new LexicalScope(parent, name);
+        }
+        return child;
     }
 
     /**

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/Declaration.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/Declaration.java
@@ -43,18 +43,10 @@ public abstract class Declaration implements IDeclaration {
         if (definitionScope != null) {
             final ILexicalScope parentPath = definitionScope.getScopePath();
             if (parentPath != null) {
-                ILexicalScope myScope = parentPath.getChild(fieldName);
-                if (myScope == null) {
-                    myScope = new LexicalScope(parentPath, fieldName);
-                }
-                return myScope;
+                return LexicalScope.create(parentPath, fieldName);
             }
         }
-        ILexicalScope child = ILexicalScope.ROOT.getChild(fieldName);
-        if (child != null) {
-            return child;
-        }
-        return new LexicalScope(ILexicalScope.ROOT, fieldName);
+        return LexicalScope.create(ILexicalScope.ROOT, fieldName);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Speeds up trace reading by ~5-10%. The concurrent hashmap was used to avoid contention. But the data inputted is stable. The data is first written, then read, never both at the same time. A will always produce B. So we can use a normal hashmap. Streaming CTF live would still read all the metadata and pause the trace reading when the metadata is updated. The lock is implicit.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Open a trace with enums that are wide (1000 keys).
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
