### PR TITLE
releng: update features for new dependencies, move new product, feature to staging

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.0.16.qualifier
+Bundle-Version: 1.0.17.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.analysis.timing.core.tests;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/pom.xml
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
 
   <artifactId>org.eclipse.tracecompass.analysis.timing.core.tests</artifactId>
-  <version>1.0.16-SNAPSHOT</version>
+  <version>1.0.17-SNAPSHOT</version>
 
   <properties>
     <skipTests>${skip-tc-core-tests}</skipTests>

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/META-INF/MANIFEST.MF
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 6.2.2.qualifier
+Bundle-Version: 6.2.3.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.analysis.timing.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.analysis.timing.core.Activator

--- a/common/org.eclipse.tracecompass.common.core.tests/META-INF/MANIFEST.MF
+++ b/common/org.eclipse.tracecompass.common.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.1.13.qualifier
+Bundle-Version: 1.1.14.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.common.core.tests;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.common.core.tests.Activator

--- a/common/org.eclipse.tracecompass.common.core.tests/pom.xml
+++ b/common/org.eclipse.tracecompass.common.core.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
 
   <artifactId>org.eclipse.tracecompass.common.core.tests</artifactId>
-  <version>1.1.13-SNAPSHOT</version>
+  <version>1.1.14-SNAPSHOT</version>
 
   <properties>
     <skipTests>${skip-tc-core-tests}</skipTests>

--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/META-INF/MANIFEST.MF
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.0.19.qualifier
+Bundle-Version: 1.0.20.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.ctf.core.tests;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.ctf.core.tests.CtfCoreTestPlugin

--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/pom.xml
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/pom.xml
@@ -23,7 +23,7 @@
 
   <name>Trace Compass CTF Core Tests Plug-in</name>
   <artifactId>org.eclipse.tracecompass.ctf.core.tests</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <version>1.0.20-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core/META-INF/MANIFEST.MF
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 5.0.1.qualifier
+Bundle-Version: 5.0.2.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.ctf.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.tmf.ctf.core.Activator

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests/META-INF/MANIFEST.MF
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.0.14.qualifier
+Bundle-Version: 1.0.15.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests/pom.xml
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests/pom.xml
@@ -24,7 +24,7 @@
   </properties>
 
   <artifactId>org.eclipse.tracecompass.tmf.ctf.ui.swtbot.tests</artifactId>
-  <version>1.0.14-SNAPSHOT</version>
+  <version>1.0.15-SNAPSHOT</version>
 
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/lttng/org.eclipse.tracecompass.lttng2.kernel.core/META-INF/MANIFEST.MF
+++ b/lttng/org.eclipse.tracecompass.lttng2.kernel.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.2.1.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.lttng2.kernel.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.lttng2.kernel.core.Activator

--- a/lttng/org.eclipse.tracecompass.lttng2.ust.core/META-INF/MANIFEST.MF
+++ b/lttng/org.eclipse.tracecompass.lttng2.ust.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 5.3.0.qualifier
+Bundle-Version: 5.3.1.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.lttng2.ust.core;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.lttng2.ust.core.Activator

