### PR TITLE
releng: Add e4.39 and update Staging targets, plugin and feature versions

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.counters.core.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.counters.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.counters.core.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.counters.ui.swtbot.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.counters.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/analysis/org.eclipse.tracecompass.analysis.graph.core.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.graph.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.graph.core.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.lami.core.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.lami.core.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/analysis/org.eclipse.tracecompass.analysis.lami.ui.swtbot.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.lami.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.lami.ui.swtbot.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.os.linux.core.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.ui.swtbot.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.os.linux.ui.swtbot.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.ui.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.os.linux.ui.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.profiling.core.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.ui.swtbot.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.profiling.ui.swtbot.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.timing.core.tests</artifactId>

--- a/analysis/org.eclipse.tracecompass.analysis.timing.ui.swtbot.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.timing.ui.swtbot.tests</artifactId>

--- a/analysis/pom.xml
+++ b/analysis/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis-parent</artifactId>

--- a/btf/org.eclipse.tracecompass.btf.core.tests/pom.xml
+++ b/btf/org.eclipse.tracecompass.btf.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.btf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.btf.core.tests</artifactId>

--- a/btf/org.eclipse.tracecompass.btf/feature.xml
+++ b/btf/org.eclipse.tracecompass.btf/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.btf"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/btf/pom.xml
+++ b/btf/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.btf-parent</artifactId>

--- a/common/org.eclipse.tracecompass.common.core.tests/pom.xml
+++ b/common/org.eclipse.tracecompass.common.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.common-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.common.core.tests</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.common-parent</artifactId>

--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/pom.xml
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.ctf-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <name>Trace Compass CTF Core Tests Plug-in</name>

--- a/ctf/org.eclipse.tracecompass.ctf.parser.tests/pom.xml
+++ b/ctf/org.eclipse.tracecompass.ctf.parser.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.ctf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.ctf.parser.tests</artifactId>

--- a/ctf/org.eclipse.tracecompass.ctf.parser/pom.xml
+++ b/ctf/org.eclipse.tracecompass.ctf.parser/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.ctf-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <name>Trace Compass CTF Parser Plug-in</name>

--- a/ctf/org.eclipse.tracecompass.ctf/feature.xml
+++ b/ctf/org.eclipse.tracecompass.ctf/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.ctf"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core.tests/pom.xml
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.ctf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.ctf.core.tests</artifactId>

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests/pom.xml
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.ctf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/ctf/org.eclipse.tracecompass.tmf.ctf/feature.xml
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf/feature.xml
@@ -3,7 +3,7 @@
 <feature
       id="org.eclipse.tracecompass.tmf.ctf"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ctf/pom.xml
+++ b/ctf/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.ctf-parent</artifactId>

--- a/doc/org.eclipse.tracecompass.analysis.profiling.doc.user/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.tracecompass.analysis.profiling.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.analysis.profiling.doc.user;singleton:=true
 Require-Bundle: org.eclipse.help

--- a/doc/org.eclipse.tracecompass.analysis.profiling.doc.user/pom.xml
+++ b/doc/org.eclipse.tracecompass.analysis.profiling.doc.user/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.doc</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.profiling.doc.user</artifactId>
@@ -96,5 +96,4 @@
     </profile>
   </profiles>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/doc/org.eclipse.tracecompass.doc.dev/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.tracecompass.doc.dev/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.doc.dev;singleton:=true
 Require-Bundle: org.eclipse.help

--- a/doc/org.eclipse.tracecompass.doc.dev/pom.xml
+++ b/doc/org.eclipse.tracecompass.doc.dev/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.doc</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.doc.dev</artifactId>
@@ -98,5 +98,4 @@
     </profile>
   </profiles>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/doc/org.eclipse.tracecompass.doc.user/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.tracecompass.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.doc.user;singleton:=true
 Require-Bundle: org.eclipse.help

--- a/doc/org.eclipse.tracecompass.doc.user/pom.xml
+++ b/doc/org.eclipse.tracecompass.doc.user/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.doc</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.doc.user</artifactId>
@@ -102,5 +102,4 @@
     </profile>
   </profiles>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/doc/org.eclipse.tracecompass.gdbtrace.doc.user/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.tracecompass.gdbtrace.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.gdbtrace.doc.user;singleton:=true
 Require-Bundle: org.eclipse.help

