### PR TITLE
Correct the number entries in the many entries warning dialog

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/ManyEntriesSelectedDialogPreCheckedListener.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/views/ManyEntriesSelectedDialogPreCheckedListener.java
@@ -48,7 +48,7 @@ public class ManyEntriesSelectedDialogPreCheckedListener implements IPreCheckSta
     public boolean setSubtreeChecked(Object element, boolean state) {
         if (state) {
             ITreeContentProvider contentProvider = (ITreeContentProvider) fFilteredCheckboxTree.getCheckboxTreeViewer().getContentProvider();
-            int nb = fFilteredCheckboxTree.getCheckedElements().length + getSubTreeSize(contentProvider, element);
+            int nb = fFilteredCheckboxTree.getCheckedElements().length + getSubTreeSize(contentProvider, element) - 1;
             return showWarning(nb);
         }
         return false;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
Correct the number entry in the message in the "Many entries selected" dialog:
+) In method `setSubtreeChecked(Object element, boolean state)`, `fFilteredCheckboxTree.getCheckedElements().length `counts the `element` as one entry, but the method `getSubTreeSize(contentProvider, element)` also counts it again, which makes the number of entries in the warning message incorrect. 
+) For example: in the **"CPU Usage"** view, if the tree table has one parent node **"kernel"** and 39 child processes in this node. If the user selects the **"kernel"** node -> the "Many entries selected" dialog opens, and the warning message is "You have selected **41** entries....". But the correct message should be "You have selected **40** entries ......"
-> We have to -1 to get the correct number of entries in the method `setSubtreeChecked(Object element, boolean state)`

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

+) Test through the **"CPU Usage"** view, when the **"Many entries selected"** dialog opens, the warning messages show the correct number of entries that will be selected in the tree table (parent node + child node)

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
