### PR TITLE
ctf: improve error message for UUID missmatch

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFStreamInput.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFStreamInput.java
@@ -299,7 +299,7 @@ public class CTFStreamInput implements IDefinitionScope {
          * create a packet bit buffer to read the packet header
          */
         int maximumSize = fStreamPacketContextDecl.getMaximumSize() + fTracePacketHeaderDecl.getMaximumSize();
-        BitBuffer bitBuffer = new BitBuffer(createPacketBitBuffer(fc, dataOffsetbits/Byte.SIZE, maximumSize));
+        BitBuffer bitBuffer = new BitBuffer(createPacketBitBuffer(fc, dataOffsetbits / Byte.SIZE, maximumSize));
         bitBuffer.setByteOrder(getStream().getTrace().getByteOrder());
         return bitBuffer;
     }
@@ -372,7 +372,13 @@ public class CTFStreamInput implements IDefinitionScope {
         }
         if (!Objects.equals(getStream().getTrace().getUUID(), uuid) && !fUUIDMismatchWarning) {
             fUUIDMismatchWarning = true;
-            CtfCoreLoggerUtil.logWarning("Reading CTF trace: UUID mismatch for trace " + getStream().getTrace()); //$NON-NLS-1$
+            CtfCoreLoggerUtil.logWarning(String.format(
+                    "Reading CTF trace stream %d: UUID mismatch for trace %s.\nMetadata UUID: %s, Stream UUID: %s", //$NON-NLS-1$
+                    getStream().getId(),
+                    getStream().getTrace(),
+                    getStream().getTrace().getUUID(),
+                    uuid
+                ));
         }
         if (streamIDDef != null) {
             long streamID = streamIDDef.getValue();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

If someone is making a hand-made metadata or modifying a trace, if the UUID doesn't match, show both UUIDs so the developer can fix it.

Before:

```
Reading CTF trace: UUID mismatch for trace CTFTrace [path=/path/to/trace, major=1, minor=1, uuid=123e4567-e89b-12d3-a456-426614174000].
```

The output error is now:

```
Reading CTF trace stream 1: UUID mismatch for trace CTFTrace [path=/path/to/trace, major=1, minor=1, uuid=123e4567-e89b-12d3-a456-426614174000].
Metadata UUID: 123e4567-e89b-12d3-a456-426614174000, Stream UUID: 789e4567-e89b-12d3-a456-426614174001
```

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Take a ctf trace, and change the UUID in the metadata, the error message will be better.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