--- a/doc/org.eclipse.tracecompass.gdbtrace.doc.user/pom.xml
+++ b/doc/org.eclipse.tracecompass.gdbtrace.doc.user/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.doc</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.gdbtrace.doc.user</artifactId>
@@ -98,5 +98,4 @@
     </profile>
   </profiles>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/doc/org.eclipse.tracecompass.rcp.doc.user/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.tracecompass.rcp.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.rcp.doc.user;singleton:=true
 Require-Bundle: org.eclipse.help

--- a/doc/org.eclipse.tracecompass.rcp.doc.user/pom.xml
+++ b/doc/org.eclipse.tracecompass.rcp.doc.user/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.doc</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.rcp.doc.user</artifactId>
@@ -98,5 +98,4 @@
     </profile>
   </profiles>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/doc/org.eclipse.tracecompass.tmf.pcap.doc.user/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.tracecompass.tmf.pcap.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.pcap.doc.user;singleton:=true
 Require-Bundle: org.eclipse.help

--- a/doc/org.eclipse.tracecompass.tmf.pcap.doc.user/pom.xml
+++ b/doc/org.eclipse.tracecompass.tmf.pcap.doc.user/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.doc</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.pcap.doc.user</artifactId>
@@ -98,5 +98,4 @@
     </profile>
   </profiles>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.doc</artifactId>

--- a/gdbtrace/org.eclipse.tracecompass.gdbtrace.core.tests/pom.xml
+++ b/gdbtrace/org.eclipse.tracecompass.gdbtrace.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.gdbtrace-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.gdbtrace.core.tests</artifactId>

--- a/gdbtrace/org.eclipse.tracecompass.gdbtrace.ui.tests/pom.xml
+++ b/gdbtrace/org.eclipse.tracecompass.gdbtrace.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.gdbtrace-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.gdbtrace.ui.tests</artifactId>

--- a/gdbtrace/org.eclipse.tracecompass.gdbtrace/feature.xml
+++ b/gdbtrace/org.eclipse.tracecompass.gdbtrace/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.gdbtrace"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/gdbtrace/pom.xml
+++ b/gdbtrace/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.gdbtrace-parent</artifactId>

--- a/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/pom.xml
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.jsontrace-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.jsontrace.core.tests</artifactId>

--- a/jsontrace/org.eclipse.tracecompass.jsontrace/feature.xml
+++ b/jsontrace/org.eclipse.tracecompass.jsontrace/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.jsontrace"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/jsontrace/pom.xml
+++ b/jsontrace/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.jsontrace-parent</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.common.core.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.common.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.common.core.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.control.core.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.control.core.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui.swtbot.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.control.ui.swtbot.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.control.ui.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.control/feature.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.control/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.lttng2.control"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.core.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.core.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.tracecompass.lttng2.kernel.core.tests</artifactId>
   <version>2.0.9-SNAPSHOT</version>

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.ui.swtbot.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.kernel.ui.swtbot.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel/feature.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel/feature.xml
@@ -3,7 +3,7 @@
 <feature
       id="org.eclipse.tracecompass.lttng2.kernel"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.ust.core.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.ui.swtbot.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.ust.ui.swtbot.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.ui.tests/pom.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng2.ust.ui.tests</artifactId>

--- a/lttng/org.eclipse.tracecompass.lttng2.ust/feature.xml
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust/feature.xml
@@ -3,7 +3,7 @@
 <feature
       id="org.eclipse.tracecompass.lttng2.ust"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/lttng/pom.xml
+++ b/lttng/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.lttng-parent</artifactId>

--- a/pcap/org.eclipse.tracecompass.pcap.core.tests/pom.xml
+++ b/pcap/org.eclipse.tracecompass.pcap.core.tests/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.pcap-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.pcap.core.tests</artifactId>

--- a/pcap/org.eclipse.tracecompass.tmf.pcap.core.tests/pom.xml
+++ b/pcap/org.eclipse.tracecompass.tmf.pcap.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.pcap-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.pcap.core.tests</artifactId>

--- a/pcap/org.eclipse.tracecompass.tmf.pcap.ui.swtbot.tests/pom.xml
+++ b/pcap/org.eclipse.tracecompass.tmf.pcap.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.pcap-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.pcap.ui.swtbot.tests</artifactId>

