### PR TITLE
ctf: Add new field classes to complete ctf2 parsing

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/BooleanDeclarationParserTest.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/BooleanDeclarationParserTest.java
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.ctf.core.tests.types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.nio.ByteOrder;
+
+import org.eclipse.tracecompass.ctf.core.event.types.BooleanDeclaration;
+import org.eclipse.tracecompass.ctf.core.trace.CTFTrace;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.JsonStructureFieldMemberMetadataNode;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.bool.BooleanDeclarationParser;
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Test class for boolean declaration parser in CTF2
+ *
+ * @author Arnaud Fiorini
+ */
+public class BooleanDeclarationParserTest {
+
+    /**
+     * Test parsing 14-bit boolean field from CTF2 JSON
+     *
+     * @throws Exception if parsing fails
+     */
+    @Test
+    public void testCTF2BooleanParsingWithoutAlignment() throws Exception {
+        CTFTrace trace = new CTFTrace();
+
+        JsonObject fieldClass = new JsonObject();
+        fieldClass.add("length", new JsonPrimitive(14));
+        fieldClass.add("byte-order", new JsonPrimitive("little-endian"));
+
+        JsonStructureFieldMemberMetadataNode node = new JsonStructureFieldMemberMetadataNode(null, "test", "test", "fixed-length-boolean", fieldClass);
+
+        BooleanDeclaration result = BooleanDeclarationParser.INSTANCE.parse(node,
+            new BooleanDeclarationParser.Param(trace));
+
+        assertNotNull(result);
+        assertEquals(1, result.getAlignment());
+        assertEquals(14, result.getMaximumSize());
+        assertEquals(ByteOrder.LITTLE_ENDIAN, result.getByteOrder());
+    }
+
+    /**
+     * Test parsing 37-bit boolean field from CTF2 JSON
+     *
+     * @throws Exception if parsing fails
+     */
+    @Test
+    public void testCTF2BooleanParsingWithAlignment() throws Exception {
+        CTFTrace trace = new CTFTrace();
+
+        JsonObject fieldClass = new JsonObject();
+        fieldClass.add("length", new JsonPrimitive(37));
+        fieldClass.add("byte-order", new JsonPrimitive("big-endian"));
+        fieldClass.add("alignment", new JsonPrimitive(8));
+
+        JsonStructureFieldMemberMetadataNode node = new JsonStructureFieldMemberMetadataNode(null, "test", "test", "fixed-length-boolean", fieldClass);
+
+        BooleanDeclaration result = BooleanDeclarationParser.INSTANCE.parse(node,
+            new BooleanDeclarationParser.Param(trace));
+
+        assertNotNull(result);
+        assertEquals(8, result.getAlignment());
+        assertEquals(37, result.getMaximumSize());
+        assertEquals(ByteOrder.BIG_ENDIAN, result.getByteOrder());
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/BooleanDeclarationTest.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/BooleanDeclarationTest.java
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.ctf.core.tests.types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteOrder;
+
+import org.eclipse.tracecompass.ctf.core.event.types.BooleanDeclaration;
+import org.eclipse.tracecompass.ctf.core.event.types.FloatDeclaration;
+import org.junit.Test;
+
+/**
+ * Test for the boolean declaration class in CTF2
+ *
+ * @author Arnaud Fiorini
+ */
+@SuppressWarnings("javadoc")
+public class BooleanDeclarationTest {
+
+    @Test
+    public void constructorTest() {
+        for (int i = 1; i < 20; i++) {
+            BooleanDeclaration booleanDeclaration = new BooleanDeclaration(i, ByteOrder.nativeOrder(), 1);
+            assertNotNull(booleanDeclaration);
+        }
+    }
+
+    @Test
+    public void getterTest() {
+        BooleanDeclaration booleanDeclaration = new BooleanDeclaration(8, ByteOrder.nativeOrder(), 1);
+        assertEquals(booleanDeclaration.getAlignment(), 1);
+        assertEquals(booleanDeclaration.getByteOrder(), ByteOrder.nativeOrder());
+        assertEquals(booleanDeclaration.getMaximumSize(), 8);
+    }
+
+    @Test
+    public void binaryEquivalentTest() {
+        BooleanDeclaration a = new BooleanDeclaration(8, ByteOrder.BIG_ENDIAN, 0);
+        BooleanDeclaration b = new BooleanDeclaration(8, ByteOrder.LITTLE_ENDIAN, 0);
+        BooleanDeclaration c = new BooleanDeclaration(8, ByteOrder.BIG_ENDIAN, 0);
+        BooleanDeclaration d = new BooleanDeclaration(24, ByteOrder.BIG_ENDIAN, 0);
+        FloatDeclaration e = new FloatDeclaration(8, 8, ByteOrder.BIG_ENDIAN, 0);
+
+        assertTrue(a.isBinaryEquivalent(a));
+        assertTrue(a.isBinaryEquivalent(b));
+        assertTrue(a.isBinaryEquivalent(c));
+        assertTrue(!a.isBinaryEquivalent(d));
+        assertTrue(!a.isBinaryEquivalent(e));
+
+        assertTrue(b.isBinaryEquivalent(a));
+        assertTrue(b.isBinaryEquivalent(b));
+        assertTrue(b.isBinaryEquivalent(c));
+        assertTrue(!b.isBinaryEquivalent(d));
+        assertTrue(!b.isBinaryEquivalent(e));
+
+        assertTrue(!c.isBinaryEquivalent(d));
+        assertTrue(!c.isBinaryEquivalent(e));
+        assertTrue(!d.isBinaryEquivalent(e));
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/BooleanDefinitionTest.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/BooleanDefinitionTest.java
@@ -1,0 +1,131 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.ctf.core.tests.types;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.ctf.core.CTFException;
+import org.eclipse.tracecompass.ctf.core.event.io.BitBuffer;
+import org.eclipse.tracecompass.ctf.core.event.types.BooleanDeclaration;
+import org.eclipse.tracecompass.ctf.core.event.types.BooleanDefinition;
+import org.junit.Test;
+
+/**
+ * Tests for the boolean definition class in CTF2
+ *
+ * @author Arnaud Fiorini
+ */
+@SuppressWarnings("javadoc")
+public class BooleanDefinitionTest {
+
+    @NonNull private static final String FIELD_NAME = "float";
+
+    /**
+     * Test a larger than long boolean field set to true
+     * @throws CTFException
+     */
+    @Test
+    public void testBiggerThanLongTrueBoolean() throws CTFException {
+        byte[] data = new byte[9];
+        data[1] = (byte) (1 << 3);
+        testBooleanCreateDefinition(9, 67, data, 0, true);
+    }
+
+    /**
+     * Test a large boolean field set to true
+     * @throws CTFException
+     */
+    @Test
+    public void testLargeTrueBoolean() throws CTFException {
+        byte[] data = new byte[17];
+        data[1] = (byte) (1 << 7);
+        testBooleanCreateDefinition(17, 129, data, 0, true);
+    }
+
+    /**
+     * Test a small boolean field set to true
+     * @throws CTFException
+     */
+    @Test
+    public void testSmallTrueBoolean() throws CTFException {
+        byte[] data = new byte[2];
+        data[1] = (byte) (1 << 5);
+        testBooleanCreateDefinition(2, 14, data, 0, true);
+    }
+
+    /**
+     * Test a large boolean field set to false
+     * @throws CTFException
+     */
+    @Test
+    public void testLargeFalseBoolean() throws CTFException {
+        byte[] data = new byte[17];
+        data[16] = (byte) (1 << 7);
+        testBooleanCreateDefinition(17, 135, data, 0, false);
+    }
+
+    /**
+     * Test a small boolean field set to false
+     * @throws CTFException
+     */
+    @Test
+    public void testSmallFalseBoolean() throws CTFException {
+        byte[] data = new byte[2];
+        data[1] = (byte) (1 << 7);
+        testBooleanCreateDefinition(2, 12, data, 0, false);
+    }
+    /**
+     * Test a large boolean field with alignment set to false
+     * @throws CTFException
+     */
+    @Test
+    public void testLargeFalseBooleanWithAlignment() throws CTFException {
+        byte[] data = new byte[20];
+        data[0] = 1;
+        testBooleanCreateDefinition(20, 145, data, 8, false);
+    }
+
+    /**
+     * Test a small boolean field with alignment set to false
+     * @throws CTFException
+     */
+    @Test
+    public void testSmallFalseBooleanWithAlignment() throws CTFException {
+        byte[] data = new byte[3];
+        data[0] = (byte) (1 << 1);
+        testBooleanCreateDefinition(3, 16, data, 8, false);
+    }
+
+    private static void testBooleanCreateDefinition(int bufferSize, int fieldSize, byte[] content, int alignment, boolean expectedValue) throws CTFException {
+        BooleanDeclaration declaration = new BooleanDeclaration(fieldSize, ByteOrder.nativeOrder(), alignment);
+        ByteBuffer byb = ByteBuffer.allocate(bufferSize);
+        byb.order(ByteOrder.nativeOrder());
+        byb.mark();
+        byb.put(content);
+        byb.reset();
+        BitBuffer bb = new BitBuffer(byb);
+        if (alignment > 1) {
+            bb.position(1);
+        }
+        BooleanDefinition definition = (BooleanDefinition) declaration.createDefinition(null, FIELD_NAME, bb);
+        assertNotNull(definition);
+        if (expectedValue) {
+            assertTrue(definition.getValue());
+        } else {
+            assertTrue(!definition.getValue());
+        }
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/DynamicBlobDeclarationTest.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core.tests/src/org/eclipse/tracecompass/ctf/core/tests/types/DynamicBlobDeclarationTest.java
@@ -1,0 +1,98 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.ctf.core.tests.types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.ctf.core.CTFException;
+import org.eclipse.tracecompass.ctf.core.event.io.BitBuffer;
+import org.eclipse.tracecompass.ctf.core.event.types.Definition;
+import org.eclipse.tracecompass.ctf.core.event.types.DynamicBlobDeclaration;
+import org.eclipse.tracecompass.ctf.core.event.types.DynamicBlobDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.Encoding;
+import org.eclipse.tracecompass.ctf.core.event.types.IntegerDeclaration;
+import org.eclipse.tracecompass.ctf.core.event.types.IntegerDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.StructDeclaration;
+import org.eclipse.tracecompass.ctf.core.event.types.StructDefinition;
+import org.junit.Test;
+
+/**
+ * Test class for dynamic blob declaration in CTF2
+ *
+ * @author Arnaud Fiorini
+ */
+@SuppressWarnings("javadoc")
+public class DynamicBlobDeclarationTest {
+
+    @Test
+    public void testStandardBlob() throws CTFException {
+        byte[] content = new byte[] {72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33};
+        testDynamicBlobDeclaration(content, 12, 12, "lengthField", "application/test", 0);
+    }
+
+    @Test
+    public void testAlignedBlob() throws CTFException {
+        byte[] content = new byte[] {0, 0, 72, 101, 108, 108, 111};
+        testDynamicBlobDeclaration(content, 5, 7, "lengthField", "application/test", 14);
+    }
+
+    @Test
+    public void testEmptyBlob() throws CTFException {
+        byte[] content = new byte[] {};
+        testDynamicBlobDeclaration(content, 0, 0, "lengthField", "application/test", 0);
+    }
+
+    @Test
+    public void testBigBlob() throws CTFException {
+        byte[] content = new byte[] {72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33, 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33, 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33};
+        testDynamicBlobDeclaration(content, 32, 36, "lengthField", "application/test", 32);
+    }
+
+    private static void testDynamicBlobDeclaration(byte[] content, int blobSize, int bufferSize, @NonNull String lengthFieldName, @NonNull String metadataType, int startingPosition) throws CTFException {
+        IntegerDeclaration id = IntegerDeclaration.createDeclaration(8, false, 8,
+                ByteOrder.LITTLE_ENDIAN, Encoding.UTF8, "", 32, null);
+        DynamicBlobDeclaration declaration = new DynamicBlobDeclaration(lengthFieldName, metadataType);
+        StructDeclaration structDec = new StructDeclaration(0);
+        structDec.addField(lengthFieldName, id);
+
+        StructDefinition structDef = new StructDefinition(
+                structDec,
+                null,
+                "x",
+                new Definition[] {
+                        new IntegerDefinition(
+                                id,
+                                null,
+                                lengthFieldName,
+                                blobSize)
+                });
+
+        ByteBuffer byb = ByteBuffer.allocate(bufferSize);
+        byb.order(ByteOrder.nativeOrder());
+        byb.mark();
+        byb.put(content);
+        byb.reset();
+        BitBuffer bb = new BitBuffer(byb);
+        bb.position(startingPosition);
+        DynamicBlobDefinition definition = (DynamicBlobDefinition) declaration.createDefinition(structDef, lengthFieldName, bb);
+        assertNotNull(definition);
+        byte[] expected = Arrays.copyOfRange(content, (int) Math.ceil((float) startingPosition / 8), content.length);
+        assertTrue(Arrays.equals(expected, definition.getBytes()));
+        assertEquals(metadataType, definition.getType());
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core/META-INF/MANIFEST.MF
+++ b/ctf/org.eclipse.tracecompass.ctf.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 5.1.0.qualifier
+Bundle-Version: 5.2.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.ctf.core;singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -20,6 +20,7 @@ Export-Package: org.eclipse.tracecompass.ctf.core,
  org.eclipse.tracecompass.internal.ctf.core.event;x-friends:="org.eclipse.tracecompass.ctf.core.tests,org.eclipse.tracecompass.tmf.ctf.core.tests",
  org.eclipse.tracecompass.internal.ctf.core.event.metadata;x-friends:="org.eclipse.tracecompass.ctf.core.tests",
  org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl;x-friends:="org.eclipse.tracecompass.ctf.core.tests",
+ org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.bool;x-friends:="org.eclipse.tracecompass.ctf.core.tests",
  org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.callsite;x-internal:=true,
  org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.enumeration;x-friends:="org.eclipse.tracecompass.ctf.core.tests",
  org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.environment;x-friends:="org.eclipse.tracecompass.ctf.core.tests",

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/BlobDeclaration.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/BlobDeclaration.java
@@ -19,9 +19,9 @@ import org.eclipse.tracecompass.ctf.core.event.io.BitBuffer;
 import org.eclipse.tracecompass.ctf.core.event.scope.IDefinitionScope;
 
 /**
- * A CTF blob class definition.
+ * A CTF blob class declaration.
  *
- * The definition of a blob data type that can be used to define sequence of
+ * The declaration of a blob data type that can be used to define sequence of
  * zero or more contiguous bytes with an associated IANA media type
  *
  * @author Sehr Moosabhoy
@@ -85,7 +85,8 @@ public class BlobDeclaration extends Declaration {
 
     @Override
     public int getMaximumSize() {
-        return fLength * 8; // This will allow the blob to be read properly and not break alignment in ctf.
+        return fLength * 8; // This will allow the blob to be read properly and
+                            // not break alignment in ctf.
     }
 
     @Override

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/BooleanDeclaration.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/BooleanDeclaration.java
@@ -1,0 +1,102 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.ctf.core.event.types;
+
+import java.nio.ByteOrder;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.ctf.core.CTFException;
+import org.eclipse.tracecompass.ctf.core.event.io.BitBuffer;
+import org.eclipse.tracecompass.ctf.core.event.scope.IDefinitionScope;
+
+/**
+ * A CTF declaration of a boolean field
+ *
+ * It declares a certain amount of bits as a boolean value.
+ *
+ * @since 5.2
+ * @author Arnaud Fiorini
+ */
+public class BooleanDeclaration extends Declaration {
+
+    private int fLength;
+    private long fAlignment;
+    private ByteOrder fByteOrder;
+
+    /**
+     * @param length
+     *            the size of the boolean field
+     * @param byteOrder
+     *            the order in which the bytes should be read
+     * @param alignment
+     *            alignment of the first bit of field relative to the beginning
+     *            of the packet
+     */
+    public BooleanDeclaration(int length, ByteOrder byteOrder, long alignment) {
+        fLength = length;
+        fByteOrder = byteOrder;
+        fAlignment = alignment;
+    }
+
+    @Override
+    public @NonNull Definition createDefinition(IDefinitionScope definitionScope, @NonNull String fieldName, @NonNull BitBuffer input) throws CTFException {
+        ByteOrder byteOrder = input.getByteOrder();
+        input.setByteOrder(fByteOrder);
+        boolean value = false;
+        try {
+            value = read(input);
+        } finally {
+            input.setByteOrder(byteOrder);
+        }
+        return new BooleanDefinition(this, definitionScope, fieldName, value);
+    }
+
+    private boolean read(BitBuffer input) throws CTFException {
+        alignRead(input);
+        for (int i = 0; i * 64 < fLength; i++) {
+            if (input.get(Math.min(64, fLength - i * 64), false) != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public long getAlignment() {
+        return fAlignment;
+    }
+
+    @Override
+    public int getMaximumSize() {
+        return fLength;
+    }
+
+    /**
+     * @return the byte order enum value
+     */
+    public ByteOrder getByteOrder() {
+        return fByteOrder;
+    }
+
+    @Override
+    public boolean isBinaryEquivalent(IDeclaration other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+        return fLength == other.getMaximumSize() && fAlignment == other.getAlignment();
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/BooleanDefinition.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/BooleanDefinition.java
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.ctf.core.event.types;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.ctf.core.event.scope.IDefinitionScope;
+
+/**
+ * A CTF2 boolean definition.
+ *
+ * The definition of a boolean field class in ctf2
+ *
+ * @author Arnaud Fiorini
+ * @since 5.2
+ */
+public class BooleanDefinition extends SimpleDatatypeDefinition {
+
+    private final boolean fValue;
+
+    /**
+     * Constructor
+     *
+     * @param declaration
+     *            the parent declaration
+     * @param definitionScope
+     *            the parent scope
+     * @param fieldName
+     *            the field name
+     * @param value
+     *            the field value
+     */
+    public BooleanDefinition(@NonNull IDeclaration declaration, IDefinitionScope definitionScope, @NonNull String fieldName, boolean value) {
+        super(declaration, definitionScope, fieldName);
+        fValue = value;
+    }
+
+    /**
+     * @return boolean value of the field
+     */
+    public boolean getValue() {
+        return fValue;
+    }
+
+    @Override
+    public BooleanDeclaration getDeclaration() {
+        return (BooleanDeclaration) super.getDeclaration();
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(fValue);
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/DynamicBlobDeclaration.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/DynamicBlobDeclaration.java
@@ -1,0 +1,137 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.ctf.core.event.types;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.ctf.core.CTFException;
+import org.eclipse.tracecompass.ctf.core.event.io.BitBuffer;
+import org.eclipse.tracecompass.ctf.core.event.scope.IDefinitionScope;
+
+/**
+ * A CTF blob class declaration.
+ *
+ * The declaration of a blob data type that can be used to define sequence of
+ * zero or more contiguous bytes with an associated IANA media type
+ *
+ * @since 5.2
+ * @author Arnaud Fiorini
+ */
+public class DynamicBlobDeclaration extends Declaration {
+
+    private String fLengthName;
+    private String fMediaType;
+
+    /**
+     * Constructor
+     *
+     * @param lengthName
+     *            the length field location
+     * @param mediaType
+     *            the IANA media type
+     */
+    public DynamicBlobDeclaration(@NonNull String lengthName, @NonNull String mediaType) {
+        fLengthName = lengthName;
+        fMediaType = mediaType;
+    }
+
+    @Override
+    public @NonNull Definition createDefinition(IDefinitionScope definitionScope, @NonNull String fieldName, @NonNull BitBuffer input) throws CTFException {
+        IDefinition lenDef = null;
+
+        if (definitionScope != null) {
+            lenDef = definitionScope.lookupDefinition(fLengthName);
+        }
+
+        if (lenDef == null) {
+            throw new CTFException("Dynamic blob length field not found"); //$NON-NLS-1$
+        }
+
+        if (!(lenDef instanceof IntegerDefinition)) {
+            throw new CTFException("Dynamic blob length field not integer"); //$NON-NLS-1$
+        }
+
+        IntegerDefinition lengthDefinition = (IntegerDefinition) lenDef;
+
+        if (lengthDefinition.getDeclaration().isSigned()) {
+            throw new CTFException("Dynamic blob length must not be signed"); //$NON-NLS-1$
+        }
+
+        long length = lengthDefinition.getValue();
+        if ((length > Integer.MAX_VALUE) || (!input.canRead((int) length * 8))) {
+            throw new CTFException("Blob is too large " + length); //$NON-NLS-1$
+        }
+
+        byte[] array = new byte[(int) length];
+        if (input.getByteBuffer().remaining() < length) {
+            throw new CTFException("There is not enough data provided. Length asked: " + length + " Remaining buffer size: " + input.getByteBuffer().remaining()); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        /* Offset the buffer position wrt the current alignment */
+        alignRead(input);
+        input.get(array);
+
+        return new DynamicBlobDefinition(this, definitionScope, fieldName, array, fMediaType);
+    }
+
+    @Override
+    public int getMaximumSize() {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * From the documentation:
+     * https://diamon.org/ctf/files/CTF2-SPECRC-7.0rA.html#align-dec
+     *
+     * Alignment of a blob will always be 8 bits
+     */
+    @Override
+    public long getAlignment() {
+        return 8;
+    }
+
+    /**
+     * @return a string describing the contents of the blob
+     */
+    public String getMediaType() {
+        return fMediaType;
+    }
+
+    /**
+     * @return the name of the field which defines the size of the blob
+     */
+    public String getLengthFieldName() {
+        return fLengthName;
+    }
+
+    @Override
+    public String toString() {
+        /* Only used for debugging */
+        return "[declaration] dynamicblob[length-field-location=" + fLengthName + ", media-type=" + fMediaType + ']'; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Override
+    public boolean isBinaryEquivalent(IDeclaration other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+        DynamicBlobDeclaration otherBlob = (DynamicBlobDeclaration) other;
+        if (!fMediaType.equals(otherBlob.fMediaType)) {
+            return false;
+        }
+        return (fLengthName.equals(otherBlob.fLengthName));
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/DynamicBlobDefinition.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/event/types/DynamicBlobDefinition.java
@@ -1,16 +1,13 @@
-/*******************************************************************************
- * Copyright (c) 2023 Ericsson
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
  *
- * All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0 which
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
  * accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Sehr Moosabhoy - Initial implementation
- *******************************************************************************/
+ **********************************************************************/
 package org.eclipse.tracecompass.ctf.core.event.types;
 
 import java.util.Base64;
@@ -24,10 +21,10 @@ import org.eclipse.tracecompass.ctf.core.event.scope.IDefinitionScope;
  * The definition of a blob data type that can be used to define sequence of
  * zero or more contiguous bytes with an associated IANA media type
  *
- * @author Sehr Moosabhoy
- * @since 4.3
+ * @author Arnaud Fiorini
+ * @since 5.2
  */
-public class BlobDefinition extends SimpleDatatypeDefinition {
+public class DynamicBlobDefinition extends SimpleDatatypeDefinition {
 
     private final byte[] fArray;
     private final String fType;
@@ -46,7 +43,7 @@ public class BlobDefinition extends SimpleDatatypeDefinition {
      * @param mediaType
      *            the IANA media type of the byte array
      */
-    public BlobDefinition(@NonNull IDeclaration declaration, IDefinitionScope definitionScope, @NonNull String fieldName, byte[] array, String mediaType) {
+    public DynamicBlobDefinition(@NonNull IDeclaration declaration, IDefinitionScope definitionScope, @NonNull String fieldName, byte[] array, String mediaType) {
         super(declaration, definitionScope, fieldName);
         fArray = array;
         fType = mediaType;
@@ -63,7 +60,7 @@ public class BlobDefinition extends SimpleDatatypeDefinition {
     }
 
     /**
-     * @return
+     * @return the IANA type of the blob
      * @since 5.2
      */
     public String getType() {
@@ -71,8 +68,8 @@ public class BlobDefinition extends SimpleDatatypeDefinition {
     }
 
     @Override
-    public @NonNull BlobDeclaration getDeclaration() {
-        return (BlobDeclaration) super.getDeclaration();
+    public @NonNull DynamicBlobDeclaration getDeclaration() {
+        return (DynamicBlobDeclaration) super.getDeclaration();
     }
 
     @Override
@@ -83,4 +80,5 @@ public class BlobDefinition extends SimpleDatatypeDefinition {
         }
         return ""; //$NON-NLS-1$
     }
+
 }

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/BlobDeclarationParser.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/BlobDeclarationParser.java
@@ -74,7 +74,7 @@ public final class BlobDeclarationParser implements ICommonTreeParser {
             throw new ParseException("Invalid length attribute in Blob: " + length); //$NON-NLS-1$
         }
 
-        if (fieldClass.has(mediaType)) {
+        if (fieldClass.has(MEDIA_TYPE)) {
             mediaType = fieldClass.get(MEDIA_TYPE).getAsString();
         }
         role = member.getRole();

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/DynamicBlobDeclarationParser.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/DynamicBlobDeclarationParser.java
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl;
+
+import java.util.Objects;
+
+import org.eclipse.tracecompass.ctf.core.event.types.DynamicBlobDeclaration;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.ICommonTreeParser;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.JsonStructureFieldMemberMetadataNode;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.ParseException;
+import org.eclipse.tracecompass.internal.ctf.core.event.types.ICTFMetadataNode;
+import org.eclipse.tracecompass.internal.ctf.core.utils.JsonMetadataStrings;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * According to the documentation:
+ * https://diamon.org/ctf/files/CTF2-SPECRC-7.0rA.html#dl-blob-fc
+ *
+ * A dynamic-length BLOB field is a sequence of zero or more contiguous bytes
+ * with an associated IANA media type (given by the media-type property of its
+ * class).
+ *
+ * The length, or number of bytes, of a dynamic-length BLOB field is specified
+ * with a length-field-location
+ *
+ * @author Arnaud Fiorini
+ */
+public class DynamicBlobDeclarationParser implements ICommonTreeParser {
+
+    /**
+     * Blob declaration parser instance
+     */
+    public static final DynamicBlobDeclarationParser INSTANCE = new DynamicBlobDeclarationParser();
+
+    private static final String DEFAULT_MEDIA_TYPE = "application/octet-stream"; //$NON-NLS-1$
+
+    private DynamicBlobDeclarationParser() {
+    }
+
+    /**
+     * Parses a blob declaration node and returns a BlobDeclaration
+     *
+     * @param blob
+     *            the JsonStructureFieldMemberMetadataNode describing the blob
+     * @param unused
+     *            unused
+     * @return the parsed BlobDeclaration
+     * @throws ParseException
+     *             if the length attribute is invalid
+     */
+    @Override
+    public DynamicBlobDeclaration parse(ICTFMetadataNode blob, ICommonTreeParserParameter unused) throws ParseException {
+        String mediaType = DEFAULT_MEDIA_TYPE;
+
+        JsonStructureFieldMemberMetadataNode member = (JsonStructureFieldMemberMetadataNode) blob;
+        JsonElement fieldClassElement = member.getFieldClass();
+        if (fieldClassElement == null || !fieldClassElement.isJsonObject()) {
+            throw new ParseException(getClass().getName() + " fieldclass must be a json object."); //$NON-NLS-1$
+        }
+        JsonObject fieldClass = member.getFieldClass().getAsJsonObject();
+
+        JsonElement lengthFieldLocation = fieldClass.get(JsonMetadataStrings.LENGTH_FIELD_LOCATION);
+        if (lengthFieldLocation == null) {
+            throw new ParseException("Dynamic-length array requires length-field-location property"); //$NON-NLS-1$
+        }
+
+        JsonElement pathElement = lengthFieldLocation.getAsJsonObject().get(JsonMetadataStrings.PATH);
+        String lengthName = pathElement.isJsonArray() ? pathElement.getAsJsonArray().get(pathElement.getAsJsonArray().size() - 1).getAsString() : pathElement.getAsString();
+
+        if (fieldClass.has(JsonMetadataStrings.MEDIA_TYPE)) {
+            mediaType = fieldClass.get(JsonMetadataStrings.MEDIA_TYPE).getAsString();
+        }
+
+        return new DynamicBlobDeclaration(Objects.requireNonNull(lengthName), Objects.requireNonNull(mediaType));
+    }
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/TypeAliasParser.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/TypeAliasParser.java
@@ -24,6 +24,7 @@ import org.eclipse.tracecompass.internal.ctf.core.event.metadata.AbstractScopedC
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.JsonFieldClassAliasMetadataNode;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.JsonStructureFieldMemberMetadataNode;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.ParseException;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.bool.BooleanDeclarationParser;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.dynamicarray.DynamicLengthArrayParser;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.dynamicstring.DynamicLengthStringParser;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.enumeration.EnumParser;
@@ -168,6 +169,9 @@ public final class TypeAliasParser extends AbstractScopedCommonTreeParser {
                 case JsonMetadataStrings.STATIC_LENGTH_BLOB:
                     targetDeclaration = BlobDeclarationParser.INSTANCE.parse(typealias, null);
                     break;
+                case JsonMetadataStrings.DYNAMIC_LENGTH_BLOB:
+                    targetDeclaration = DynamicBlobDeclarationParser.INSTANCE.parse(member, null);
+                    break;
                 case JsonMetadataStrings.NULL_TERMINATED_STRING:
                     targetDeclaration = StringDeclarationParser.INSTANCE.parse(typealias, null);
                     break;
@@ -189,11 +193,23 @@ public final class TypeAliasParser extends AbstractScopedCommonTreeParser {
                 case JsonMetadataStrings.DYNAMIC_LENGTH_ARRAY:
                     targetDeclaration = DynamicLengthArrayParser.INSTANCE.parse(typealias, new DynamicLengthArrayParser.Param(trace, scope));
                     break;
+                case JsonMetadataStrings.FIXED_LENGTH_BIT_ARRAY:
+                    // TODO: Handle fixed length bit arrays
+                    break;
+                case JsonMetadataStrings.FIXED_LENGTH_BIT_MAP:
+                    // TODO: handle fixed length bit map
+                    break;
                 case JsonMetadataStrings.STRUCTURE:
                     targetDeclaration = StructParser.INSTANCE.parse(typealias, new StructParser.Param(trace, null, scope));
                     break;
+                case JsonMetadataStrings.OPTIONAL:
+                    // TODO: handle optional
+                    break;
                 case JsonMetadataStrings.FIXED_LENGTH_FLOATING_POINT:
                     targetDeclaration = FloatDeclarationParser.INSTANCE.parse(typealias, new FloatDeclarationParser.Param(trace));
+                    break;
+                case JsonMetadataStrings.FIXED_LENGTH_BOOLEAN:
+                    targetDeclaration = BooleanDeclarationParser.INSTANCE.parse(typealias, new BooleanDeclarationParser.Param(trace));
                     break;
                 case JsonMetadataStrings.VARIABLE_LENGTH_FLOATING_POINT:
                     targetDeclaration = FloatDeclarationParser.INSTANCE.parse(typealias, new FloatDeclarationParser.Param(trace));

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/bool/BooleanDeclarationParser.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/bool/BooleanDeclarationParser.java
@@ -1,0 +1,120 @@
+/**********************************************************************
+ * Copyright (c) 2026 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.bool;
+
+import java.nio.ByteOrder;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.tracecompass.ctf.core.event.types.BooleanDeclaration;
+import org.eclipse.tracecompass.ctf.core.trace.CTFTrace;
+import org.eclipse.tracecompass.ctf.parser.CTFParser;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.CTFJsonMetadataNode;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.ICommonTreeParser;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.JsonStructureFieldMemberMetadataNode;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.ParseException;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.AlignmentParser;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.tsdl.ByteOrderParser;
+import org.eclipse.tracecompass.internal.ctf.core.event.types.ICTFMetadataNode;
+import org.eclipse.tracecompass.internal.ctf.core.utils.JsonMetadataStrings;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * According to the documentation:
+ * https://diamon.org/ctf/files/CTF2-SPECRC-7.0rA.html#fl-bool-fc
+ *
+ * A fixed length boolean field class is a fixed length bit array where if all
+ * the bits are cleared (zero) then the value is false else it is true.
+ *
+ * The length, or number of bits, of a boolean is specified as a property.
+ *
+ * @author Arnaud Fiorini
+ */
+public class BooleanDeclarationParser implements ICommonTreeParser {
+
+    /**
+     * Parameter object with only a trace in it
+     */
+    @NonNullByDefault
+    public static final class Param implements ICommonTreeParserParameter {
+        private final CTFTrace fTrace;
+
+        /**
+         * Constructor
+         *
+         * @param trace
+         *            the trace
+         */
+        public Param(CTFTrace trace) {
+            fTrace = trace;
+        }
+    }
+
+    /**
+     * Instance
+     */
+    public static final BooleanDeclarationParser INSTANCE = new BooleanDeclarationParser();
+
+    private BooleanDeclarationParser() {
+    }
+
+    @Override
+    public @NonNull BooleanDeclaration parse(ICTFMetadataNode bool, ICommonTreeParserParameter param) throws ParseException {
+        if (!(param instanceof Param)) {
+            throw new IllegalArgumentException("Param must be a " + Param.class.getCanonicalName()); //$NON-NLS-1$
+        }
+        CTFTrace trace = ((Param) param).fTrace;
+
+        /* The return value */
+        ByteOrder byteOrder = trace.getByteOrder();
+        long alignment = 0;
+        int size = 0;
+
+        if (bool instanceof JsonStructureFieldMemberMetadataNode member) {
+            JsonElement fieldClassElement = member.getFieldClass();
+            if (fieldClassElement == null || !fieldClassElement.isJsonObject()) {
+                throw new ParseException(getClass().getName() + " fieldclass must be a json object."); //$NON-NLS-1$
+            }
+            JsonObject fieldclass = member.getFieldClass().getAsJsonObject();
+            if (fieldclass.has(JsonMetadataStrings.LENGTH)) {
+                size = fieldclass.get(JsonMetadataStrings.LENGTH).getAsInt();
+
+                if (size <= 0) {
+                    throw new ParseException("Unsupported boolean size: " + size); //$NON-NLS-1$
+                }
+            }
+
+            if (fieldclass.has(JsonMetadataStrings.BYTE_ORDER)) {
+                CTFJsonMetadataNode bo = new CTFJsonMetadataNode(bool, CTFParser.tokenNames[CTFParser.UNARY_EXPRESSION_STRING], fieldclass.get(JsonMetadataStrings.BYTE_ORDER).getAsString());
+                byteOrder = ByteOrderParser.INSTANCE.parse(bo, new ByteOrderParser.Param(trace));
+            }
+
+            if (fieldclass.has(JsonMetadataStrings.ALIGNMENT)) {
+                alignment = AlignmentParser.INSTANCE.parse(bool, null);
+            }
+        } else {
+            throw new ParseException("The fixed-length boolean field class is not supported in CTF 1.8."); //$NON-NLS-1$
+        }
+
+        if (size == 0) {
+            throw new ParseException("The size is a required property for the fixed-length boolean field class."); //$NON-NLS-1$
+        }
+
+        if (alignment == 0) {
+            alignment = 1;
+        }
+
+        return new BooleanDeclaration(size, byteOrder, alignment);
+    }
+
+}

--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/utils/JsonMetadataStrings.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/utils/JsonMetadataStrings.java
@@ -57,7 +57,6 @@ public final class JsonMetadataStrings {
      */
     public static final String NAME = "name"; //$NON-NLS-1$
 
-
     /**
      * Type string for a CTF2 clock class fragment
      */
@@ -163,6 +162,26 @@ public final class JsonMetadataStrings {
     public static final String FIXED_LENGTH_FLOATING_POINT = "fixed-length-floating-point-number"; //$NON-NLS-1$
 
     /**
+     * Type string for a fixed-length boolean field which is a fixed-length bit
+     * array field
+     */
+    public static final String FIXED_LENGTH_BOOLEAN = "fixed-length-boolean"; //$NON-NLS-1$
+
+    /**
+     * Type string for a fixed-length bit array field class which describes
+     * fixed-length bit array fields and is a base of a fixed-length bit map
+     * field class, a fixed-length boolean field class, a fixed-length integer
+     * field class, and a fixed-length floating point number field class
+     */
+    public static final String FIXED_LENGTH_BIT_ARRAY = "fixed-length-bit-array"; //$NON-NLS-1$
+
+    /**
+     * Type string for a fixed-length bit array field class with one or more
+     * associated bit names thanks to the flags property
+     */
+    public static final String FIXED_LENGTH_BIT_MAP = "fixed-length-bit-map"; //$NON-NLS-1$
+
+    /**
      * Type string for a variable length floating point number field class
      */
     public static final String VARIABLE_LENGTH_FLOATING_POINT = "variable-length-floating-point-number"; //$NON-NLS-1$
@@ -186,6 +205,12 @@ public final class JsonMetadataStrings {
      * Type string for a dynamic length string field class
      */
     public static final String DYNAMIC_LENGTH_STRING = "dynamic-length-string"; //$NON-NLS-1$
+
+    /**
+     * Type string for a dynamic-length BLOB field which is a sequence of zero
+     * or more contiguous bytes with an associated IANA media type
+     */
+    public static final String DYNAMIC_LENGTH_BLOB = "dynamic-length-blob"; //$NON-NLS-1$
 
     /**
      * The length field location for a dynamic string
@@ -212,6 +237,12 @@ public final class JsonMetadataStrings {
     public static final String STRUCTURE = "structure"; //$NON-NLS-1$
 
     /**
+     * Type string for an optional field class which is depending on the value
+     * of another field, an instance of a given field class or a zero-bit field
+     */
+    public static final String OPTIONAL = "optional"; //$NON-NLS-1$
+
+    /**
      * Type string for an internal structure field class
      */
     public static final String STRUCT = "struct"; //$NON-NLS-1$
@@ -219,9 +250,9 @@ public final class JsonMetadataStrings {
     /**
      * Map of encoding names to Charset objects
      */
-    public static final Map<String, Charset> ENCODINGS = Map.of("utf-8",StandardCharsets.UTF_8, //$NON-NLS-1$
-            "utf-16be",StandardCharsets.UTF_16BE,"utf-16le",StandardCharsets.UTF_16LE, //$NON-NLS-1$ //$NON-NLS-2$
-            "utf-32be", Charset.forName("UTF-32BE"),"utf-32le", Charset.forName("UTF-32LE")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    public static final Map<String, Charset> ENCODINGS = Map.of("utf-8", StandardCharsets.UTF_8, //$NON-NLS-1$
+            "utf-16be", StandardCharsets.UTF_16BE, "utf-16le", StandardCharsets.UTF_16LE, //$NON-NLS-1$ //$NON-NLS-2$
+            "utf-32be", Charset.forName("UTF-32BE"), "utf-32le", Charset.forName("UTF-32LE")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
     /**
      * Field string for encoding
@@ -267,5 +298,10 @@ public final class JsonMetadataStrings {
      * Field string for byte order
      */
     public static final String BYTE_ORDER = "byte-order"; //$NON-NLS-1$
+
+    /**
+     * Field string for the metadata type of a blob
+     */
+    public static final String MEDIA_TYPE = "media-type"; //$NON-NLS-1$
 
 }

--- a/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/event/CtfTmfEventField.java
+++ b/ctf/org.eclipse.tracecompass.tmf.ctf.core/src/org/eclipse/tracecompass/tmf/ctf/core/event/CtfTmfEventField.java
@@ -23,14 +23,17 @@ import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.ctf.core.event.types.AbstractArrayDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.BlobDefinition;
 import org.eclipse.tracecompass.ctf.core.event.types.CompoundDeclaration;
 import org.eclipse.tracecompass.ctf.core.event.types.Definition;
+import org.eclipse.tracecompass.ctf.core.event.types.DynamicBlobDefinition;
 import org.eclipse.tracecompass.ctf.core.event.types.EnumDefinition;
 import org.eclipse.tracecompass.ctf.core.event.types.FloatDefinition;
 import org.eclipse.tracecompass.ctf.core.event.types.ICompositeDefinition;
@@ -211,7 +214,10 @@ public abstract class CtfTmfEventField extends TmfEventField {
                 /* A safe-guard, but curFieldDef should never be null */
                 field = new CTFStringField(curFieldName, ""); //$NON-NLS-1$
             }
-
+        } else if (fieldDef instanceof BlobDefinition blob) {
+            field = new CTFHexBlobField(fieldName, blob.getType(), blob.getBytes());
+        } else if (fieldDef instanceof DynamicBlobDefinition blob) {
+            field = new CTFHexBlobField(fieldName, blob.getType(), blob.getBytes());
         } else {
             /*
              * Safe-guard, to avoid null exceptions later, field is expected not
@@ -570,6 +576,27 @@ final class CTFVariantField extends CtfTmfEventField {
         return super.getField(path);
     }
 
+}
+
+final class CTFHexBlobField extends CtfTmfEventField {
+
+    private String fBlobType;
+
+    CTFHexBlobField(@NonNull String name, String blobType, byte[] value) {
+        super(name, value, null);
+        fBlobType = blobType;
+    }
+
+    @Override
+    public byte[] getValue() {
+        return (byte[]) super.getValue();
+    }
+
+    @Override
+    public String getFormattedValue() {
+        String encoded = Base64.getEncoder().encodeToString(getValue());
+        return "[" + fBlobType + "]<" + encoded + '>'; //$NON-NLS-1$ //$NON-NLS-2$
+    }
 }
 
 /* Implement other possible fields types here... */


### PR DESCRIPTION
### What it does
- Add the support for the following ctf2 field classes: Fixed-length boolean field class and Dynamic-length BLOB field class
- Fixes part of #376 
### How to test
- Open the trace [pass-dl-blob.zip](https://github.com/user-attachments/files/25419980/pass-dl-blob.zip)

### Follow-ups

- Support for fixed-length-bit-map, fixed-length-bit-array, optional

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fixed-length boolean fields: configurable bit length, byte order, and alignment
  * Dynamic-length blob fields: length-sourced blobs that carry media-type info
  * Blob field display: shows media type and Base64-encoded content

* **Documentation / Parsing**
  * TSDL metadata parsing extended to handle dynamic blobs and fixed-length booleans, plus media-type support

* **Tests**
  * New unit tests covering boolean parsing/decoding and dynamic blob parsing/handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eclipse-tracecompass/org.eclipse.tracecompass/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->