### PR TITLE
Add segment store data density provider

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreDensityDataProviderTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/src/org/eclipse/tracecompass/analysis/timing/core/tests/segmentstore/SegmentStoreDensityDataProviderTest.java
@@ -10,25 +10,29 @@
  **********************************************************************/
 package org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.analysis.timing.core.tests.stubs.segmentstore.StubSegmentStoreProvider;
 import org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider;
-import org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProviderFactory;
 import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
-import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderParameterUtils;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
-import org.eclipse.tracecompass.tmf.core.model.SeriesModel;
 import org.eclipse.tracecompass.tmf.core.model.filters.TimeQueryFilter;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.ISeriesModel;
 import org.eclipse.tracecompass.tmf.core.model.xy.ITmfTreeXYDataProvider;
 import org.eclipse.tracecompass.tmf.core.model.xy.ITmfXyModel;
+import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.tests.stubs.trace.xml.TmfXmlTraceStub;
@@ -49,34 +53,6 @@ public class SegmentStoreDensityDataProviderTest {
 
     @NonNull
     private static final TmfXmlTraceStub fTrace = new TmfXmlTraceStubNs();
-    private static final double[] yValues = new double[] { 15.0, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 15.0, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 15.0,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 15.0, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 15.0, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 15.0, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 15.0, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324 };
-    private static final long[] xValues = new long[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
-            5, 5, 5 };
-    private static final long[] xValuesNull = new long[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0 };
-    private static final double[] yValuesNull = new double[] { 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324,
-            4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324, 4.9E-324 };
     private static final String ID = "org.eclipse.tracecompass.analysis.timing.core.tests.segmentstore";
 
     /**
@@ -88,16 +64,9 @@ public class SegmentStoreDensityDataProviderTest {
     @BeforeClass
     public static void init() throws TmfAnalysisException {
         StubSegmentStoreProvider fixture = getValidSegment(fTrace);
-        IDataProviderFactory fp = new SegmentStoreDensityDataProviderFactory();
-        assertNull(fp.createProvider(fTrace));
-        assertNotNull(fp.createProvider(fTrace, ID));
-        assertTrue(fp.getDescriptors(fTrace).isEmpty());
         fDataProvider = new SegmentStoreDensityDataProvider(fTrace, fixture, ID);
+
         StubSegmentStoreProvider fixtureNull = getValidNullSegment(fTrace);
-        IDataProviderFactory fpNullSegment = new SegmentStoreDensityDataProviderFactory();
-        assertNull(fpNullSegment.createProvider(fTrace));
-        assertNotNull(fpNullSegment.createProvider(fTrace, ID));
-        assertTrue(fpNullSegment.getDescriptors(fTrace).isEmpty());
         fDataProviderNullSegments = new SegmentStoreDensityDataProvider(fTrace, fixtureNull, ID);
     }
 
@@ -126,43 +95,111 @@ public class SegmentStoreDensityDataProviderTest {
     }
 
     /**
-     * Tests data model returned by the fetch XY
+     * Tests successful TmfXyResponseFactory.create() call
      */
-    @Test()
-    public void testDataProviderFetchXY() {
-        TimeQueryFilter timeQueryFilter = new TimeQueryFilter(0, 100, 100);
-        TmfModelResponse<@NonNull ITmfXyModel> response = fDataProvider.fetchXY(FetchParametersUtils.timeQueryToMap(timeQueryFilter), null);
+    @Test
+    public void testSuccessfulFetchXY() {
+        TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> treeResponse = fDataProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 100, 100)), null);
+        assertNotNull(treeResponse);
+        TmfTreeModel<@NonNull TmfTreeDataModel> treeModel = treeResponse.getModel();
+        assertNotNull(treeModel);
+
+        List<Long> itemIds = treeModel.getEntries().stream().map(TmfTreeDataModel::getId).collect(Collectors.toList());
+
+        Map<String, Object> fetchParameters = new HashMap<>();
+        fetchParameters.put(DataProviderParameterUtils.REQUESTED_TIMERANGE_KEY, Arrays.asList(1000L, 5000L, 100L));
+        fetchParameters.put(DataProviderParameterUtils.REQUESTED_ITEMS_KEY, itemIds);
+
+        TmfModelResponse<@NonNull ITmfXyModel> response = fDataProvider.fetchXY(fetchParameters, null);
         assertNotNull(response);
+        assertEquals(ITmfResponse.Status.COMPLETED, response.getStatus());
+
         ITmfXyModel responseModel = response.getModel();
         assertNotNull(responseModel);
-        SeriesModel seriesResponse = (SeriesModel) responseModel.getSeriesData().toArray()[0];
-        assertTrue(Arrays.equals(yValues, seriesResponse.getData()));
-        assertTrue(Arrays.equals(xValues, seriesResponse.getXAxis()));
+        assertNotNull(responseModel.getSeriesData());
+
+        if (!responseModel.getSeriesData().isEmpty()) {
+            ISeriesModel seriesModel = responseModel.getSeriesData().iterator().next();
+            assertNotNull(seriesModel);
+            assertNotNull(seriesModel.getData());
+            assertEquals(100, seriesModel.getData().length);
+            assertEquals(ISeriesModel.DisplayType.BAR, seriesModel.getDisplayType());
+        }
     }
 
     /**
-     * Tests data model returned by the fetch XY
+     * Tests TmfXyResponseFactory.createFailedResponse() for null filter
      */
