### PR TITLE
releng: Build with tracecompass-e4.39 by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
-    <target-platform>tracecompass-e4.38</target-platform>
+    <target-platform>tracecompass-e4.39</target-platform>
 
     <rcptt-version>2.5.4</rcptt-version>
     <!-- Disable GTK3 because it's not quite usable yet and it can make the tests hang (bug in IcedTea http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1736) -->

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.30-e4.38/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.30-e4.38/tracing.product
@@ -135,6 +135,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.pcap"/>
+      <feature id="org.eclipse.ecf.core.ssl.feature"/>
+      <feature id="org.eclipse.ecf.filetransfer.ssl.feature"/>
       <feature id="org.eclipse.ecf.core.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.tracecompass.rcp.incubator"/>

--- a/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
@@ -135,8 +135,6 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.pcap"/>
-      <feature id="org.eclipse.ecf.core.ssl.feature"/>
-      <feature id="org.eclipse.ecf.filetransfer.ssl.feature"/>
       <feature id="org.eclipse.ecf.core.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.tracecompass.rcp.incubator"/>

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -206,10 +206,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.swtchart"
-         version="0.0.0"/>
-
-   <plugin
          id="jakarta.xml.bind-api"
          version="0.0.0"/>
 
@@ -443,6 +439,86 @@
 
    <plugin
          id="com.fasterxml.jackson.core.jackson-core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.command"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.runtime"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.shell"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.cm"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.component"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.device"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.event"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.metatype"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.provisioning"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.upnp"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.useradmin"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.wireadmin"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.function"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.measurement"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.position"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.promise"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.xml"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.prefs"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.ant"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.jcraft.jsch"
          version="0.0.0"/>
 
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.38/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.38/feature.xml
@@ -206,6 +206,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.swtchart"
+         version="0.0.0"/>
+
+   <plugin
          id="jakarta.xml.bind-api"
          version="0.0.0"/>
 
@@ -439,86 +443,6 @@
 
    <plugin
          id="com.fasterxml.jackson.core.jackson-core"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.command"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.runtime"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.shell"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.cm"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.component"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.device"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.event"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.metatype"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.provisioning"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.upnp"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.useradmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.wireadmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.function"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.measurement"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.position"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.promise"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.xml"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.prefs"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.ant"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.jcraft.jsch"
          version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
### What it does

releng: Build with tracecompass-e4.39 target by default

### How to test

Build in stable branch with default target.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Eclipse target platform to version 4.39
  * Reorganized SSL and dependency configurations across legacy and current product variants
  * Adjusted plugin dependencies to align with platform version requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->