--- a/rcp/org.eclipse.tracecompass.rcp.product/staging/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/staging/tracing.product
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Trace Compass" uid="org.eclipse.tracecompass.rcp" id="org.eclipse.tracecompass.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="11.3.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+
+   <aboutInfo>
+      <image path="/org.eclipse.tracecompass.rcp.branding/icons/tc_about.png"/>
+      <text>
+         Trace Compass
+
+Version: 11.3.0
+
+Copyright (c) 2013, 2026 Ericsson and others.
+
+All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/
+
+SPDX-License-Identifier: EPL-2.0
+      </text>
+   </aboutInfo>
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <programArgs>-data @noDefault
+      </programArgs>
+      <programArgsLin>--launcher.GTK_version 3
+      </programArgsLin>
+      <vmArgsLin>-Xms512m -Xmx1024m -Dosgi.requiredJavaVersion=17
+      </vmArgsLin>
+      <vmArgsMac>-Xms512m -Xmx1024m -XstartOnFirstThread -Dosgi.requiredJavaVersion=17 -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+      <vmArgsWin>-Xms512m -Xmx1024m -Dosgi.requiredJavaVersion=17
+      </vmArgsWin>
+   </launcherArgs>
+
+   <windowImages i16="/org.eclipse.tracecompass.rcp.branding/icons/png/tc_icon_16x16.png" i32="/org.eclipse.tracecompass.rcp.branding/icons/png/tc_icon_32x32.png" i48="/org.eclipse.tracecompass.rcp.branding/icons/png/tc_icon_48x48.png" i64="/org.eclipse.tracecompass.rcp.branding/icons/png/tc_icon_64x64.png" i128="/org.eclipse.tracecompass.rcp.branding/icons/png/tc_icon_128x128.png" i256="/org.eclipse.tracecompass.rcp.branding/icons/png/tc_icon_256x256.png"/>
+
+   <splash
+      location="org.eclipse.tracecompass.rcp.branding" />
+   <launcher name="tracecompass">
+      <linux icon="../org.eclipse.tracecompass.rcp.branding/icons/xpm/tc_icon_256x256.xpm"/>
+      <macosx icon="../org.eclipse.tracecompass.rcp.branding/icons/icns/tc_icon.icns"/>
+      <win useIco="true">
+         <ico path="../org.eclipse.tracecompass.rcp.branding/icons/ico/tc_icon.ico"/>
+         <bmp/>
+      </win>
+   </launcher>
+
+   <vm>
+      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</linux>
+      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</macos>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</windows>
+   </vm>
+
+   <license>
+        <url>http://eclipse.org/legal/epl/notice.php</url>
+        <text>
+   Eclipse Foundation Software User Agreement
+
+November 22, 2017
+Usage Of Content
+
+THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY &quot;CONTENT&quot;). USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW. BY USING THE CONTENT, YOU AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED BY THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW. IF YOU DO NOT AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW, THEN YOU MAY NOT USE THE CONTENT.
+Applicable Licenses
+
+Unless otherwise indicated, all Content made available by the Eclipse Foundation is provided to you under the terms and conditions of the Eclipse Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is provided with this Content and is also available at http://www.eclipse.org/legal/epl-2.0. For purposes of the EPL, &quot;Program&quot; will mean the Content.
+
+Content includes, but is not limited to, source code, object code, documentation and other files maintained in the Eclipse Foundation source code repository (&quot;Repository&quot;) in software modules (&quot;Modules&quot;) and made available as downloadable archives (&quot;Downloads&quot;).
+
+    Content may be structured and packaged into modules to facilitate delivering, extending, and upgrading the Content. Typical modules may include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and features (&quot;Features&quot;).
+    Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java™ ARchive) in a directory named &quot;plugins&quot;.
+    A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material. Each Feature may be packaged as a sub-directory in a directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of the Plug-ins and/or Fragments associated with that Feature.
+    Features may also include other Features (&quot;Included Features&quot;). Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of Included Features.
+
+The terms and conditions governing Plug-ins and Fragments should be contained in files named &quot;about.html&quot; (&quot;Abouts&quot;). The terms and conditions governing Features and Included Features should be contained in files named &quot;license.html&quot; (&quot;Feature Licenses&quot;). Abouts and Feature Licenses may be located in any directory of a Download or Module including, but not limited to the following locations:
+
+    The top-level (root) directory
+    Plug-in and Fragment directories
+    Inside Plug-ins and Fragments packaged as JARs
+    Sub-directories of the directory named &quot;src&quot; of certain Plug-ins
+    Feature directories
+
+Note: if a Feature made available by the Eclipse Foundation is installed using the Provisioning Technology (as defined below), you must agree to a license (&quot;Feature Update License&quot;) during the installation process. If the Feature contains Included Features, the Feature Update License should either provide you with the terms and conditions governing the Included Features or inform you where you can locate them. Feature Update Licenses may be found in the &quot;license&quot; property of files named &quot;feature.properties&quot; found within a Feature. Such Abouts, Feature Licenses, and Feature Update Licenses contain the terms and conditions (or references to such terms and conditions) that govern your use of the associated Content in that directory.
+
+THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):
+
+    Eclipse Public License Version 1.0 (available at http://www.eclipse.org/legal/epl-v10.html)
+    Eclipse Distribution License Version 1.0 (available at http://www.eclipse.org/licenses/edl-v1.0.html)
+    Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)
+    Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)
+    Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)
+    Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)
+
+IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License is provided, please contact the Eclipse Foundation to determine what terms and conditions govern that particular Content.
+Use of Provisioning Technology
+
+The Eclipse Foundation makes available provisioning software, examples of which include, but are not limited to, p2 and the Eclipse Update Manager (&quot;Provisioning Technology&quot;) for the purpose of allowing users to install software, documentation, information and/or other materials (collectively &quot;Installable Software&quot;). This capability is provided with the intent of allowing such users to install, extend and update Eclipse-based products. Information about packaging Installable Software is available at http://eclipse.org/equinox/p2/repository_packaging.html (&quot;Specification&quot;).
+
+You may use Provisioning Technology to allow other parties to install Installable Software. You shall be responsible for enabling the applicable license agreements relating to the Installable Software to be presented to, and accepted by, the users of the Provisioning Technology in accordance with the Specification. By using Provisioning Technology in such a manner and making it available in accordance with the Specification, you further acknowledge your agreement to, and the acquisition of all necessary rights to permit the following:
+
+    A series of actions may occur (&quot;Provisioning Process&quot;) in which a user may execute the Provisioning Technology on a machine (&quot;Target Machine&quot;) with the intent of installing, extending or updating the functionality of an Eclipse-based product.
+    During the Provisioning Process, the Provisioning Technology may cause third party Installable Software or a portion thereof to be accessed and copied to the Target Machine.
+    Pursuant to the Specification, you will provide to the user the terms and conditions that govern the use of the Installable Software (&quot;Installable Software Agreement&quot;) and such Installable Software Agreement shall be accessed from the Target Machine in accordance with the Specification. Such Installable Software Agreement must inform the user of the terms and conditions that govern the Installable Software and must solicit acceptance by the end user in the manner prescribed in such Installable Software Agreement. Upon such indication of agreement by the user, the provisioning Technology will complete installation of the Installable Software.
+
+Cryptography
+
+Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check the country&apos;s laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted.
+
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.
+         </text>
+   </license>
+
+   <plugins>
+   </plugins>
+
+   <features>
+      <feature id="org.eclipse.tracecompass.rcp.branding.feature"/>
+      <feature id="org.eclipse.tracecompass.rcp"/>
+      <feature id="org.eclipse.tracecompass.lttng2.kernel"/>
+      <feature id="org.eclipse.tracecompass.lttng2.ust"/>
+      <feature id="org.eclipse.tracecompass.lttng2.control"/>
+      <feature id="org.eclipse.equinox.p2.core.feature"/>
+      <feature id="org.eclipse.platform"/>
+      <feature id="org.eclipse.help"/>
+      <feature id="org.eclipse.emf.ecore"/>
+      <feature id="org.eclipse.equinox.p2.rcp.feature"/>
+      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.tracecompass.tmf"/>
+      <feature id="org.eclipse.rcp"/>
+      <feature id="org.eclipse.e4.rcp"/>
+      <feature id="org.eclipse.emf.common"/>
+      <feature id="org.eclipse.equinox.p2.extras.feature"/>
+      <feature id="org.eclipse.tracecompass.btf"/>
+      <feature id="org.eclipse.tracecompass.ctf"/>
+      <feature id="org.eclipse.tracecompass.tmf.ctf"/>
+      <feature id="org.eclipse.tracecompass.tmf.pcap"/>
+      <feature id="org.eclipse.ecf.core.feature"/>
+      <feature id="org.eclipse.ecf.filetransfer.feature"/>
+      <feature id="org.eclipse.tracecompass.rcp.incubator"/>
+      <feature id="org.eclipse.tracecompass.jsontrace"/>
+      <feature id="org.eclipse.ecf.filetransfer.httpclient5.feature"/>
+      <feature id="org.eclipse.ecf.filetransfer.httpclientjava.feature"/>
+      <feature id="org.eclipse.tracecompass.tmf.cli"/>
+      <feature id="org.eclipse.equinox.executable"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped" installMode="root"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="org.eclipse.tracecompass.rcp.ui" autoStart="false" startLevel="5" />
+      <plugin id="org.eclipse.update.configurator" autoStart="true" startLevel="3" />
+   </configurations>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+   </repositories>
+
+   <preferencesInfo>
+      <targetfile overwrite="false"/>
+   </preferencesInfo>
+
+   <cssInfo>
+   </cssInfo>
+
+</product>

