### PR TITLE
releng: 11.3.0 release

### DIFF
--- a/TraceCompass.setup
+++ b/TraceCompass.setup
@@ -75,7 +75,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="tracecompass-e4.38"
+      defaultValue="tracecompass-e4.39"
       storageURI="scope://Workspace"
       label="Target Platform">
     <choice
@@ -136,6 +136,9 @@
         value="tracecompass-e4.38"
         label="Trace Compass Eclipse 2025-12 - 4.38"/>
     <choice
+        value="tracecompass-e4.39"
+        label="Trace Compass Eclipse 2026-03 - 4.39"/>
+    <choice
         value="tracecompass-eStaging"
         label="Trace Compass Eclipse Latest"/>
     <description>Choose the compatibly level of the target platform</description>
@@ -172,15 +175,15 @@
     <setupTask
         xsi:type="pde:TargetPlatformTask"
         id="tracecompass-baseline-resolve"
-        name="tracecompass-baseline-11.2.0"
+        name="tracecompass-baseline-11.3.0"
         activate="false">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask
         xsi:type="pde:APIBaselineFromTargetTask"
-        id="tracecompass-baseline-11.2.0"
+        id="tracecompass-baseline-11.3.0"
         name="Trace Compass Baseline"
-        targetName="tracecompass-baseline-11.2.0">
+        targetName="tracecompass-baseline-11.3.0">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
-    <target-platform>tracecompass-e4.38</target-platform>
+    <target-platform>tracecompass-e4.39</target-platform>
 
     <rcptt-version>2.5.4</rcptt-version>
     <!-- Disable GTK3 because it's not quite usable yet and it can make the tests hang (bug in IcedTea http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1736) -->

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.30-e4.38/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.30-e4.38/tracing.product
@@ -135,6 +135,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.pcap"/>
+      <feature id="org.eclipse.ecf.core.ssl.feature"/>
+      <feature id="org.eclipse.ecf.filetransfer.ssl.feature"/>
       <feature id="org.eclipse.ecf.core.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.tracecompass.rcp.incubator"/>

--- a/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
@@ -135,8 +135,6 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.pcap"/>
-      <feature id="org.eclipse.ecf.core.ssl.feature"/>
-      <feature id="org.eclipse.ecf.filetransfer.ssl.feature"/>
       <feature id="org.eclipse.ecf.core.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.tracecompass.rcp.incubator"/>

--- a/rcp/org.eclipse.tracecompass.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/feature.xml
@@ -206,10 +206,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.swtchart"
-         version="0.0.0"/>
-
-   <plugin
          id="jakarta.xml.bind-api"
          version="0.0.0"/>
 
@@ -443,6 +439,86 @@
 
    <plugin
          id="com.fasterxml.jackson.core.jackson-core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.command"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.runtime"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.felix.gogo.shell"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.cm"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.component"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.device"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.event"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.metatype"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.provisioning"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.upnp"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.useradmin"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.wireadmin"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.function"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.measurement"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.position"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.promise"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.util.xml"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.prefs"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.ant"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.jcraft.jsch"
          version="0.0.0"/>
 
 </feature>

--- a/rcp/org.eclipse.tracecompass.rcp/legacy-e4.38/feature.xml
+++ b/rcp/org.eclipse.tracecompass.rcp/legacy-e4.38/feature.xml
@@ -206,6 +206,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.swtchart"
+         version="0.0.0"/>
+
+   <plugin
          id="jakarta.xml.bind-api"
          version="0.0.0"/>
 
@@ -439,86 +443,6 @@
 
    <plugin
          id="com.fasterxml.jackson.core.jackson-core"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.command"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.runtime"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.shell"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.cm"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.component"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.device"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.event"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.metatype"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.provisioning"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.upnp"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.useradmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.wireadmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.function"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.measurement"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.position"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.promise"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.xml"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.prefs"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.ant"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.jcraft.jsch"
          version="0.0.0"/>
 
 </feature>

--- a/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-11.3.0.target
+++ b/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-11.3.0.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="tracecompass-baseline-11.2.0" sequenceNumber="1">
+<?pde version="3.8"?><target name="tracecompass-baseline-11.3.0" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.analysis.counters.core" version="0.0.0"/>
@@ -46,11 +46,11 @@
 <unit id="org.eclipse.tracecompass.tmf.remote.core" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tracecompass/releases/11.2.0/repository/"/>
+<repository location="https://download.eclipse.org/tracecompass/releases/11.3.0/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.core.runtime" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2025-12"/>
+<repository location="https://download.eclipse.org/releases/2026-03"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
### What it does


releng: Update OOMPH setup file for 11.3.0
releng: Add Trace Compass 11.3.0 baseline
releng: Build with tracecompass-e4.39 target by default

### How to test

Build with default target
Set tracecompass-11.2.0 baseline
Setup with OOMPH

### Follow-ups

N/A

### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Eclipse 2026-03 (e4.39) as the default target platform.

* **Chores**
  * Updated Trace Compass baseline from version 11.2.0 to 11.3.0.
  * Updated project dependencies and plugin inclusions; legacy builds maintain compatibility with earlier Eclipse versions.
  * Adjusted SSL feature configuration across product variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->