-    @Test()
-    public void testDataProviderNullFetchXY() {
-        TimeQueryFilter timeQueryFilter = new TimeQueryFilter(0, 100, 100);
-        TmfModelResponse<@NonNull ITmfXyModel> response = fDataProviderNullSegments.fetchXY(FetchParametersUtils.timeQueryToMap(timeQueryFilter), null);
+    @Test
+    public void testFailedResponseNullFilter() {
+        Map<String, Object> emptyParameters = new HashMap<>();
+
+        TmfModelResponse<@NonNull ITmfXyModel> response = fDataProvider.fetchXY(emptyParameters, null);
         assertNotNull(response);
-        ITmfXyModel responseModel = response.getModel();
-        assertNotNull(responseModel);
-        SeriesModel seriesResponse = (SeriesModel) responseModel.getSeriesData().toArray()[0];
-        assertTrue(Arrays.equals(yValuesNull, seriesResponse.getData()));
-        assertTrue(Arrays.equals(xValuesNull, seriesResponse.getXAxis()));
+        assertEquals(ITmfResponse.Status.FAILED, response.getStatus());
     }
 
     /**
-     * Tests fetch tree of the data provider
+     * Tests TmfXyResponseFactory.createCancelledResponse() for cancelled monitor
      */
-    @Test()
+    @Test
+    public void testCancelledResponseMonitor() {
+        TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> treeResponse = fDataProvider.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 100, 100)), null);
+        assertNotNull(treeResponse);
+        TmfTreeModel<@NonNull TmfTreeDataModel> treeModel = treeResponse.getModel();
+        assertNotNull(treeModel);
+
+        List<Long> itemIds = treeModel.getEntries().stream().map(TmfTreeDataModel::getId).collect(Collectors.toList());
+
+        Map<String, Object> fetchParameters = new HashMap<>();
+        fetchParameters.put(DataProviderParameterUtils.REQUESTED_TIMERANGE_KEY, Arrays.asList(1000L, 5000L, 100L));
+        fetchParameters.put(DataProviderParameterUtils.REQUESTED_ITEMS_KEY, itemIds);
+
+        NullProgressMonitor cancelledMonitor = new NullProgressMonitor();
+        cancelledMonitor.setCanceled(true);
+
+        TmfModelResponse<@NonNull ITmfXyModel> response = fDataProvider.fetchXY(fetchParameters, cancelledMonitor);
+        assertNotNull(response);
+        assertEquals(ITmfResponse.Status.CANCELLED, response.getStatus());
+    }
+
+    /**
+     * Tests null segments provider
+     */
+    @Test
+    public void testNullSegmentsProvider() {
+        TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> treeResponse = fDataProviderNullSegments.fetchTree(FetchParametersUtils.timeQueryToMap(new TimeQueryFilter(0, 100, 100)), null);
+        assertNotNull(treeResponse);
+        TmfTreeModel<@NonNull TmfTreeDataModel> treeModel = treeResponse.getModel();
+        assertNotNull(treeModel);
+
+        List<Long> itemIds = treeModel.getEntries().stream().map(TmfTreeDataModel::getId).collect(Collectors.toList());
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(DataProviderParameterUtils.REQUESTED_TIMERANGE_KEY, Arrays.asList(1000L, 5000L, 100L));
+        parameters.put(DataProviderParameterUtils.REQUESTED_ITEMS_KEY, itemIds);
+
+        TmfModelResponse<@NonNull ITmfXyModel> response = fDataProviderNullSegments.fetchXY(parameters, null);
+        assertNotNull(response);
+
+        ITmfXyModel responseModel = response.getModel();
+        if (responseModel != null && !responseModel.getSeriesData().isEmpty()) {
+            ISeriesModel seriesModel = responseModel.getSeriesData().iterator().next();
+            assertNotNull(seriesModel);
+            assertNotNull(seriesModel.getData());
+            assertEquals(100, seriesModel.getData().length);
+        }
+    }
+
+    /**
+     * Tests fetch tree
+     */
+    @Test
     public void testFetchTree() {
         TimeQueryFilter timeQueryFilter = new TimeQueryFilter(0, 100, 100);
         TmfModelResponse<@NonNull TmfTreeModel<@NonNull TmfTreeDataModel>> response = fDataProvider.fetchTree(FetchParametersUtils.timeQueryToMap(timeQueryFilter), null);
         assertNotNull(response);
+        assertEquals(ITmfResponse.Status.COMPLETED, response.getStatus());
     }
 
     /**
@@ -170,6 +207,7 @@ public class SegmentStoreDensityDataProviderTest {
      */
     @Test
     public void testID() {
-        assertTrue(fDataProvider.getId().equals(ID));
+        String expectedId = SegmentStoreDensityDataProvider.ID + ":" + ID;
+        assertEquals(expectedId, fDataProvider.getId());
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/Messages.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/Messages.java
@@ -153,6 +153,11 @@ public class Messages extends NLS {
     public static @Nullable String SegmentStoreDensityDataProvider_title;
 
     /**
+     * Segment store density description
+     */
+    public static @Nullable String SegmentStoreDensityDataProvider_description;
+
+    /**
      * Segment store density total
      */
     public static @Nullable String SegmentStoreDensity_TotalLabel;

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreDensityDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreDensityDataProvider.java
@@ -11,38 +11,60 @@
 
 package org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.analysis.timing.core.segmentstore.IGroupingSegmentAspect;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.ISegmentStoreProvider;
 import org.eclipse.tracecompass.internal.tmf.core.model.TmfXyResponseFactory;
 import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
 import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
+import org.eclipse.tracecompass.segmentstore.core.segment.interfaces.INamedSegment;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.component.DataProviderConstants;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.AbstractTmfTraceDataProvider;
 import org.eclipse.tracecompass.tmf.core.model.CommonStatusMessage;
+import org.eclipse.tracecompass.tmf.core.model.ISampling;
 import org.eclipse.tracecompass.tmf.core.model.YModel;
+import org.eclipse.tracecompass.tmf.core.model.filters.SelectionTimeQueryFilter;
 import org.eclipse.tracecompass.tmf.core.model.filters.TimeQueryFilter;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataProvider;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.ISeriesModel.DisplayType;
 import org.eclipse.tracecompass.tmf.core.model.xy.ITmfTreeXYDataProvider;
 import org.eclipse.tracecompass.tmf.core.model.xy.ITmfXyModel;
 import org.eclipse.tracecompass.tmf.core.model.xy.IYModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfXYAxisDescription;
 import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
+import org.eclipse.tracecompass.tmf.core.response.ITmfResponse.Status;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
-
-import com.google.common.collect.ImmutableList;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.eclipse.tracecompass.tmf.core.util.Pair;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 /**
  * This data provider will return an XY model based on a query filter. The model
@@ -58,12 +80,14 @@ public class SegmentStoreDensityDataProvider extends AbstractTmfTraceDataProvide
      */
     public static final String ID = "org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider"; //$NON-NLS-1$
     private static final AtomicLong TRACE_IDS = new AtomicLong();
+    private static final String GROUP_PREFIX = "group"; //$NON-NLS-1$
 
     private final String fID;
-    private final String title = Objects.requireNonNull(Messages.SegmentStoreDensityDataProvider_title);
     private final ISegmentStoreProvider fProvider;
     private final long fTotalId = TRACE_IDS.getAndIncrement();
     private final long fTraceId = TRACE_IDS.getAndIncrement();
+    private Iterable<IGroupingSegmentAspect> fGroupingAspects;
+    private final BiMap<Long, String> fIdToType = HashBiMap.create();
 
     /**
      * Constructor
@@ -78,86 +102,307 @@ public class SegmentStoreDensityDataProvider extends AbstractTmfTraceDataProvide
     public SegmentStoreDensityDataProvider(ITmfTrace trace, ISegmentStoreProvider provider, String id) {
         super(trace);
         fProvider = provider;
-        fID = id;
-        if (provider instanceof IAnalysisModule) {
-            ((IAnalysisModule) provider).waitForCompletion();
-        }
+        fGroupingAspects = Iterables.filter(provider.getSegmentAspects(), IGroupingSegmentAspect.class);
+        fID = ID + DataProviderConstants.ID_SEPARATOR + id;
     }
 
     @Override
     public TmfModelResponse<ITmfXyModel> fetchXY(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
-        ISegmentStore<ISegment> segmentStore = fProvider.getSegmentStore();
-        if (segmentStore == null) {
-            return TmfXyResponseFactory.createFailedResponse(Objects.requireNonNull(Messages.SegmentStoreDataProvider_SegmentNotAvailable));
+        SelectionTimeQueryFilter filter = FetchParametersUtils.createSelectionTimeQueryWithSamples(fetchParameters);
+        if (filter == null) {
+            return TmfXyResponseFactory.createFailedResponse(CommonStatusMessage.INCORRECT_QUERY_PARAMETERS);
         }
-        TimeQueryFilter queryFilter = FetchParametersUtils.createSelectionTimeQuery(fetchParameters);
-        if (queryFilter == null) {
-            queryFilter = FetchParametersUtils.createTimeQuery(fetchParameters);
-            if (queryFilter == null) {
-                return TmfXyResponseFactory.createFailedResponse(CommonStatusMessage.INCORRECT_QUERY_PARAMETERS);
-            }
-        }
-        return getXyData(segmentStore, queryFilter);
-    }
-
-    private TmfModelResponse<ITmfXyModel> getXyData(ISegmentStore<ISegment> segmentStore, TimeQueryFilter queryFilter) {
-        long startTraceTime = queryFilter.getStart();
-        long endTraceTime = queryFilter.getEnd();
-        int width = queryFilter.getTimesRequested().length;
-        Iterable<ISegment> displayData = segmentStore.getIntersectingElements(startTraceTime, endTraceTime);
 
         IAnalysisModule module = (fProvider instanceof IAnalysisModule) ? (IAnalysisModule) fProvider : null;
-        boolean complete = module != null && module.isQueryable(queryFilter.getEnd());
-
-        Optional<ISegment> maxSegment = StreamSupport.stream(displayData.spliterator(), false).max(SegmentComparators.INTERVAL_LENGTH_COMPARATOR);
-        long maxLength = 1;
-        if (maxSegment.isPresent()) {
-            maxLength = maxSegment.get().getLength();
-        }
-
-        double[] yValues = getYValues(displayData, width, maxLength);
-        long[] xValues = getXValues(width, maxLength);
-        ImmutableList.Builder<IYModel> builder = ImmutableList.builder();
-        String totalName = getTrace().getName() + '/' + Messages.SegmentStoreDensity_TotalLabel;
-        builder.add(new YModel(fTotalId, totalName, yValues));
-        return TmfXyResponseFactory.create(title, xValues, builder.build(), complete);
-    }
-
-    private static long[] getXValues(int width, long maxLength) {
-        double timeWidth = (double) maxLength / (double) width;
-        long[] xValues = new long[width];
-        for (int i = 0; i < width; i++) {
-            xValues[i] = (long) (i * timeWidth);
-            xValues[i] += timeWidth / 2;
-        }
-        return xValues;
-    }
-
-    private static double[] getYValues(Iterable<ISegment> displayData, int width, long maxLength) {
-        double maxFactor = 1.0 / (maxLength + 1.0);
-        double[] yValues = new double[width];
-        Arrays.fill(yValues, Double.MIN_VALUE);
-        for (ISegment segment : displayData) {
-            double xBox = segment.getLength() * maxFactor * width;
-            if (yValues[(int) xBox] < 1) {
-                yValues[(int) xBox] = 1;
-            } else {
-                yValues[(int) xBox]++;
+        if (module != null) {
+            if (monitor != null) {
+                module.waitForCompletion(monitor);
+            }
+            if (monitor != null && monitor.isCanceled()) {
+                return TmfXyResponseFactory.createCancelledResponse(CommonStatusMessage.TASK_CANCELLED);
             }
         }
-        return yValues;
+
+        Pair<ISampling, Collection<IYModel>> pair = getXAxisAndYSeriesModels(fetchParameters, monitor);
+        if (pair == null) {
+            return TmfXyResponseFactory.createCancelledResponse(CommonStatusMessage.TASK_CANCELLED);
+        }
+
+        boolean complete = module == null || module.isQueryable(filter.getEnd());
+        return TmfXyResponseFactory.create(
+                getTitle(),
+                pair.getFirst(),
+                ImmutableList.copyOf(pair.getSecond()),
+                getDisplayType(),
+                getXAxisDescription(),
+                complete);
     }
 
     @Override
     public TmfModelResponse<TmfTreeModel<TmfTreeDataModel>> fetchTree(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
-        Builder<TmfTreeDataModel> builder = ImmutableList.builder();
-        builder.add(new TmfTreeDataModel(fTraceId, -1, Collections.singletonList(String.valueOf(getTrace().getName()))));
-        builder.add(new TmfTreeDataModel(fTotalId, fTraceId, Collections.singletonList(Objects.requireNonNull(Messages.SegmentStoreDensity_TotalLabel))));
-        return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), builder.build()), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+        ISegmentStoreProvider provider = fProvider;
+        boolean waitResult = true;
+        if (provider instanceof IAnalysisModule) {
+            IAnalysisModule module = (IAnalysisModule) provider;
+            IProgressMonitor mon = monitor != null ? monitor : new NullProgressMonitor();
+            waitResult = module.waitForCompletion(mon);
+            if (mon.isCanceled()) {
+                return new TmfModelResponse<>(null, Status.CANCELLED, CommonStatusMessage.TASK_CANCELLED);
+            }
+        }
+        ISegmentStore<ISegment> segStore = provider.getSegmentStore();
+
+        if (segStore == null) {
+            if (!waitResult) {
+                return new TmfModelResponse<>(null, ITmfResponse.Status.FAILED, CommonStatusMessage.ANALYSIS_INITIALIZATION_FAILED);
+            }
+            return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), Collections.emptyList()), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+        }
+        TimeQueryFilter filter = FetchParametersUtils.createTimeQuery(fetchParameters);
+        if (filter == null) {
+            return new TmfModelResponse<>(null, ITmfResponse.Status.FAILED, CommonStatusMessage.INCORRECT_QUERY_PARAMETERS);
+        }
+
+        long start = filter.getStart();
+        long end = filter.getEnd();
+        final Iterable<ISegment> intersectingElements = Iterables.filter(segStore.getIntersectingElements(start, end), s -> s.getStart() >= start);
+        Map<String, INamedSegment> segmentTypes = new HashMap<>();
+        IAnalysisModule module = (provider instanceof IAnalysisModule) ? (IAnalysisModule) provider : null;
+        boolean complete = module == null || module.isQueryable(filter.getEnd());
+
+        // Create the list of segment types that will each create a series
+        for (INamedSegment segment : Iterables.filter(intersectingElements, INamedSegment.class)) {
+            if (monitor != null && monitor.isCanceled()) {
+                return new TmfModelResponse<>(null, ITmfResponse.Status.CANCELLED, CommonStatusMessage.TASK_CANCELLED);
+            }
+            segmentTypes.put(segment.getName(), segment);
+        }
+
+        Builder<TmfTreeDataModel> nodes = new ImmutableList.Builder<>();
+        nodes.add(new TmfTreeDataModel(fTraceId, -1, Collections.singletonList(String.valueOf(getTrace().getName()))));
+        Map<IGroupingSegmentAspect, Map<String, Long>> names = new HashMap<>();
+
+        for (Entry<String, INamedSegment> series : segmentTypes.entrySet()) {
+            long parentId = fTraceId;
+            /*
+             * Create a tree sorting aspects by "Grouping aspect" much like
+             * counter analyses
+             */
+            for (IGroupingSegmentAspect aspect : fGroupingAspects) {
+                names.putIfAbsent(aspect, new HashMap<>());
+                Map<String, Long> map = names.get(aspect);
+                if (map == null) {
+                    break;
+                }
+                String name = String.valueOf(aspect.resolve(series.getValue()));
+                String key = GROUP_PREFIX + name;
+                Long uniqueId = map.get(key);
+                if (uniqueId == null) {
+                    uniqueId = getUniqueId(key);
+                    map.put(key, uniqueId);
+                    nodes.add(new TmfTreeDataModel(uniqueId, parentId, name));
+                }
+                parentId = uniqueId;
+            }
+            long seriesId = getUniqueId(series.getKey());
+            nodes.add(new TmfTreeDataModel(seriesId, parentId, series.getKey()));
+        }
+
+        return new TmfModelResponse<>(new TmfTreeModel<>(Collections.emptyList(), nodes.build()), complete ? ITmfResponse.Status.COMPLETED : ITmfResponse.Status.RUNNING,
+                complete ? CommonStatusMessage.COMPLETED : CommonStatusMessage.RUNNING);
+    }
+
+    // ISegmentStoreProvider provider = fProvider;
+    private long getUniqueId(String name) {
+        synchronized (fIdToType) {
+            return fIdToType.inverse().computeIfAbsent(name, n -> TRACE_IDS.getAndIncrement());
+        }
+    }
+
+    public TmfXYAxisDescription getXAxisDescription() {
+        return new TmfXYAxisDescription("Duration", "ns", DataType.DURATION);
+    }
+
+    private static String getTitle() {
+        return Objects.requireNonNull(Messages.SegmentStoreDensityDataProvider_title);
+    }
+
+    private static DisplayType getDisplayType() {
+        return DisplayType.BAR;
+    }
+
+    private @Nullable Pair<@NonNull ISampling, @NonNull Collection<@NonNull IYModel>> getXAxisAndYSeriesModels(
+            @NonNull Map<@NonNull String, @NonNull Object> fetchParameters, @Nullable IProgressMonitor monitor) {
+        SelectionTimeQueryFilter filter = FetchParametersUtils.createSelectionTimeQueryWithSamples(fetchParameters);
+        if (filter == null) {
+            return null;
+        }
+        final ISegmentStore<ISegment> segStore = fProvider.getSegmentStore();
+        if (segStore == null) {
+            return null;
+        }
+
+        // Get segments in time range
+        Iterable<ISegment> segments = segStore.getIntersectingElements(filter.getStart(), filter.getEnd());
+
+        // Find max duration
+        long maxLength = getMaxDuration();
+        if (maxLength <= 0) {
+            maxLength = 1;
+        }
+
+        int nbSamples = filter.getNumberOfSamples();
+        long sampleStart = 0;
+        long sampleEnd = maxLength;
+
+        // Create bins based on selected entries
+        Map<@NonNull Long, @NonNull Integer> selectedEntries = getSelectedEntries(filter);
+        ISampling.Ranges sampling = createEvenlyDistributedRanges(sampleStart, sampleEnd, nbSamples);
+        if (sampling == null) {
+            return null;
+        }
+
+        // Create bins for each selected entry
+        Map<Long, double[]> entryToBins = new HashMap<>();
+        for (Long entryId : selectedEntries.keySet()) {
+            entryToBins.put(entryId, new double[nbSamples]);
+        }
+
+        // Process segments and fill bins
+        long totalSpan = sampleEnd - sampleStart + 1;
+        long step = totalSpan / nbSamples;
+
+        for (ISegment segment : segments) {
+            if (monitor != null && monitor.isCanceled()) {
+                return null;
+            }
+
+            long duration = segment.getLength();
+            if (step > 0 && duration >= sampleStart && duration <= sampleEnd) {
+                int index = (int) ((duration - sampleStart) / step);
+                if (index >= nbSamples) {
+                    index = nbSamples - 1;
+                }
+
+                // Add to appropriate bins based on segment type
+                String segmentType = getSegmentType(segment);
+                Long entryId = getEntryIdForSegmentType(segmentType);
+                if (entryId != null) {
+                    double[] bins = entryToBins.get(entryId);
+                    if (bins != null) {
+                        bins[index]++;
+                    }
+                }
+            }
+        }
+
+        // Create Y models
+        List<@NonNull IYModel> yModels = new ArrayList<>();
+        TmfXYAxisDescription yAxisDescription = new TmfXYAxisDescription("Count", "", DataType.NUMBER);
+
+        for (Entry<Long, double[]> entry : entryToBins.entrySet()) {
+            Long entryId = entry.getKey();
+            double[] bins = entry.getValue();
+            String name = getNameForEntryId(entryId);
+            yModels.add(new YModel(entryId, name, bins, yAxisDescription));
+        }
+
+        return new Pair<>(sampling, yModels);
+    }
+
+    private static String getSegmentType(ISegment segment) {
+        if (segment instanceof INamedSegment) {
+            return ((INamedSegment) segment).getName();
+        }
+        return "Total";
+    }
+
+    private @Nullable Long getEntryIdForSegmentType(String segmentType) {
+        synchronized (fIdToType) {
+            return fIdToType.inverse().get(segmentType);
+        }
+    }
+
+    private String getNameForEntryId(Long entryId) {
+        if (entryId.equals(fTotalId)) {
+            return Objects.requireNonNull(Messages.SegmentStoreDensity_TotalLabel);
+        }
+        synchronized (fIdToType) {
+            String name = fIdToType.get(entryId);
+            return name != null ? name : "Unknown";
+        }
+    }
+
+    private static Map<@NonNull Long, @NonNull Integer> getSelectedEntries(SelectionTimeQueryFilter filter) {
+        Map<@NonNull Long, @NonNull Integer> selectedEntries = new HashMap<>();
+        Collection<Long> selectedItems = filter.getSelectedItems();
+
+        int index = 0;
+        for (Long item : selectedItems) {
+            selectedEntries.put(item, index++);
+        }
+        return selectedEntries;
+    }
+
+    private static ISampling.@Nullable Ranges createEvenlyDistributedRanges(long start, long end, int samples) {
+        if (samples <= 0 || start >= end) {
+            return null;
+        }
+
+        List<ISampling.@NonNull Range<@NonNull Long>> ranges = new ArrayList<>(samples);
+        long totalSpan = end - start;
+        long step = totalSpan / samples;
+        long remainder = totalSpan % samples;
+
+        long current = start;
+        for (int i = 0; i < samples; i++) {
+            long rangeStart = current;
+            long rangeEnd = current + step - 1;
+            if (remainder > 0) {
+                rangeEnd += 1;
+                remainder--;
+            }
+            if (rangeEnd >= end || i == samples - 1) {
+                rangeEnd = end;
+            }
+            ranges.add(new ISampling.Range<>(rangeStart, rangeEnd));
+            current = rangeEnd + 1;
+        }
+
+        return new ISampling.Ranges(ranges);
+    }
+
+    private long getMaxDuration() {
+        final ISegmentStore<ISegment> segStore = fProvider.getSegmentStore();
+        if (segStore == null) {
+            return -1;
+        }
+        Optional<ISegment> maxSegment = StreamSupport.stream(segStore.spliterator(), false)
+                .max(SegmentComparators.INTERVAL_LENGTH_COMPARATOR);
+        return maxSegment.map(ISegment::getLength).orElse(1L);
     }
 
     @Override
     public String getId() {
         return fID;
+    }
+
+    public static @Nullable ITmfTreeDataProvider<? extends ITmfTreeDataModel> create(ITmfTrace trace, String secondaryId) {
+        // The trace can be an experiment, so we need to know if there are
+        // multiple analysis modules with the same ID
+        Iterable<ISegmentStoreProvider> modules = TmfTraceUtils.getAnalysisModulesOfClass(trace, ISegmentStoreProvider.class);
+        Iterable<ISegmentStoreProvider> filteredModules = Iterables.filter(modules, m -> ((IAnalysisModule) m).getId().equals(secondaryId));
+        Iterator<ISegmentStoreProvider> iterator = filteredModules.iterator();
+        if (iterator.hasNext()) {
+            ISegmentStoreProvider module = iterator.next();
+            if (iterator.hasNext()) {
+                // More than one module, must be an experiment, return null so
+                // the factory can try with individual traces
+                return null;
+            }
+            ((IAnalysisModule) module).schedule();
+            return new SegmentStoreDensityDataProvider(trace, module, secondaryId);
+        }
+        return null;
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreDensityDataProviderFactory.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/SegmentStoreDensityDataProviderFactory.java
@@ -10,15 +10,28 @@
  **********************************************************************/
 package org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.ISegmentStoreProvider;
-import org.eclipse.tracecompass.analysis.timing.core.segmentstore.SegmentStoreAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.component.DataProviderConstants;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
-import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfTreeXYCompositeDataProvider;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 
 /**
  * Generalized {@link SegmentStoreDensityDataProvider} factory using secondary
@@ -35,15 +48,45 @@ public class SegmentStoreDensityDataProviderFactory implements IDataProviderFact
 
     @Override
     public @Nullable ITmfTreeDataProvider<? extends ITmfTreeDataModel> createProvider(ITmfTrace trace, String secondaryId) {
-        IAnalysisModule m = new SegmentStoreAnalysisModule(trace, secondaryId);
-        try {
-            m.setTrace(trace);
-            String composedId = SegmentStoreDensityDataProvider.ID + ":" + secondaryId; //$NON-NLS-1$
-            m.schedule();
-            return new SegmentStoreDensityDataProvider(trace, (ISegmentStoreProvider) m, composedId);
-        } catch (TmfAnalysisException ex) {
-            m.dispose();
-            return null;
+
+        ITmfTreeDataProvider<? extends ITmfTreeDataModel> provider = SegmentStoreDensityDataProvider.create(trace, secondaryId);
+
+        if (provider != null) {
+            return provider;
         }
+        // Otherwise, see if it's an experiment and create a composite if that's
+        // the case
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        if (traces.size() == 1) {
+            return SegmentStoreScatterDataProvider.create(trace, secondaryId);
+        }
+        return TmfTreeXYCompositeDataProvider.create(traces,
+                Objects.requireNonNull(Messages.SegmentStoreDensityDataProvider_title),
+                SegmentStoreDensityDataProvider.ID, secondaryId);
+    }
+
+    @Override
+    public Collection<IDataProviderDescriptor> getDescriptors(ITmfTrace trace) {
+        Iterable<ISegmentStoreProvider> modules = TmfTraceUtils.getAnalysisModulesOfClass(trace, ISegmentStoreProvider.class);
+        List<IDataProviderDescriptor> descriptors = new ArrayList<>();
+        Set<String> existingModules = new HashSet<>();
+        for (ISegmentStoreProvider module : modules) {
+            if (!(module instanceof IAnalysisModule)) {
+                continue;
+            }
+            IAnalysisModule analysis = (IAnalysisModule) module;
+            if (!existingModules.contains(analysis.getId())) {
+                DataProviderDescriptor.Builder builder = new DataProviderDescriptor.Builder();
+                builder.setId(SegmentStoreDensityDataProvider.ID + DataProviderConstants.ID_SEPARATOR + analysis.getId())
+                        .setParentId(analysis.getConfiguration() != null ? analysis.getId() : null)
+                        .setName(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreDensityDataProvider_title, analysis.getName())))
+                        .setDescription(Objects.requireNonNull(NLS.bind(Messages.SegmentStoreDensityDataProvider_description, analysis.getHelpText())))
+                        .setProviderType(ProviderType.TREE_GENERIC_XY)
+                        .setConfiguration(analysis.getConfiguration());
+                descriptors.add(builder.build());
+                existingModules.add(analysis.getId());
+            }
+        }
+        return descriptors;
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/messages.properties
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/segmentstore/messages.properties
@@ -28,7 +28,8 @@ SegmentStoreTableDataProvider_description=Show latency table provided by {0}
 SegmentStoreScatterGraphDataProvider_title={0} - Latency vs Time
 SegmentStoreScatterGraphDataProvider_description=Show latencies provided by {0}
 
-SegmentStoreDensityDataProvider_title={0} - Function Density
+SegmentStoreDensityDataProvider_title={0} - Latency Density
+SegmentStoreDensityDataProvider_description=Shows latency density distribution by {0}
 
 SegmentStoreDensity_TotalLabel=Total
 SegmentStoreStatistics_Label=Label

--- a/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/DataProviderManagerTest.java
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/src/org/eclipse/tracecompass/integration/core/tests/dataproviders/DataProviderManagerTest.java
@@ -211,6 +211,29 @@ public class DataProviderManagerTest {
                 .setProviderType(ProviderType.TIME_GRAPH)
                 .setId("org.eclipse.tracecompass.internal.tmf.core.statesystem.provider.StateSystemDataProvider");
         EXPECTED_KERNEL_DP_DESCRIPTORS.add(builder.build());
+        builder.setName("IRQ Analysis - Latency Density")
+                .setDescription("Shows latency density distribution by Analysis module: IRQ Analysis")
+                .setProviderType(ProviderType.TREE_GENERIC_XY)
+                .setId("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider:lttng.analysis.irq");
+        EXPECTED_KERNEL_DP_DESCRIPTORS.add(builder.build());
+        builder = new DataProviderDescriptor.Builder();
+        builder.setName("Scheduler Wakeup to Scheduler Switch Latency - Latency Density")
+                .setDescription("Shows latency density distribution by Analysis module: Scheduler Wakeup to Scheduler Switch Latency")
+                .setProviderType(ProviderType.TREE_GENERIC_XY)
+                .setId("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider:org.eclipse.tracecompass.analysis.os.linux.core.swslatency.sws");
+        EXPECTED_KERNEL_DP_DESCRIPTORS.add(builder.build());
+        builder = new DataProviderDescriptor.Builder();
+        builder.setName("Futex Contention Analysis - Latency Density")
+                .setDescription("Shows latency density distribution by Analysis module: Futex Contention Analysis")
+                .setProviderType(ProviderType.TREE_GENERIC_XY)
+                .setId("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider:lttng.analysis.futex");
+        EXPECTED_KERNEL_DP_DESCRIPTORS.add(builder.build());
+        builder = new DataProviderDescriptor.Builder();
+        builder.setName("System Call Latency - Latency Density")
+                .setDescription("Shows latency density distribution by Analysis module: System Call Latency")
+                .setProviderType(ProviderType.TREE_GENERIC_XY)
+                .setId("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider:org.eclipse.tracecompass.analysis.os.linux.latency.syscall");
+        EXPECTED_KERNEL_DP_DESCRIPTORS.add(builder.build());
 
         // UST Trace
         builder = new DataProviderDescriptor.Builder();
@@ -292,7 +315,18 @@ public class DataProviderManagerTest {
                 .setProviderType(ProviderType.TIME_GRAPH)
                 .setId("org.eclipse.tracecompass.internal.tmf.core.statesystem.provider.StateSystemDataProvider");
         EXPECTED_UST_DP_DESCRIPTORS.add(builder.build());
-
+        builder = new DataProviderDescriptor.Builder();
+        builder.setName("LTTng-UST CallStack - Latency Density")
+                .setDescription("Shows latency density distribution by Analysis module: LTTng-UST CallStack")
+                .setProviderType(ProviderType.TREE_GENERIC_XY)
+                .setId("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider:org.eclipse.linuxtools.lttng2.ust.analysis.callstack");
+        EXPECTED_UST_DP_DESCRIPTORS.add(builder.build());
+        builder = new DataProviderDescriptor.Builder();
+        builder.setName("LTTng-UST CallStack (new) - Latency Density")
+                .setDescription("Shows latency density distribution by Analysis module: LTTng-UST CallStack (new)")
+                .setProviderType(ProviderType.TREE_GENERIC_XY)
+                .setId("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider:org.eclipse.tracecompass.lttng2.ust.core.analysis.callstack");
+        EXPECTED_UST_DP_DESCRIPTORS.add(builder.build());
         EXPECTED_EXPERIMENT_SET.addAll(EXPECTED_UST_DP_DESCRIPTORS);
         EXPECTED_EXPERIMENT_SET.addAll(EXPECTED_KERNEL_DP_DESCRIPTORS);
         // Additional Experiment Traces
@@ -313,6 +347,12 @@ public class DataProviderManagerTest {
                 .setDescription("Show latency statistics provided by Analysis module: Event Matching Latency")
                 .setProviderType(ProviderType.DATA_TREE)
                 .setId("org.eclipse.tracecompass.analysis.timing.core.segmentstore.SegmentStoreStatisticsDataProvider:org.eclipse.tracecompass.internal.analysis.timing.core.event.matching");
+        EXPECTED_EXPERIMENT_SET.add(builder.build());
+        builder = new DataProviderDescriptor.Builder();
+        builder.setName("Event Matching Latency - Latency Density")
+                .setDescription("Shows latency density distribution by Analysis module: Event Matching Latency")
+                .setProviderType(ProviderType.TREE_GENERIC_XY)
+                .setId("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.SegmentStoreDensityDataProvider:org.eclipse.tracecompass.internal.analysis.timing.core.event.matching");
         EXPECTED_EXPERIMENT_SET.add(builder.build());
 
     }
@@ -371,7 +411,6 @@ public class DataProviderManagerTest {
         Set<IDataProviderDescriptor> ustDescriptorsSet = new HashSet<>(ustDescriptors);
         List<IDataProviderDescriptor> expDescriptors = DataProviderManager.getInstance().getAvailableProviders(fExperiment);
         Set<IDataProviderDescriptor> expDescriptorsSet = new HashSet<>(expDescriptors);
-
         assertTrue(kernelDescriptorSet.equals(EXPECTED_KERNEL_DP_DESCRIPTORS));
         assertTrue(ustDescriptorsSet.equals(EXPECTED_UST_DP_DESCRIPTORS));
         assertTrue(expDescriptorsSet.equals(EXPECTED_EXPERIMENT_SET));


### PR DESCRIPTION

### What it does

- Add fetchTree and fetchXY 
- Add getXAxisAndYSeriesModels'
- Adapt the response data structure to match the genericXY
- Add tests in DataProviderMangerTest
- Add tests in SegmentStoreDensityDataProvider
- Use Q for help
### How to test

- run the trace server
- open a trace in vscode-trace-extension
- open one of the latency density views

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Density analysis: hierarchical tree of grouped segments, sampling-based XY generation, and axis metadata exposure
  * Conditional/experiment-aware provider creation and composite-trace support

* **Improvements**
  * Renamed label from "Function Density" to "Latency Density" and added descriptive text
  * Improved cancellation handling, progress monitoring, and provider discovery

* **Tests**
  * Added/updated latency-density descriptors and tests for tree/XY fetch, success/failure/cancel scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->