--- a/pcap/org.eclipse.tracecompass.tmf.pcap/feature.xml
+++ b/pcap/org.eclipse.tracecompass.tmf.pcap/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.tmf.pcap"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/pcap/pom.xml
+++ b/pcap/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.pcap-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.eclipse.tracecompass</groupId>
   <artifactId>org.eclipse.tracecompass</artifactId>
-  <version>11.2.0-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Trace Compass Parent</name>
 
@@ -422,7 +422,7 @@
               <groupId>org.eclipse.tracecompass</groupId>
               <artifactId>org.eclipse.tracecompass.target</artifactId>
               <classifier>${target-platform}</classifier>
-              <version>11.2.0-SNAPSHOT</version>
+              <version>11.3.0-SNAPSHOT</version>
             </artifact>
           </target>
         </configuration>

--- a/rcp/org.eclipse.tracecompass.rcp.branding.feature/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.branding.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp.branding.feature"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/rcp/org.eclipse.tracecompass.rcp.branding.feature/pom.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.branding.feature/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.rcp-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.rcp.branding.feature</artifactId>
@@ -61,5 +61,4 @@
     </plugins>
   </build>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/rcp/org.eclipse.tracecompass.rcp.branding/META-INF/MANIFEST.MF
+++ b/rcp/org.eclipse.tracecompass.rcp.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.rcp.branding;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/rcp/org.eclipse.tracecompass.rcp.branding/about.properties
+++ b/rcp/org.eclipse.tracecompass.rcp.branding/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013, 2025 Ericsson
+# Copyright (c) 2013, 2026 Ericsson
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ blurb=Trace Compass\n\
 \n\
 Version: {featureVersion}\n\
 \n\
-Copyright (c) 2013, 2025 Ericsson and others.\n\
+Copyright (c) 2013, 2026 Ericsson and others.\n\
 \n\
 All rights reserved. This program and the accompanying materials are \
 made available under the terms of the Eclipse Public License 2.0 which \

--- a/rcp/org.eclipse.tracecompass.rcp.branding/plugin.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.branding/plugin.xml
@@ -21,7 +21,7 @@
             </property>
             <property
                   name="aboutText"
-                  value="Trace Compass&#x0A;&#x0A;Version: 11.2.0&#x0A;&#x0A;Copyright (c) 2013, 2025 Ericsson and others.&#x0A;&#x0A;All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/&#x0A;&#x0A;SPDX-License-Identifier: EPL-2.0">
+                  value="Trace Compass&#x0A;&#x0A;Version: 11.3.0&#x0A;&#x0A;Copyright (c) 2013, 2026 Ericsson and others.&#x0A;&#x0A;All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/&#x0A;&#x0A;SPDX-License-Identifier: EPL-2.0">
             </property>
             <property
                   name="windowImages"

--- a/rcp/org.eclipse.tracecompass.rcp.branding/pom.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.branding/pom.xml
@@ -21,8 +21,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.rcp-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/rcp/org.eclipse.tracecompass.rcp.incubator/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.incubator/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp.incubator"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.2.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.3.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
       <text>
          Trace Compass
 
-Version: 11.2.0
+Version: 11.3.0
 
-Copyright (c) 2013, 2025 Ericsson and others.
+Copyright (c) 2013, 2026 Ericsson and others.
 
 All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/
 

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.2.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.3.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
       <text>
          Trace Compass
 
-Version: 11.2.0
+Version: 11.3.0
 
-Copyright (c) 2013, 2025 Ericsson and others.
+Copyright (c) 2013, 2026 Ericsson and others.
 
 All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/
 

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.2.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.3.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
       <text>
          Trace Compass
 
-Version: 11.2.0
+Version: 11.3.0
 
-Copyright (c) 2013, 2025 Ericsson and others.
+Copyright (c) 2013, 2026 Ericsson and others.
 
 All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/
 

--- a/rcp/org.eclipse.tracecompass.rcp.product/pom.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.product/pom.xml
@@ -16,7 +16,7 @@
     <parent>
       <artifactId>org.eclipse.tracecompass.rcp-parent</artifactId>
       <groupId>org.eclipse.tracecompass</groupId>
-      <version>11.2.0-SNAPSHOT</version>
+      <version>11.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.eclipse.tracecompass.rcp.product</artifactId>
@@ -306,5 +306,4 @@
         </build>
       </profile>
     </profiles>
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.2.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.3.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
       <text>
          Trace Compass
 
