### PR TITLE
Thread statuses improvements

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernel/KernelThreadInformationProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/analysis/os/linux/core/kernel/KernelThreadInformationProvider.java
@@ -548,7 +548,7 @@ public final class KernelThreadInformationProvider {
         if (ss == null) {
             return Objects.requireNonNull(Collections.emptyMap());
         }
-        List<Long> currentTimes = times.stream().filter(time -> (time > ss.getCurrentEndTime() || time < ss.getStartTime())).sorted().collect(Collectors.toList());
+        List<Long> currentTimes = times.stream().filter(time -> (time < ss.getCurrentEndTime() && time > ss.getStartTime())).sorted().collect(Collectors.toList());
         if (currentTimes.isEmpty()) {
             return Objects.requireNonNull(Collections.emptyMap());
         }

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/FlameChartDataProviderTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/FlameChartDataProviderTest.java
@@ -24,9 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import java.util.Set;
-//import java.util.stream.Collectors;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -46,6 +44,9 @@ import org.eclipse.tracecompass.tmf.core.model.CommonStatusMessage;
 import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
 import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
 import org.eclipse.tracecompass.tmf.core.model.StyleProperties.SymbolType;
+import org.eclipse.tracecompass.tmf.core.model.annotations.Annotation;
+import org.eclipse.tracecompass.tmf.core.model.annotations.AnnotationCategoriesModel;
+import org.eclipse.tracecompass.tmf.core.model.annotations.AnnotationModel;
 import org.eclipse.tracecompass.tmf.core.model.filters.SelectionTimeQueryFilter;
 import org.eclipse.tracecompass.tmf.core.model.filters.TimeQueryFilter;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.ITimeGraphArrow;
@@ -55,10 +56,6 @@ import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphArrow;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphModel;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphState;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
-import org.eclipse.tracecompass.tmf.core.model.annotations.Annotation;
-//import org.eclipse.tracecompass.tmf.core.model.annotations.Annotation;
-import org.eclipse.tracecompass.tmf.core.model.annotations.AnnotationCategoriesModel;
-import org.eclipse.tracecompass.tmf.core.model.annotations.AnnotationModel;
 import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.junit.Test;
@@ -262,7 +259,7 @@ public class FlameChartDataProviderTest extends CallStackTestBase2 {
                 new TimeGraphState(6, 2, null, new OutputElementStyle(LinuxStyle.WAIT_FOR_CPU.getLabel())),
                 new TimeGraphState(8, 2, null, new OutputElementStyle(LinuxStyle.USERMODE.getLabel())),
                 new TimeGraphState(10, 2, null, new OutputElementStyle(LinuxStyle.WAIT_FOR_CPU.getLabel())),
-                new TimeGraphState(12, 8, null, new OutputElementStyle(LinuxStyle.USERMODE.getLabel()))), true);
+                new TimeGraphState(12, 8, "openat", new OutputElementStyle(LinuxStyle.SYSCALL.getLabel()))), true);
 
         // Get the row model for those entries with low resolution
         rowResponse = dataProvider.fetchRowModel(FetchParametersUtils.selectionTimeQueryToMap(new SelectionTimeQueryFilter(3, 15, 2, selectedIds)), new NullProgressMonitor());
@@ -300,7 +297,7 @@ public class FlameChartDataProviderTest extends CallStackTestBase2 {
         // Verify kernel statuses of tid 6
         verifyStates(rows, FlameDataProviderTestUtils.findEntryByDepthAndType(tid6Children, -1, EntryType.KERNEL), ImmutableList.of(
                 new TimeGraphState(1, 5, null, new OutputElementStyle(LinuxStyle.USERMODE.getLabel())),
-                new TimeGraphState(12, 8, null, new OutputElementStyle(LinuxStyle.USERMODE.getLabel()))), true);
+                new TimeGraphState(12, 8, "openat", new OutputElementStyle(LinuxStyle.SYSCALL.getLabel()))), true);
 
         // Check arrows
         FlameChartEntryModel tid2 = FlameDataProviderTestUtils.findEntryByNameAndType(modelEntries, "2", EntryType.LEVEL);