--- a/rcp/org.eclipse.tracecompass.rcp/staging/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/staging/feature.xml
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.tracecompass.rcp"
+      label="%featureName"
+      version="11.3.0.qualifier"
+      provider-name="%featureProvider"
+      plugin="org.eclipse.tracecompass.rcp.branding"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <requires>
+      <import feature="org.eclipse.e4.rcp" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.equinox.p2.core.feature" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.equinox.p2.extras.feature" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.help" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.tracecompass.tmf" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.platform" version="0.0.0" match="greaterOrEqual"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.orbit.xml-apis-ext"
+         version="0.0.0"/>
+
+   <plugin
+         id="jakarta.activation-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="json"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.antlr.runtime"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.tracecompass.rcp.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.tracecompass.rcp.doc.user"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.swtchart"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.swtchart.extensions"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.google.gson"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.google.guava"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.cdt.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.cdt.core.native"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ui.trace"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.concurrent"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ui.views.log"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-io"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.e4.ui.progress"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jdt.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jdt.core.compiler.batch"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.remote.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.remote.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.remote.jsch.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.remote.jsch.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.common.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.common.environment"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.common.frameworks"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.common.frameworks.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.common.project.facet.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.common.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.common.uriresolver"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.sse.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.sse.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.validation"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.validation.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.xml.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.xml.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.xerces"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.xml.resolver"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.xml.serializer"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-compress"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.lang3"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.wst.xsd.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.xsd"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.cli"
+         version="0.0.0"/>
+
+   <plugin
+         id="jakarta.xml.bind-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.sat4j.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.sat4j.pb"
+         version="0.0.0"/>
+
+   <plugin
+         id="slf4j.api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.mozilla.javascript"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.scr"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.sun.jna"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.sun.jna.platform"
+         version="0.0.0"/>
+
+   <plugin
+         id="jakarta.annotation-api"
+         version="1.3.5"/>
+
+   <plugin
+         id="jakarta.annotation-api"
+         version="2.1.1"/>
+
+   <plugin
+         id="jakarta.inject.jakarta.inject-api"
+         version="1.0.5"/>
+
+   <plugin
+         id="jakarta.inject.jakarta.inject-api"
+         version="2.0.1"/>
+
+   <plugin
+         id="org.apache.lucene.analysis-common"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.lucene.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.lucene.analysis-smartcn"
+         version="0.0.0"/>
+
+   <plugin
+         id="bcpg"
+         version="0.0.0"/>
+
+   <plugin
+         id="bcprov"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.mortbay.jasper.mortbay-apache-jsp"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.google.guava.failureaccess"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-logging"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.search.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.servlet-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.aries.spifly.dynamic.bundle"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.objectweb.asm"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.objectweb.asm.commons"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.objectweb.asm.util"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.objectweb.asm.tree"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.objectweb.asm.tree.analysis"
+         version="0.0.0"/>
+
+   <plugin
+         id="ch.qos.logback.classic"
+         version="0.0.0"/>
+
+   <plugin
+         id="ch.qos.logback.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.css"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.i18n"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.util"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.constants"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.http"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.server"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.session"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee8.servlet"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee8.server"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.util"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.io"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.security"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee8.security"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.ibm.icu"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.http.service.api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.http.whiteboard"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.mortbay.jasper.apache-el"
+         version="0.0.0"/>
+
+   <plugin
+         id="jakarta.el-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="jakarta.servlet.jsp-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="jakarta.servlet-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="bcutil"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.component.annotations"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.osgi.services"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.tukaani.xz"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.xmlgraphics"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.launchbar.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.github.weisj.jsvg"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.tracecompass.trace-event-logger"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.fasterxml.jackson.core.jackson-core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.command"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.runtime"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.shell"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.cm"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.component"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.device"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.event"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.metatype"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.provisioning"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.upnp"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.useradmin"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.wireadmin"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.function"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.measurement"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.position"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.promise"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.xml"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.prefs"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.ant"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.jcraft.jsch"
+         version="0.0.0"/>
+
+</feature>