-Version: 11.2.0
+Version: 11.3.0
 
-Copyright (c) 2013, 2025 Ericsson and others.
+Copyright (c) 2013, 2026 Ericsson and others.
 
 All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/
 

--- a/rcp/org.eclipse.tracecompass.rcp.rcptt.tests/pom.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.rcptt.tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.rcp-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <packaging>rcpttTest</packaging>

--- a/rcp/org.eclipse.tracecompass.rcp.ui.tests/pom.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.rcp-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.rcp.ui.tests</artifactId>

--- a/rcp/org.eclipse.tracecompass.rcp.ui/META-INF/MANIFEST.MF
+++ b/rcp/org.eclipse.tracecompass.rcp.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 11.2.0.qualifier
+Bundle-Version: 11.3.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.rcp.ui;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tracing.rcp.ui.TracingRcpPlugin

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.30/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.30/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.32/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.32/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.33/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.33/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.34/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.34/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.35/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.35/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.36/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.36/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.37/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.37/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/legacy/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.rcp"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.eclipse.tracecompass.rcp.branding"
       license-feature="org.eclipse.license"

--- a/rcp/org.eclipse.tracecompass.rcp/pom.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.rcp-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.rcp</artifactId>
@@ -137,5 +137,4 @@
     </plugins>
   </build>
 
-<version>11.2.0-SNAPSHOT</version>
 </project>

--- a/rcp/pom.xml
+++ b/rcp/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.rcp-parent</artifactId>

--- a/releng/org.eclipse.tracecompass.alltests/pom.xml
+++ b/releng/org.eclipse.tracecompass.alltests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.releng-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.alltests</artifactId>

--- a/releng/org.eclipse.tracecompass.integration.core.tests/pom.xml
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.releng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/releng/org.eclipse.tracecompass.integration.swtbot.tests/pom.xml
+++ b/releng/org.eclipse.tracecompass.integration.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.releng-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.integration.swtbot.tests</artifactId>

--- a/releng/org.eclipse.tracecompass.releng-site/pom.xml
+++ b/releng/org.eclipse.tracecompass.releng-site/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.releng-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.releng-site</artifactId>

--- a/releng/org.eclipse.tracecompass.target/pom.xml
+++ b/releng/org.eclipse.tracecompass.target/pom.xml
@@ -20,7 +20,7 @@
     <parent>
       <artifactId>org.eclipse.tracecompass.releng-parent</artifactId>
       <groupId>org.eclipse.tracecompass</groupId>
-      <version>11.2.0-SNAPSHOT</version>
+      <version>11.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.eclipse.tracecompass.target</artifactId>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.39.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.39.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="265">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e39" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.10/"/>

--- a/releng/org.eclipse.tracecompass.testing/feature.xml
+++ b/releng/org.eclipse.tracecompass.testing/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.testing"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.releng-parent</artifactId>

--- a/releng/scripts/update_parent_pom_versions.py
+++ b/releng/scripts/update_parent_pom_versions.py
@@ -23,5 +23,5 @@ import sys, re
 if len(sys.argv) < 4:
     sys.exit('Usage: python update_parent_pom_versions.py [file] [old version] [new version]')
 fileContent = open(sys.argv[1]).read()
-fileContent = re.sub("<version>" + sys.argv[2] + "-SNAPSHOT</version>(\n\s+</parent>)", "<version>" + sys.argv[3] + "-SNAPSHOT</version>\g<1>", fileContent)
+fileContent = re.sub("<version>" + sys.argv[2] + r"-SNAPSHOT</version>(\n\s+</parent>)", "<version>" + sys.argv[3] + r"-SNAPSHOT</version>\g<1>", fileContent)
 open(sys.argv[1], "w").write(fileContent)

--- a/releng/scripts/update_root_pom_versions.py
+++ b/releng/scripts/update_root_pom_versions.py
@@ -27,7 +27,7 @@ import sys, re
 if len(sys.argv) < 4:
     sys.exit('Usage: python update_root_pom_versions.py [file] [old version] [new version]')
 fileContent = open(sys.argv[1]).read()
