### PR TITLE
Enqueue less

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/cpuusage/KernelCpuUsageStateProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/cpuusage/KernelCpuUsageStateProvider.java
@@ -91,6 +91,11 @@ public class KernelCpuUsageStateProvider extends AbstractTmfStateProvider {
     }
 
     @Override
+    protected boolean considerEvent(ITmfEvent event) {
+        return super.considerEvent(event) && event.getName().equals(fLayout.eventSchedSwitch());
+    }
+
+    @Override
     protected void eventHandle(@Nullable ITmfEvent event) {
         if (event == null) {
             return;

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernelmemoryusage/KernelMemoryStateProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernelmemoryusage/KernelMemoryStateProvider.java
@@ -12,6 +12,9 @@ package org.eclipse.tracecompass.analysis.os.linux.core.kernelmemoryusage;
 
 import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
 
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.analysis.os.linux.core.kernel.KernelTidAspect;
@@ -58,6 +61,12 @@ public class KernelMemoryStateProvider extends AbstractTmfStateProvider {
 
     private IKernelAnalysisEventLayout fLayout;
 
+    private final String fEventKmemPageFree;
+
+    private final String fEventKmemPageAlloc;
+
+    private final Set<String> fToConsider = new TreeSet<>();
+
     /**
      * Constructor
      *
@@ -69,6 +78,10 @@ public class KernelMemoryStateProvider extends AbstractTmfStateProvider {
     public KernelMemoryStateProvider(@NonNull ITmfTrace trace, IKernelAnalysisEventLayout layout) {
         super(trace, "Kernel:Memory"); //$NON-NLS-1$
         fLayout = layout;
+        fEventKmemPageAlloc = fLayout.eventKmemPageAlloc();
+        fEventKmemPageFree = fLayout.eventKmemPageFree();
+        fToConsider.add(fEventKmemPageAlloc);
+        fToConsider.add(fEventKmemPageFree);
     }
 
     @Override
@@ -82,16 +95,23 @@ public class KernelMemoryStateProvider extends AbstractTmfStateProvider {
     }
 
     @Override
+    protected boolean considerEvent(ITmfEvent event) {
+        return super.considerEvent(event) && fToConsider.contains(event.getName());
+    }
+
+    @Override
     protected void eventHandle(@NonNull ITmfEvent event) {
         String name = event.getName();
 
         long inc;
-        if (name.equals(fLayout.eventKmemPageAlloc())) {
+        if (name.equals(fEventKmemPageAlloc)) {
             inc = PAGE_SIZE;
-        } else if (name.equals(fLayout.eventKmemPageFree())) {
-            inc = -PAGE_SIZE;
         } else {
-            return;
+            if (name.equals(fEventKmemPageFree)) {
+                inc = -PAGE_SIZE;
+            } else {
+                return;
+            }
         }
 
         try {

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/tid/ActiveTidStateProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/tid/ActiveTidStateProvider.java
@@ -73,10 +73,12 @@ class ActiveTidStateProvider extends AbstractTmfStateProvider {
     }
 
     @Override
+    protected boolean considerEvent(@NonNull ITmfEvent event) {
+        return super.considerEvent(event) && event.getName().equals(fSchedSwitch);
+    }
+
+    @Override
     protected void eventHandle(@NonNull ITmfEvent event) {
-        if (!event.getName().equals(fSchedSwitch)) {
-            return;
-        }
         ITmfStateSystemBuilder ssb = getStateSystemBuilder();
         if (ssb == null) {
             return;

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/KernelStateProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/KernelStateProvider.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.tracecompass.internal.analysis.os.linux.core.kernel;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.os.linux.core.trace.IKernelAnalysisEventLayout;
@@ -98,6 +100,7 @@ public class KernelStateProvider extends AbstractTmfStateProvider {
 
     private final KernelEventHandler fSysEntryHandler;
     private final KernelEventHandler fSysExitHandler;
+    private final Set<String> fValidEventNames = new HashSet<>();
 
     // ------------------------------------------------------------------------
     // Constructor
@@ -116,7 +119,7 @@ public class KernelStateProvider extends AbstractTmfStateProvider {
         super(trace, "Kernel"); //$NON-NLS-1$
         fLayout = layout;
         fEventNames = buildEventNames(layout);
-
+        fValidEventNames.addAll(fEventNames.keySet());
         fSysEntryHandler = new SysEntryHandler(fLayout);
         fSysExitHandler = new SysExitHandler(fLayout);
     }
@@ -173,6 +176,19 @@ public class KernelStateProvider extends AbstractTmfStateProvider {
     @Override
     public KernelStateProvider getNewInstance() {
         return new KernelStateProvider(this.getTrace(), fLayout);
+    }
+
+    @Override
+    protected boolean considerEvent(ITmfEvent event) {
+        boolean considerEvent = super.considerEvent(event);
+        if (!considerEvent) {
+            return false;
+        }
+        String name = event.getName();
+        if (fValidEventNames.contains(name)) {
+            return true;
+        }
+        return isSyscallEntry(name) || isSyscallExit(name);
     }
 
     @Override

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/callstack/CallStackStateProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/analysis/profiling/core/callstack/CallStackStateProvider.java
@@ -114,9 +114,6 @@ public abstract class CallStackStateProvider extends AbstractTmfStateProvider {
 
     @Override
     protected void eventHandle(ITmfEvent event) {
-        if (!considerEvent(event)) {
-            return;
-        }
 
         ITmfStateSystemBuilder ss = checkNotNull(getStateSystemBuilder());
 
@@ -204,7 +201,10 @@ public abstract class CallStackStateProvider extends AbstractTmfStateProvider {
      * @return If false, the event will be ignored by the state provider. If
      *         true processing will continue.
      */
-    protected abstract boolean considerEvent(ITmfEvent event);
+    @Override
+    protected boolean considerEvent(ITmfEvent event) {
+        return true;
+    }
 
     /**
      * Check an event if it indicates a function entry.

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/memory/UstMemoryStateProvider.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/internal/lttng2/ust/core/analysis/memory/UstMemoryStateProvider.java
@@ -160,6 +160,14 @@ public class UstMemoryStateProvider extends AbstractTmfStateProvider {
     }
 
     @Override
+    protected boolean considerEvent(@NonNull ITmfEvent event) {
+        if (!super.considerEvent(event)) {
+            return false;
+        }
+        return fEventNames.containsKey(event.getName());
+    }
+
+    @Override
     protected void eventHandle(ITmfEvent event) {
         String name = event.getName();
         Integer index = fEventNames.get(name);

--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/AbstractTmfStateProvider.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/statesystem/AbstractTmfStateProvider.java
@@ -319,6 +319,10 @@ public abstract class AbstractTmfStateProvider implements ITmfStateProvider {
                         event = fEventsQueue.take();
                         continue;
                     }
+                    if (!considerEvent(event)) {
+                        event = fEventsQueue.take();
+                        continue;
+                    }
                     currentEvent = event;
                     long currentTime = event.getTimestamp().toNanos();
                     fSafeTime = currentTime - 1;
@@ -435,6 +439,22 @@ public abstract class AbstractTmfStateProvider implements ITmfStateProvider {
     // ------------------------------------------------------------------------
     // Abstract methods
     // ------------------------------------------------------------------------
+
+    /**
+     * Check if this event should be considered for processing by the state
+     * provider. This check is a fast fail filter invoked before
+     * {@link #eventHandle(ITmfEvent)} to allow events to not be processed as
+     * much.
+     *
+     * @param event
+     *            The event to check
+     * @return If false, the event will be ignored by the state provider. If
+     *         true processing will continue.
+     * @since 10.2
+     */
+    protected boolean considerEvent(ITmfEvent event) {
+        return true;
+    }
 
     /**
      * Handle the given event and send the appropriate state transitions into


### PR DESCRIPTION
### What it does

This PR adds pre-filtering to event dispatch to speed up trace parsing by reducing queue fill. Only events that may be read by analyses are enqueued, improving performance.

The following state providers are updated to implement event filtering:
* ActiveTidStateProvider
* KernelStateProvider
* KernelMemoryStateProvider
* KernelCpuUsageStateProvider
* CallStackStateProvider
* UstMemoryStateProvider

### How to test

1. Open a large trace file (particularly kernel traces)
2. Observe the parsing time and memory usage (Use tracing!)
3. Compare with previous versions - parsing should be faster with reduced queue buildup (diff flamegraph)
4. Verify that all analyses still produce correct results (no events are incorrectly filtered out)

### Follow-ups

Add more analyses.
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->


- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved event filtering and caching across providers to reduce unnecessary processing and speed up analyses.
* **Refactor**
  * Standardized a new pre-filter hook so providers share consistent event-selection behavior.
* **Behavior**
  * Call stack analysis now processes all incoming events by default; several memory and kernel analyses now only consider known, relevant events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->