--- a/releng/org.eclipse.tracecompass.integration.core.tests/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.0.14.qualifier
+Bundle-Version: 1.0.15.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.integration.core.tests;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/releng/org.eclipse.tracecompass.integration.core.tests/pom.xml
+++ b/releng/org.eclipse.tracecompass.integration.core.tests/pom.xml
@@ -21,7 +21,7 @@
   </parent>
 
   <artifactId>org.eclipse.tracecompass.integration.core.tests</artifactId>
-  <version>1.0.14-SNAPSHOT</version>
+  <version>1.0.15-SNAPSHOT</version>
 
   <properties>
     <skipTests>${skip-tc-core-tests}</skipTests>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.39.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.39.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e39" sequenceNumber="1">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.39" sequenceNumber="265">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.10/"/>
@@ -39,9 +39,27 @@
 <unit id="org.apache.commons.commons-io" version="0.0.0"/>
 <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
+<unit id="org.apache.felix.gogo.command" version="0.0.0"/>
+<unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
+<unit id="org.apache.felix.gogo.shell" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
 <unit id="org.mortbay.jasper.mortbay-apache-jsp" version="9.0.111"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
+<unit id="org.osgi.util.function" version="0.0.0"/>
+<unit id="org.osgi.util.promise" version="0.0.0"/>
+<unit id="org.osgi.util.measurement" version="0.0.0"/>
+<unit id="org.osgi.util.position" version="0.0.0"/>
+<unit id="org.osgi.util.xml" version="0.0.0"/>
+<unit id="org.osgi.service.cm" version="0.0.0"/>
+<unit id="org.osgi.service.component" version="0.0.0"/>
+<unit id="org.osgi.service.device" version="0.0.0"/>
+<unit id="org.osgi.service.event" version="0.0.0"/>
+<unit id="org.osgi.service.metatype" version="0.0.0"/>
+<unit id="org.osgi.service.prefs" version="0.0.0"/>
+<unit id="org.osgi.service.provisioning" version="0.0.0"/>
+<unit id="org.osgi.service.upnp" version="0.0.0"/>
+<unit id="org.osgi.service.useradmin" version="0.0.0"/>
+<unit id="org.osgi.service.wireadmin" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.39.0/"/>
@@ -88,6 +106,13 @@
 <unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xsd" version="0.0.0"/>
 <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.45.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/rt/ecf/3.16.2/site.p2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -39,9 +39,27 @@
 <unit id="org.apache.commons.commons-io" version="0.0.0"/>
 <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