@@ -436,11 +433,9 @@ public class FlameChartDataProviderTest extends CallStackTestBase2 {
         assertNotNull(rowModel);
         @SuppressWarnings("null")
         List<ITimeGraphState> states = rowModel.getStates();
+        assertEquals(expectedStates.size(), states.size());
         for (int i = 0; i < states.size(); i++) {
             String entryName = entry.getName();
-            if (i > expectedStates.size() - 1) {
-                fail("Unexpected state at position " + i + FOR_ENTRY + entryName + ": " + states.get(i));
-            }
             ITimeGraphState actual = states.get(i);
             ITimeGraphState expected = expectedStates.get(i);
             assertEquals("State start time at " + i + FOR_ENTRY + entryName, expected.getStartTime(), actual.getStartTime());

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/callgraph2/FlameGraphDataProviderTest.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/src/org/eclipse/tracecompass/analysis/profiling/core/tests/callgraph2/FlameGraphDataProviderTest.java
@@ -300,7 +300,7 @@ public class FlameGraphDataProviderTest extends CallStackTestBase2 {
         assertNotNull(tooltipModel);
         if (expectedObject.equals("null")) {
             assertTrue(tooltipModel.isEmpty());
-        } else if (List.of(ProcessStatus.RUN.toString(), ProcessStatus.WAIT_CPU.toString()).contains(expectedObject)) {
+        } else if (List.of(ProcessStatus.RUN.toString(), ProcessStatus.WAIT_CPU.toString(), ProcessStatus.RUN_SYTEMCALL.toString()).contains(expectedObject)) {
             if (isAction) {
                 assertNotNull(tooltipModel);
             } else {

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs2/KernelStateProviderStub.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/stubs/org/eclipse/tracecompass/analysis/profiling/core/tests/stubs2/KernelStateProviderStub.java
@@ -59,14 +59,15 @@ public class KernelStateProviderStub extends AbstractTmfStateProvider {
     @Override
     protected void eventHandle(ITmfEvent event) {
         ITmfStateSystemBuilder ssb = getStateSystemBuilder();
-        if (ssb == null) {
+        if (ssb == null || event.getName().equals("instant_event")) {
             return;
         }
         int threadQuark = ssb.getQuarkAbsoluteAndAdd(Attributes.THREADS, event.getContent().getFieldValue(String.class, "tid"));
         boolean isEntry = event.getName().equals(ENTRY);
         long timestamp = event.getTimestamp().getValue();
         if (isEntry) {
-            if (event.getName().equals("op4")) {
+            String operationName = event.getContent().getFieldValue(String.class, "op");
+            if (operationName != null && operationName.equals("op4")) {
                 int systemCallQuark = ssb.getQuarkRelativeAndAdd(threadQuark, Attributes.SYSTEM_CALL);
                 ssb.modifyAttribute(timestamp, "openat", systemCallQuark);
                 /* Put the process in system call mode */

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowFull2Times
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowFull2Times
@@ -1,14 +1,14 @@
 function,0,level,2:0,8,op4,op4
 function,1,level,2:0,8,-,null
 function,2,level,2:0,8,-,null
-kernel,Kernel statuses,level,2:0,8,RUN,RUN
+kernel,Kernel statuses,level,2:0,8,RUN_SYTEMCALL,RUN_SYTEMCALL
 function,0,level,3:0,17,op2,op2
 function,1,level,3:0,1,op3,op3
 kernel,Kernel statuses,level,3:0,8,WAIT_CPU,WAIT_CPU
 function,0,level,6:0,19,op1,op1
 function,1,level,6:0,3,op2,op2,16,3,-,null
 function,2,level,6:0,1,op3,op3,5,14,-,null
-kernel,Kernel statuses,level,6:0,4,WAIT_CPU,WAIT_CPU,4,15,RUN,RUN
+kernel,Kernel statuses,level,6:0,4,WAIT_CPU,WAIT_CPU,11,8,RUN_SYTEMCALL,RUN_SYTEMCALL
 function,0,level,7:0,19,op5,op5
 function,1,level,7:0,12,op2,op2,12,7,-,null
 function,2,level,7:0,1,op3,op3,1,18,-,null

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowFullAll
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowFullAll
@@ -1,14 +1,14 @@
 function,0,level,2:0,8,op4,op4,8,9,op1,op1
 function,1,level,2:0,8,-,null,8,4,op2,op2,12,5,-,null
 function,2,level,2:0,8,-,null,8,1,op3,op3,9,8,-,null
-kernel,Kernel statuses,level,2:0,8,RUN,RUN,8,4,RUN,RUN,12,5,WAIT_CPU,WAIT_CPU
+kernel,Kernel statuses,level,2:0,8,RUN_SYTEMCALL,RUN_SYTEMCALL,8,4,RUN,RUN,12,5,WAIT_CPU,WAIT_CPU
 function,0,level,3:0,17,op2,op2
 function,1,level,3:0,1,op3,op3,1,6,op2,op2,7,10,-,null
 kernel,Kernel statuses,level,3:0,8,WAIT_CPU,WAIT_CPU,8,9,RUN,RUN
 function,0,level,6:0,19,op1,op1
 function,1,level,6:0,3,op2,op2,3,5,op3,op3,8,8,op4,op4,16,3,-,null
 function,2,level,6:0,1,op3,op3,1,2,-,null,3,2,op1,op1,5,14,-,null
-kernel,Kernel statuses,level,6:0,4,WAIT_CPU,WAIT_CPU,4,15,RUN,RUN
+kernel,Kernel statuses,level,6:0,4,WAIT_CPU,WAIT_CPU,4,7,RUN,RUN,11,8,RUN_SYTEMCALL,RUN_SYTEMCALL
 function,0,level,7:0,19,op5,op5
 function,1,level,7:0,12,op2,op2,12,7,-,null
 function,2,level,7:0,1,op3,op3,1,18,-,null

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowFullZoom
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowFullZoom
@@ -8,7 +8,7 @@ kernel,Kernel statuses,level,3:8,9,RUN,RUN
 function,0,level,6:0,19,op1,op1
 function,1,level,6:8,8,op4,op4,16,3,-,null
 function,2,level,6:5,14,-,null
-kernel,Kernel statuses,level,6:4,15,RUN,RUN
+kernel,Kernel statuses,level,6:4,7,RUN,RUN,11,8,RUN_SYTEMCALL,RUN_SYTEMCALL
 function,0,level,7:0,19,op5,op5
 function,1,level,7:0,12,op2,op2,12,7,-,null
 function,2,level,7:1,18,-,null

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowOne2Times
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowOne2Times
@@ -1,4 +1,4 @@
 function,0,level,All:0,8,op4,op4,44,28,op1,op1
 function,1,level,All:0,8,-,null,64,8,-,null
 function,2,level,All:0,25,-,null,51,21,-,null
-kernel,Kernel statuses,level,All:0,8,RUN,RUN,53,19,RUN,RUN
+kernel,Kernel statuses,level,All:0,8,RUN_SYTEMCALL,RUN_SYTEMCALL,61,11,RUN,RUN

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowOneAll
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowOneAll
@@ -1,4 +1,4 @@
 function,0,level,All:0,8,op4,op4,8,17,op2,op2,25,19,op5,op5,44,28,op1,op1
 function,1,level,All:0,8,-,null,8,1,op3,op3,9,6,op2,op2,15,10,-,null,25,12,op2,op2,37,7,-,null,44,5,op3,op3,49,7,op2,op2,56,8,op4,op4,64,8,-,null
 function,2,level,All:0,25,-,null,25,1,op3,op3,26,18,-,null,44,2,op1,op1,46,3,-,null,49,2,op3,op3,51,21,-,null
-kernel,Kernel statuses,level,All:0,8,RUN,RUN,8,8,WAIT_CPU,WAIT_CPU,16,9,RUN,RUN,25,8,WAIT_CPU,WAIT_CPU,33,11,RUN,RUN,44,9,WAIT_CPU,WAIT_CPU,53,19,RUN,RUN
+kernel,Kernel statuses,level,All:0,8,RUN_SYTEMCALL,RUN_SYTEMCALL,8,8,WAIT_CPU,WAIT_CPU,16,9,RUN,RUN,25,8,WAIT_CPU,WAIT_CPU,33,11,RUN,RUN,44,8,RUN_SYTEMCALL,RUN_SYTEMCALL,52,9,WAIT_CPU,WAIT_CPU,61,11,RUN,RUN

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowOneZoom
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowOneZoom
@@ -1,4 +1,4 @@
 function,0,level,All:25,19,op5,op5,44,28,op1,op1
 function,1,level,All:25,12,op2,op2,37,7,-,null,44,5,op3,op3,49,7,op2,op2,56,8,op4,op4,64,8,-,null
 function,2,level,All:26,18,-,null,44,2,op1,op1,46,3,-,null,49,2,op3,op3,51,21,-,null
-kernel,Kernel statuses,level,All:33,11,RUN,RUN,44,9,WAIT_CPU,WAIT_CPU,53,19,RUN,RUN
+kernel,Kernel statuses,level,All:33,11,RUN,RUN,44,8,RUN_SYTEMCALL,RUN_SYTEMCALL,52,9,WAIT_CPU,WAIT_CPU,61,11,RUN,RUN

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowProcess2Times
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowProcess2Times
@@ -1,7 +1,7 @@
 function,0,level,1:0,8,op4,op4
 function,1,level,1:0,8,-,null
 function,2,level,1:0,8,-,null
-kernel,Kernel statuses,level,1:0,8,RUN,RUN
+kernel,Kernel statuses,level,1:0,8,RUN_SYTEMCALL,RUN_SYTEMCALL
 function,0,level,5:0,19,op1,op1,19,19,op5,op5
 function,1,level,5:0,3,op2,op2,31,7,-,null
 function,2,level,5:0,1,op3,op3,20,18,-,null

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowProcessAll
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowProcessAll
@@ -1,8 +1,8 @@
 function,0,level,1:0,8,op4,op4,8,9,op1,op1,17,17,op2,op2
 function,1,level,1:0,8,-,null,8,4,op2,op2,12,5,-,null,17,1,op3,op3,18,6,op2,op2,24,10,-,null
 function,2,level,1:0,8,-,null,8,1,op3,op3,9,25,-,null
-kernel,Kernel statuses,level,1:0,8,RUN,RUN,8,4,RUN,RUN,12,5,WAIT_CPU,WAIT_CPU,17,8,WAIT_CPU,WAIT_CPU,25,9,RUN,RUN
+kernel,Kernel statuses,level,1:0,8,RUN_SYTEMCALL,RUN_SYTEMCALL,8,4,RUN,RUN,12,5,WAIT_CPU,WAIT_CPU,17,8,WAIT_CPU,WAIT_CPU,25,9,RUN,RUN
 function,0,level,5:0,19,op1,op1,19,19,op5,op5
 function,1,level,5:0,3,op2,op2,3,5,op3,op3,8,8,op4,op4,16,3,-,null,19,12,op2,op2,31,7,-,null
 function,2,level,5:0,1,op3,op3,1,2,-,null,3,2,op1,op1,5,14,-,null,19,1,op3,op3,20,18,-,null
-kernel,Kernel statuses,level,5:0,4,WAIT_CPU,WAIT_CPU,4,15,RUN,RUN,19,8,WAIT_CPU,WAIT_CPU,27,11,RUN,RUN
+kernel,Kernel statuses,level,5:0,4,WAIT_CPU,WAIT_CPU,4,7,RUN,RUN,11,8,RUN_SYTEMCALL,RUN_SYTEMCALL,19,8,WAIT_CPU,WAIT_CPU,27,11,RUN,RUN

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowSelection2Times
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowSelection2Times
@@ -1,13 +1,13 @@
 function,0,level,2:0,3,op4,op4
 function,1,level,2:0,3,-,null
-kernel,Kernel statuses,level,2:0,3,RUN,RUN
+kernel,Kernel statuses,level,2:0,3,RUN_SYTEMCALL,RUN_SYTEMCALL
 function,0,level,3:0,10,op2,op2
 function,1,level,3:0,1,op3,op3,7,3,-,null
 kernel,Kernel statuses,level,3:0,3,WAIT_CPU,WAIT_CPU,3,7,RUN,RUN
 function,0,level,6:0,10,op1,op1
 function,1,level,6:0,2,op3,op3,8,2,-,null
 function,2,level,6:0,1,op1,op1,3,7,-,null
-kernel,Kernel statuses,level,6:0,4,WAIT_CPU,WAIT_CPU,4,6,RUN,RUN
+kernel,Kernel statuses,level,6:0,3,RUN,RUN,6,4,WAIT_CPU,WAIT_CPU
 function,0,level,7:0,10,op5,op5
 function,1,level,7:0,5,op2,op2,5,5,-,null
 function,2,level,7:0,1,op3,op3,1,9,-,null

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowSelectionAll
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowSelectionAll
@@ -1,13 +1,13 @@
 function,0,level,2:0,3,op4,op4,3,5,op1,op1
 function,1,level,2:0,3,-,null,3,2,op2,op2,5,3,-,null
-kernel,Kernel statuses,level,2:0,3,RUN,RUN,3,5,WAIT_CPU,WAIT_CPU
+kernel,Kernel statuses,level,2:0,3,RUN_SYTEMCALL,RUN_SYTEMCALL,3,5,WAIT_CPU,WAIT_CPU
 function,0,level,3:0,10,op2,op2
 function,1,level,3:0,1,op3,op3,1,6,op2,op2,7,3,-,null
 kernel,Kernel statuses,level,3:0,3,WAIT_CPU,WAIT_CPU,3,7,RUN,RUN
 function,0,level,6:0,10,op1,op1
 function,1,level,6:0,2,op3,op3,2,3,op2,op2,5,3,op4,op4,8,2,-,null
 function,2,level,6:0,1,op1,op1,1,1,-,null,2,1,op3,op3,3,7,-,null
-kernel,Kernel statuses,level,6:0,4,WAIT_CPU,WAIT_CPU,4,6,RUN,RUN
+kernel,Kernel statuses,level,6:0,3,RUN,RUN,3,3,RUN_SYTEMCALL,RUN_SYTEMCALL,6,4,WAIT_CPU,WAIT_CPU
 function,0,level,7:0,10,op5,op5
 function,1,level,7:0,5,op2,op2,5,5,-,null
 function,2,level,7:0,1,op3,op3,1,9,-,null

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowSelectionZoom
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core.tests/testfiles/dp/expectedFgRowSelectionZoom
@@ -7,7 +7,7 @@ kernel,Kernel statuses,level,3:3,7,RUN,RUN
 function,0,level,6:0,10,op1,op1
 function,1,level,6:5,3,op4,op4,8,2,-,null
 function,2,level,6:3,7,-,null
-kernel,Kernel statuses,level,6:4,6,RUN,RUN
+kernel,Kernel statuses,level,6:3,3,RUN_SYTEMCALL,RUN_SYTEMCALL,6,4,WAIT_CPU,WAIT_CPU
 function,0,level,7:0,10,op5,op5
 function,1,level,7:5,5,-,null
 function,2,level,7:1,9,-,null

--- a/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.profiling.core/src/org/eclipse/tracecompass/internal/analysis/profiling/core/instrumented/FlameChartDataProvider.java
@@ -289,6 +289,7 @@ public class FlameChartDataProvider extends AbstractTmfTraceDataProvider impleme
             return new TmfModelResponse<>(tooltip, Status.COMPLETED, CommonStatusMessage.COMPLETED);
         }
     }
+
     private @Nullable Map<String, String> getTooltip(Long entryId, FlameChartEntryModel entryModel, Long time) {
         switch (entryModel.getEntryType()) {
         case FUNCTION: {
@@ -579,23 +580,27 @@ public class FlameChartDataProvider extends AbstractTmfTraceDataProvider impleme
         Map<Long, List<ITimeGraphState>> kernelStates = new HashMap<>();
 
         IHostModel model = ModelManager.getModelFor(getTrace().getHostId());
-        Map<Integer, Long> threadIdsToEntryIds = tids.stream().collect(Collectors.toMap(tid -> tid.fTid.getTid(), tid -> tid.fLinked));
+        Map<Integer, Set<Long>> threadIdsToEntryIds = tids.stream().collect(Collectors.groupingBy(
+                tid -> tid.fTid.getTid(),
+                Collectors.mapping(tid -> tid.fLinked, Collectors.toSet())));
         Map<Integer, Iterable<ProcessStatusInterval>> kernelStatuses = model.getThreadStatusIntervals(threadIdsToEntryIds.keySet(), times, monitor);
         for (Entry<Integer, Iterable<ProcessStatusInterval>> processStatuses : kernelStatuses.entrySet()) {
-            Long linkedEntryId = threadIdsToEntryIds.get(processStatuses.getKey());
-            if (linkedEntryId == null) {
+            Set<Long> linkedEntryIds = threadIdsToEntryIds.get(processStatuses.getKey());
+            if (linkedEntryIds == null) {
                 continue;
             }
-            Long entryId = fLinkedEntries.get(linkedEntryId);
-            if (entryId == null) {
-                entryId = linkedEntryId;
-            }
-            List<ITimeGraphState> states = kernelStates.computeIfAbsent(linkedEntryId, k -> new ArrayList<>());
-            for (ProcessStatusInterval processStatus : Objects.requireNonNull(processStatuses.getValue())) {
-                OutputElementStyle style = new OutputElementStyle(
-                        FlameWithKernelPalette.getStyleFor(processStatus.getProcessStatus().getStateValue().unboxInt()));
-                ITimeGraphState state = new TimeGraphState(processStatus.getStart(), processStatus.getLength(), processStatus.getSyscallName(), style);
-                applyFilterAndAddState(states, state, entryId, predicates, monitor);
+            for (Long linkedEntryId : linkedEntryIds) {
+                Long entryId = fLinkedEntries.get(linkedEntryId);
+                if (entryId == null) {
+                    entryId = linkedEntryId;
+                }
+                List<ITimeGraphState> states = kernelStates.computeIfAbsent(linkedEntryId, k -> new ArrayList<>());
+                for (ProcessStatusInterval processStatus : Objects.requireNonNull(processStatuses.getValue())) {
+                    OutputElementStyle style = new OutputElementStyle(
+                            FlameWithKernelPalette.getStyleFor(processStatus.getProcessStatus().getStateValue().unboxInt()));
+                    ITimeGraphState state = new TimeGraphState(processStatus.getStart(), processStatus.getLength(), processStatus.getSyscallName(), style);
+                    applyFilterAndAddState(states, state, entryId, predicates, monitor);
+                }
             }
         }
         return kernelStates;
@@ -727,7 +732,7 @@ public class FlameChartDataProvider extends AbstractTmfTraceDataProvider impleme
 
     @Override
     public TmfModelResponse<AnnotationCategoriesModel> fetchAnnotationCategories(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
-        return new TmfModelResponse<>(new AnnotationCategoriesModel(Collections.singletonList( InstrumentedCallStackAnalysis.ANNOTATIONS)), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+        return new TmfModelResponse<>(new AnnotationCategoriesModel(Collections.singletonList(InstrumentedCallStackAnalysis.ANNOTATIONS)), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
     }
 
     @Override
@@ -758,7 +763,7 @@ public class FlameChartDataProvider extends AbstractTmfTraceDataProvider impleme
                     continue;
                 }
                 int parentQuark = ss.getParentAttributeQuark(ss.getParentAttributeQuark(cs.getQuark()));
-                int markersQuark = ss.optQuarkRelative(parentQuark,  InstrumentedCallStackAnalysis.ANNOTATIONS);
+                int markersQuark = ss.optQuarkRelative(parentQuark, InstrumentedCallStackAnalysis.ANNOTATIONS);
                 if (markersQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
                     List<Long> times = DataProviderParameterUtils.extractTimeRequested(fetchParameters);
                     for (ITmfStateInterval markerInterval : ss.query2D(Collections.singleton(markersQuark), times)) {
@@ -780,11 +785,11 @@ public class FlameChartDataProvider extends AbstractTmfTraceDataProvider impleme
                             ITmfStateValue a = markerInterval.getStateValue();
                             String annotValue = a.toString();
 
-                                OutputElementStyle style = new OutputElementStyle(null, ImmutableMap.of(
-                                        StyleProperties.COLOR, "#7D3D31", //$NON-NLS-1$
-                                        StyleProperties.HEIGHT, 0.33f,
-                                        StyleProperties.SYMBOL_TYPE, SymbolType.DIAMOND));
-                                annotations.add(new Annotation(startTime, 0, rowId, annotValue, style));
+                            OutputElementStyle style = new OutputElementStyle(null, ImmutableMap.of(
+                                    StyleProperties.COLOR, "#7D3D31", //$NON-NLS-1$
+                                    StyleProperties.HEIGHT, 0.33f,
+                                    StyleProperties.SYMBOL_TYPE, SymbolType.DIAMOND));
+                            annotations.add(new Annotation(startTime, 0, rowId, annotValue, style));
                         }
                     }
                 }
@@ -793,6 +798,6 @@ public class FlameChartDataProvider extends AbstractTmfTraceDataProvider impleme
             return new TmfModelResponse<>(null, ITmfResponse.Status.FAILED, e.getMessage());
         }
 
-        return new TmfModelResponse<>(new AnnotationModel(Collections.singletonMap( InstrumentedCallStackAnalysis.ANNOTATIONS, annotations)), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+        return new TmfModelResponse<>(new AnnotationModel(Collections.singletonMap(InstrumentedCallStackAnalysis.ANNOTATIONS, annotations)), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
     }
 }


### PR DESCRIPTION
### What it does

- Make callstack analysis with multiple callstacks for each thread work without having errors
- Reverse the filter which was not implemented correctly, when the predicate is true, the element is kept.

### How to test

Open a callstack analysis that have threads callstacks with a kernel trace alongside it. For example using https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/265

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of timestamp filtering for thread interval queries; kernel-level states now correctly surface syscall labels in flame charts.
* **Refactor**
  * Flame chart handling updated to support multiple linked kernel entries per thread.
* **Tests**
  * Test fixtures and assertions updated to expect syscall labels and to enforce exact state counts before per-state comparisons.
* **Style**
  * Annotation formatting cleaned up; event-stub handling refined for instant events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eclipse-tracecompass/org.eclipse.tracecompass/pull/398)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->