### PR TITLE
releng: 11.3.0 release

### DIFF
--- a/TraceCompass.setup
+++ b/TraceCompass.setup
@@ -75,7 +75,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="tracecompass-e4.38"
+      defaultValue="tracecompass-e4.39"
       storageURI="scope://Workspace"
       label="Target Platform">
     <choice
@@ -136,6 +136,9 @@
         value="tracecompass-e4.38"
         label="Trace Compass Eclipse 2025-12 - 4.38"/>
     <choice
+        value="tracecompass-e4.39"
+        label="Trace Compass Eclipse 2026-03 - 4.39"/>
+    <choice
         value="tracecompass-eStaging"
         label="Trace Compass Eclipse Latest"/>
     <description>Choose the compatibly level of the target platform</description>
@@ -172,15 +175,15 @@
     <setupTask
         xsi:type="pde:TargetPlatformTask"
         id="tracecompass-baseline-resolve"
-        name="tracecompass-baseline-11.2.0"
+        name="tracecompass-baseline-11.3.0"
         activate="false">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask
         xsi:type="pde:APIBaselineFromTargetTask"
-        id="tracecompass-baseline-11.2.0"
+        id="tracecompass-baseline-11.3.0"
         name="Trace Compass Baseline"
-        targetName="tracecompass-baseline-11.2.0">
+        targetName="tracecompass-baseline-11.3.0">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask

--- a/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-11.3.0.target
+++ b/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-11.3.0.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="tracecompass-baseline-11.2.0" sequenceNumber="1">
+<?pde version="3.8"?><target name="tracecompass-baseline-11.3.0" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.analysis.counters.core" version="0.0.0"/>
@@ -46,11 +46,11 @@
 <unit id="org.eclipse.tracecompass.tmf.remote.core" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tracecompass/releases/11.2.0/repository/"/>
+<repository location="https://download.eclipse.org/tracecompass/releases/11.3.0/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.core.runtime" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2025-12"/>
+<repository location="https://download.eclipse.org/releases/2026-03"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
### What it does

- releng: Update OOMPH setup file for 11.3.0
- releng: Add Trace Compass 11.3.0 baseline
- releng: Build with tracecompass-e4.39 target by default

### How to test

- Build with default target
- Set tracecompass-11.2.0 baseline
- Setup with OOMPH

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
