### PR TITLE
lttng: fix validation of ust ctf2 trace

### DIFF
--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/lttng2/ust/core/trace/LttngUstTrace.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core/src/org/eclipse/tracecompass/lttng2/ust/core/trace/LttngUstTrace.java
@@ -190,7 +190,7 @@ public class LttngUstTrace extends CtfTmfTrace implements ILttngTrace{
             Map<String, String> environment = ctfTraceValidationStatus.getEnvironment();
             /* Make sure the domain is "ust" in the trace's env vars */
             String domain = environment.get("domain"); //$NON-NLS-1$
-            if (domain == null || !domain.equals("\"ust\"")) { //$NON-NLS-1$
+            if (domain == null || !(domain.equals("ust") || domain.equals("\"ust\""))) { //$NON-NLS-1$ //$NON-NLS-2$
                 return Status.error(Messages.LttngUstTrace_DomainError);
             }
             return new CtfTraceValidationStatus(CONFIDENCE, Activator.PLUGIN_ID, environment, ctfTraceValidationStatus.getEventNames() );


### PR DESCRIPTION
### What it does

It makes LTTng UST ctf2 traces detectable by Trace Compass by modifying the validate function.

### How to test

Open a CTF2 trace generated from LTTng 2.15 with a program instrumented by LTTng-UST

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain validation to accept alternative domain value formats, improving trace parsing compatibility and reducing validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->