### PR TITLE
releng: build with e4.40 by default and enable automatic updates for 12.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.5.4</cbi-plugins.version>
-    <target-platform>tracecompass-e4.39</target-platform>
+    <target-platform>tracecompass-e4.40</target-platform>
 
     <rcptt-version>2.8.1</rcptt-version>
     <!-- Disable GTK3 because it's not quite usable yet and it can make the tests hang (bug in IcedTea http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1736) -->

--- a/rcp/org.eclipse.tracecompass.rcp.branding/plugin_customization.ini
+++ b/rcp/org.eclipse.tracecompass.rcp.branding/plugin_customization.ini
@@ -2,3 +2,6 @@ org.eclipse.e4.ui.css.swt.theme/themeid=org.eclipse.e4.ui.css.theme.e4_default
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
 org.eclipse.ui/defaultPerspectiveId=org.eclipse.linuxtools.lttng2.kernel.ui.perspective
 org.eclipse.help/HELP_DATA=help_data.xml
+# check for updates every time Trace Compass starts. This should only be done in stable releases.
+# https://bugs.eclipse.org/bugs/show_bug.cgi?id=499247
+org.eclipse.equinox.p2.ui.sdk.scheduler/enabled=true

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.23-e4.25/tracing.product
@@ -159,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.26-e4.29/tracing.product
@@ -159,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.30-e4.38/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy-e4.30-e4.38/tracing.product
@@ -160,7 +160,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/legacy/tracing.product
@@ -159,7 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
+++ b/rcp/org.eclipse.tracecompass.rcp.product/tracing.product
@@ -158,7 +158,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/stable/rcp-repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/src/org/eclipse/tracecompass/tmf/ui/swtbot/tests/project/AddProjectNatureTest.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui.swtbot.tests/src/org/eclipse/tracecompass/tmf/ui/swtbot/tests/project/AddProjectNatureTest.java
@@ -90,7 +90,7 @@ public class AddProjectNatureTest {
     private static final String CUSTOMIZE_VIEW_DIALOG_TITLE_4_7 = "Filters and Customization";
     private static final String CUSTOMIZE_VIEW_RESOURCES_FILTER = ".* resources";
     private static final String CUSTOMIZE_VIEW_SHADOW_FILTER = "Trace Compass Shadow Projects";
-    private static final String OK_BUTTON = "OK";
+    private static final String APPLY_BUTTON = "Apply";
 
     private static IWorkspaceRoot fWorkspaceRoot;
     private static IProject fSomeProject;
@@ -249,6 +249,6 @@ public class AddProjectNatureTest {
             item.toggleCheck();
         }
 
-        shell.bot().button(OK_BUTTON).click();
+        shell.bot().button(APPLY_BUTTON).click();
     }
 }


### PR DESCRIPTION
### What it does

- releng: build with tracecompass-e4.40 target by default
- tmf.ui.swtbot.tests: Modify button name to make the test work
- releng: enable automatic updates in the RCP for 12.0 release
### How to test

Build Trace Compass
### Follow-ups

N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
