### PR TITLE
pcap: Update test files URLs

### DIFF
--- a/pcap/org.eclipse.tracecompass.pcap.core.tests/rsc/get-traces.xml
+++ b/pcap/org.eclipse.tracecompass.pcap.core.tests/rsc/get-traces.xml
@@ -69,13 +69,13 @@ http://wiki.wireshark.org/SampleCaptures
 
 <target name="downloadTraceFiles">
   <echo message="Attempting to download test traces"/>
-  <get ignoreerrors="true" maxtime="1200" dest="Short_LittleEndian.pcap.zip" skipexisting="true" src="http://wiki.eclipse.org/images/1/18/Short_LittleEndian.pcap.zip" />
-  <get ignoreerrors="true" maxtime="1200" dest="Short_BigEndian.pcap.zip" skipexisting="true" src="http://wiki.eclipse.org/images/2/25/Short_BigEndian.pcap.zip" />
-  <get ignoreerrors="true" maxtime="1200" dest="MostlyUDP.pcap.zip" skipexisting="true" src="http://wiki.eclipse.org/images/6/64/MostlyUDP.pcap.zip" />
-  <get ignoreerrors="true" maxtime="1200" dest="MostlyTCP.pcap.zip" skipexisting="true" src="http://wiki.eclipse.org/images/8/8d/MostlyTCP.pcap.zip" />
-  <get ignoreerrors="true" maxtime="1200" dest="EmptyPcap.pcap.zip" skipexisting="true" src="http://wiki.eclipse.org/images/c/c1/EmptyPcap.pcap.zip" />
-  <get ignoreerrors="true" maxtime="1200" dest="BadPcapFile.pcap.zip" skipexisting="true" src="http://wiki.eclipse.org/images/5/5e/BadPcapFile.pcap.zip" />
-  <get ignoreerrors="true" maxtime="2400" dest="BenchmarkTrace.pcap.zip" skipexisting="true" src="http://wiki.eclipse.org/images/1/12/BenchmarkTrace.pcap.zip" />
+  <get ignoreerrors="true" maxtime="1200" dest="Short_LittleEndian.pcap.zip" skipexisting="true" src="https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/Test_Files/Pcap/Short_LittleEndian.pcap.zip" />
+  <get ignoreerrors="true" maxtime="1200" dest="Short_BigEndian.pcap.zip" skipexisting="true" src="https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/Test_Files/Pcap/Short_BigEndian.pcap.zip" />
+  <get ignoreerrors="true" maxtime="1200" dest="MostlyUDP.pcap.zip" skipexisting="true" src="https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/Test_Files/Pcap/MostlyUDP.pcap.zip" />
+  <get ignoreerrors="true" maxtime="1200" dest="MostlyTCP.pcap.zip" skipexisting="true" src="https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/Test_Files/Pcap/MostlyTCP.pcap.zip" />
+  <get ignoreerrors="true" maxtime="1200" dest="EmptyPcap.pcap.zip" skipexisting="true" src="https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/Test_Files/Pcap/EmptyPcap.pcap.zip" />
+  <get ignoreerrors="true" maxtime="1200" dest="BadPcapFile.pcap.zip" skipexisting="true" src="https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/Test_Files/Pcap/BadPcapFile.pcap.zip" />
+  <get ignoreerrors="true" maxtime="2400" dest="BenchmarkTrace.pcap.zip" skipexisting="true" src="https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/wiki/Trace_Compass/Test_Files/Pcap/BenchmarkTrace.pcap.zip" />
   <get ignoreerrors="true" maxtime="1200" dest="sample-ctf-trace-20120412.tar.bz2" skipexisting="true" src="http://lttng.org/files/samples/sample-ctf-trace-20120412.tar.bz2"/>
 </target>
 


### PR DESCRIPTION
### What it does

pcap: Update test files URLs

Files moved due to `wiki.eclipse.org` shutdown

### How to test

Successful CI

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test resource download sources to reflect current repository infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->