+<unit id="org.apache.felix.gogo.command" version="0.0.0"/>
+<unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
+<unit id="org.apache.felix.gogo.shell" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
 <unit id="org.mortbay.jasper.mortbay-apache-jsp" version="9.0.111"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
+<unit id="org.osgi.util.function" version="0.0.0"/>
+<unit id="org.osgi.util.promise" version="0.0.0"/>
+<unit id="org.osgi.util.measurement" version="0.0.0"/>
+<unit id="org.osgi.util.position" version="0.0.0"/>
+<unit id="org.osgi.util.xml" version="0.0.0"/>
+<unit id="org.osgi.service.cm" version="0.0.0"/>
+<unit id="org.osgi.service.component" version="0.0.0"/>
+<unit id="org.osgi.service.device" version="0.0.0"/>
+<unit id="org.osgi.service.event" version="0.0.0"/>
+<unit id="org.osgi.service.metatype" version="0.0.0"/>
+<unit id="org.osgi.service.prefs" version="0.0.0"/>
+<unit id="org.osgi.service.provisioning" version="0.0.0"/>
+<unit id="org.osgi.service.upnp" version="0.0.0"/>
+<unit id="org.osgi.service.useradmin" version="0.0.0"/>
+<unit id="org.osgi.service.wireadmin" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.39.0/"/>
@@ -88,6 +106,13 @@
 <unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xsd" version="0.0.0"/>
 <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.45.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/rt/ecf/3.16.2/site.p2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION


### What it does

- Update staging feature.xml for e4.39
- Update staging product
- Update staging target
- Bump versions for the RC1 step in Release preparation

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Trace Compass RCP product (v11.3.0) enabling a standalone tracing application with branding, icons, and Java 17 runtime settings.
  * Introduced a feature descriptor enumerating bundled plugins and runtime dependencies for the product.

* **Chores**
  * Bumped bundle and module versions across analysis, common, CTF, LTTNG, and integration test components.
  * Updated target platform to include additional ECF repositories and OSGi utility/runtime bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->