### PR TITLE
lttng: detect ctf2 kernel traces as kernel traces

### DIFF
--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.core/src/org/eclipse/tracecompass/lttng2/kernel/core/trace/LttngKernelTrace.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.core/src/org/eclipse/tracecompass/lttng2/kernel/core/trace/LttngKernelTrace.java
@@ -181,7 +181,7 @@ public class LttngKernelTrace extends CtfTmfTrace implements IKernelTrace, ILttn
             Map<String, String> environment = ((CtfTraceValidationStatus) status).getEnvironment();
             /* Make sure the domain is "kernel" in the trace's env vars */
             String domain = environment.get("domain"); //$NON-NLS-1$
-            if (domain == null || !domain.equals("\"kernel\"")) { //$NON-NLS-1$
+            if (domain == null || !(domain.equals("kernel") || domain.equals("\"kernel\""))) { //$NON-NLS-1$ //$NON-NLS-2$
                 return new Status(IStatus.ERROR, Activator.PLUGIN_ID, Messages.LttngKernelTrace_DomainError);
             }
             return new TraceValidationStatus(CONFIDENCE, Activator.PLUGIN_ID);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Detect lttng CTF2 kernel traces as linux kernel traces.

### How to test

Open a CTF2 lttng trace.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed domain validation to accept both standard and quoted kernel domain identifiers in trace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->