### PR TITLE
Update e4.40 and eStaging targets for 2026-06 RC1

### DIFF
--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.40.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.40.target
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.40" sequenceNumber="3">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.40" sequenceNumber="4">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.10/"/>
+<repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.11/"/>
 <unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -10,7 +10,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-m2/"/>
+<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -27,6 +27,7 @@
 <unit id="com.google.guava" version="33.6.0.jre"/>
 <unit id="jakarta.activation-api" version="1.2.2"/>
 <unit id="jakarta.annotation-api" version="1.3.5"/>
+<unit id="jakarta.annotation-api" version="2.1.1"/>
 <unit id="jakarta.el-api" version="5.0.1"/>
 <unit id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
 <unit id="jakarta.servlet.jsp-api" version="3.1.1"/>
@@ -43,7 +44,7 @@
 <unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
 <unit id="org.apache.felix.gogo.shell" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
-<unit id="org.mortbay.jasper.mortbay-apache-jsp" version="9.0.111"/>
+<unit id="org.mortbay.jasper.mortbay-apache-jsp" version="9.0.118"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="org.osgi.util.function" version="0.0.0"/>
 <unit id="org.osgi.util.promise" version="0.0.0"/>
@@ -62,7 +63,7 @@
 <unit id="org.osgi.service.wireadmin" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202605211430"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.40.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -89,7 +90,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260521-1800/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260528-0011/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -105,7 +106,7 @@
 <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202604250852"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.46.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="268">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.10/"/>
+<repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.11/"/>
 <unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -10,7 +10,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-m2/"/>
+<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc1/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -27,6 +27,7 @@
 <unit id="com.google.guava" version="33.6.0.jre"/>
 <unit id="jakarta.activation-api" version="1.2.2"/>
 <unit id="jakarta.annotation-api" version="1.3.5"/>
+<unit id="jakarta.annotation-api" version="2.1.1"/>
 <unit id="jakarta.el-api" version="5.0.1"/>
 <unit id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
 <unit id="jakarta.servlet.jsp-api" version="3.1.1"/>
@@ -43,7 +44,7 @@
 <unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
 <unit id="org.apache.felix.gogo.shell" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
-<unit id="org.mortbay.jasper.mortbay-apache-jsp" version="9.0.111"/>
+<unit id="org.mortbay.jasper.mortbay-apache-jsp" version="9.0.118"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="org.osgi.util.function" version="0.0.0"/>
 <unit id="org.osgi.util.promise" version="0.0.0"/>
@@ -62,7 +63,7 @@
 <unit id="org.osgi.service.wireadmin" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202605211430"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.40.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -89,7 +90,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260521-1800/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260528-0011/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -105,7 +106,7 @@
 <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202604250852"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.46.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
### What it does

Update e4.40 and eStaging targets for 2026-06 RC1
### How to test

Build Trace Compass with staging or e4.40
### Follow-ups
N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build target platform configurations with upgraded dependencies, including Java runtime (21.0.11), CDT build tools, Jakarta annotations API, Mortbay JSP, Orbit aggregation, and EMF builds to stable and release candidate versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eclipse-tracecompass/org.eclipse.tracecompass/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->