-fileContent = re.sub("(<artifactId>org.eclipse.tracecompass.*</artifactId>\n\s+)<version>" + sys.argv[2] + "-SNAPSHOT</version>", "\g<1><version>" + sys.argv[3] + "-SNAPSHOT</version>", fileContent)
+fileContent = re.sub(r"(<artifactId>org.eclipse.tracecompass.*</artifactId>\n\s+)<version>" + sys.argv[2] + "-SNAPSHOT</version>", r"\g<1><version>" + sys.argv[3] + "-SNAPSHOT</version>", fileContent)
 # Also the target platform version being used
-fileContent = re.sub("<version>" + sys.argv[2] + "-SNAPSHOT</version>(\n\s+</artifact>)", "<version>" + sys.argv[3] + "-SNAPSHOT</version>\g<1>", fileContent)
+fileContent = re.sub("<version>" + sys.argv[2] + r"-SNAPSHOT</version>(\n\s+</artifact>)", "<version>" + sys.argv[3] + r"-SNAPSHOT</version>\g<1>", fileContent)
 open(sys.argv[1], "w").write(fileContent)

--- a/statesystem/org.eclipse.tracecompass.datastore.core.tests/pom.xml
+++ b/statesystem/org.eclipse.tracecompass.datastore.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.statesystem-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.datastore.core.tests</artifactId>

--- a/statesystem/org.eclipse.tracecompass.segmentstore.core.tests/pom.xml
+++ b/statesystem/org.eclipse.tracecompass.segmentstore.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.statesystem-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.segmentstore.core.tests</artifactId>

--- a/statesystem/org.eclipse.tracecompass.statesystem.core.tests/pom.xml
+++ b/statesystem/org.eclipse.tracecompass.statesystem.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.statesystem-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.statesystem.core.tests</artifactId>

--- a/statesystem/pom.xml
+++ b/statesystem/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.statesystem-parent</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.analysis.xml.core.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.ui.swtbot.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.analysis.xml.ui.swtbot.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.ui.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/tmf/org.eclipse.tracecompass.tmf.chart.core.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.chart.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.chart.core.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.chart.ui.swtbot.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.chart.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.chart.ui.swtbot.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.chart.ui.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.chart.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/tmf/org.eclipse.tracecompass.tmf.cli.core.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.cli.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.cli.core.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.cli/feature.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.cli/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.tmf.cli"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/tmf/org.eclipse.tracecompass.tmf.core.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/tmf/org.eclipse.tracecompass.tmf.filter.parser/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.filter.parser/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <name>Trace Compass Filter Parser</name>

--- a/tmf/org.eclipse.tracecompass.tmf.remote.core.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.remote.core.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/tmf/org.eclipse.tracecompass.tmf.remote.ui.swtbot.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.remote.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.remote.ui.swtbot.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.remote.ui.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.remote.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.remote.ui.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.remote/feature.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.remote/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.tmf.remote"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.ui.swtbot.tests</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf.ui.tests/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
 
   </parent>
 

--- a/tmf/org.eclipse.tracecompass.tmf.ui/pom.xml
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.tracecompass</groupId>
     <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf.ui</artifactId>

--- a/tmf/org.eclipse.tracecompass.tmf/feature.xml
+++ b/tmf/org.eclipse.tracecompass.tmf/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.tracecompass.tmf"
       label="%featureName"
-      version="11.2.0.qualifier"
+      version="11.3.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/tmf/pom.xml
+++ b/tmf/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>org.eclipse.tracecompass</artifactId>
     <groupId>org.eclipse.tracecompass</groupId>
-    <version>11.2.0-SNAPSHOT</version>
+    <version>11.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.tracecompass.tmf-parent</artifactId>


### PR DESCRIPTION
### What it does

- Update Trace Compass plug-in and feature versions for 11.3.0
- Add e4.39 and update eStaging targets for 2026-03
- Remove dependency on Eclipse ECF

### How to test

Build with e4.37 or eStaging target with Eclipse 2026-03

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
- Creating new stable branch for 11.3.0
- Modifying root pom.xml
- And other release steps

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped product and module versions from 11.2.0 → 11.3.0 across the project.
  * Updated copyright year to 2026.
* **New Features / Platform**
  * Added an Eclipse 4.39 target definition with Java 21 runtime.
  * Updated target platform components (CDT 12.4.0, Orbit 4.39.0, WebTools R3.41.0, JustJ 21.0.10) and related target repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->