### PR TITLE
releng: Build with tracecompass-e4.38 target by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
-    <target-platform>tracecompass-e4.37</target-platform>
+    <target-platform>tracecompass-e4.38</target-platform>
     <help-docs-eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.23</help-docs-eclipserun-repo>
 
     <rcptt-version>2.5.4</rcptt-version>

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -190,10 +190,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.lang"
-         version="0.0.0"/>
-
-   <plugin
          id="org.apache.commons.lang3"
          version="0.0.0"/>
 
@@ -282,7 +278,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.mortbay.jasper.apache-jsp"
+         id="org.mortbay.jasper.mortbay-apache-jsp"
          version="0.0.0"/>
 
    <plugin

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.37/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.37/feature.xml
@@ -190,6 +190,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.apache.commons.lang"
+         version="0.0.0"/>
+
+   <plugin
          id="org.apache.commons.lang3"
          version="0.0.0"/>
 
@@ -278,7 +282,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.mortbay.jasper.mortbay-apache-jsp"
+         id="org.mortbay.jasper.apache-jsp"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
### What it does

releng: Build with tracecompass-e4.38 target by default

### How to test

Build in stable branch with default target.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
