### PR TITLE
Synchronize the start/stop LTTng trace in Control view with the external trace

### DIFF
--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/META-INF/MANIFEST.MF
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.5.0.qualifier
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.tracecompass.lttng2.control.ui;singleton:=true
 Bundle-Activator: org.eclipse.tracecompass.internal.lttng2.control.ui.Activator
@@ -42,6 +42,7 @@ Export-Package: org.eclipse.tracecompass.internal.lttng2.control.ui;x-friends:="
  org.eclipse.tracecompass.internal.lttng2.control.ui.views.model.impl;x-friends:="org.eclipse.tracecompass.lttng2.control.ui.tests,org.eclipse.tracecompass.lttng2.control.ui.swtbot.tests",
  org.eclipse.tracecompass.internal.lttng2.control.ui.views.preferences;x-friends:="org.eclipse.tracecompass.lttng2.control.ui.tests",
  org.eclipse.tracecompass.internal.lttng2.control.ui.views.property;x-friends:="org.eclipse.tracecompass.lttng2.control.ui.tests",
- org.eclipse.tracecompass.internal.lttng2.control.ui.views.service;x-friends:="org.eclipse.tracecompass.lttng2.control.ui.tests,org.eclipse.tracecompass.lttng2.control.ui.swtbot.tests"
+ org.eclipse.tracecompass.internal.lttng2.control.ui.views.service;x-friends:="org.eclipse.tracecompass.lttng2.control.ui.tests,org.eclipse.tracecompass.lttng2.control.ui.swtbot.tests",
+ org.eclipse.tracecompass.lttng2.control.ui.views.signals
 Import-Package: com.google.common.collect
 Automatic-Module-Name: org.eclipse.tracecompass.lttng2.control.ui

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/handlers/StartHandler.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/handlers/StartHandler.java
@@ -15,8 +15,15 @@ package org.eclipse.tracecompass.internal.lttng2.control.ui.views.handlers;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.TraceSessionState;
+import org.eclipse.tracecompass.internal.lttng2.control.ui.Activator;
 import org.eclipse.tracecompass.internal.lttng2.control.ui.views.model.impl.TraceSessionComponent;
+import org.eclipse.tracecompass.lttng2.control.ui.views.signals.ExternalTraceStartSignal;
+import org.eclipse.tracecompass.lttng2.control.ui.views.signals.LTTngSessionStartSignal;
+import org.eclipse.tracecompass.lttng2.control.ui.views.signals.LTTngSessionStopSignal;
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignalHandler;
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
 
 /**
  * <p>
@@ -26,6 +33,20 @@ import org.eclipse.tracecompass.internal.lttng2.control.ui.views.model.impl.Trac
  * @author Bernd Hufmann
  */
 public class StartHandler extends ChangeSessionStateHandler {
+
+    /**
+     * Constructor
+     */
+    public StartHandler() {
+        super();
+        TmfSignalManager.register(this);
+    }
+
+    @Override
+    public void dispose() {
+        TmfSignalManager.deregister(this);
+        super.dispose();
+    }
 
     // ------------------------------------------------------------------------
     // Accessors
@@ -43,5 +64,35 @@ public class StartHandler extends ChangeSessionStateHandler {
     @Override
     public void changeState(TraceSessionComponent session, IProgressMonitor monitor) throws ExecutionException {
         session.startSession(monitor);
+        TmfSignalManager.dispatchSignal(
+                new LTTngSessionStartSignal(session));
+    }
+
+    /**
+     * Handle the external trace start signal
+     * @param signal contains the information of the start external trace
+     */
+    @TmfSignalHandler
+    public void handle(ExternalTraceStartSignal signal) {
+        Display.getDefault().asyncExec(() -> {
+            try {
+                execute(null);
+            } catch (ExecutionException e) {
+                Activator.getDefault().logError("Failed to synchronize with the external trace start signal", e); //$NON-NLS-1$
+            }
+        });
+    }
+
+    /**
+     * Handle the LTTng session stop signal
+     * @param signal contains the information of the stop LTTng session
+     */
+    @TmfSignalHandler
+    public void handle(LTTngSessionStopSignal signal) {
+        Display.getDefault().asyncExec(() -> {
+            if (signal.getSource() instanceof TraceSessionComponent session && !this.fSessions.contains(session)) {
+                this.fSessions.add(session);
+            }
+        });
     }
 }

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/handlers/StopHandler.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/internal/lttng2/control/ui/views/handlers/StopHandler.java
@@ -15,8 +15,15 @@ package org.eclipse.tracecompass.internal.lttng2.control.ui.views.handlers;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.tracecompass.internal.lttng2.control.core.model.TraceSessionState;
+import org.eclipse.tracecompass.internal.lttng2.control.ui.Activator;
 import org.eclipse.tracecompass.internal.lttng2.control.ui.views.model.impl.TraceSessionComponent;
+import org.eclipse.tracecompass.lttng2.control.ui.views.signals.ExternalTraceStopSignal;
+import org.eclipse.tracecompass.lttng2.control.ui.views.signals.LTTngSessionStartSignal;
+import org.eclipse.tracecompass.lttng2.control.ui.views.signals.LTTngSessionStopSignal;
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignalHandler;
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
 
 /**
  * <p>
@@ -26,6 +33,20 @@ import org.eclipse.tracecompass.internal.lttng2.control.ui.views.model.impl.Trac
  * @author Bernd Hufmann
  */
 public class StopHandler extends ChangeSessionStateHandler {
+
+    /**
+     * Constructor
+     */
+    public StopHandler() {
+        super();
+        TmfSignalManager.register(this);
+    }
+
+    @Override
+    public void dispose() {
+        TmfSignalManager.deregister(this);
+        super.dispose();
+    }
 
     // ------------------------------------------------------------------------
     // Accessors
@@ -43,5 +64,35 @@ public class StopHandler extends ChangeSessionStateHandler {
     @Override
     public void changeState(TraceSessionComponent session, IProgressMonitor monitor) throws ExecutionException {
         session.stopSession(monitor);
+        TmfSignalManager.dispatchSignal(
+                new LTTngSessionStopSignal(session));
+    }
+
+    /**
+     * Handle the external trace stop signal
+     * @param signal contains the information of the stop external trace
+     */
+    @TmfSignalHandler
+    public void handle(ExternalTraceStopSignal signal) {
+        Display.getDefault().asyncExec(() -> {
+            try {
+                execute(null);
+            } catch (ExecutionException e) {
+                Activator.getDefault().logError("Failed to synchronize with the external trace stop signal", e); //$NON-NLS-1$
+            }
+        });
+    }
+
+    /**
+     * Handle the LTTng session start signal
+     * @param signal contains the information of the start LTTng session
+     */
+    @TmfSignalHandler
+    public void handle(LTTngSessionStartSignal signal) {
+        Display.getDefault().asyncExec(() -> {
+            if (signal.getSource() instanceof TraceSessionComponent session && !this.fSessions.contains(session)) {
+                this.fSessions.add(session);
+            }
+        });
     }
 }

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/ExternalTraceStartSignal.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/ExternalTraceStartSignal.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Renesas Electronics Corp.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Tuan Can - Initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.lttng2.control.ui.views.signals;
+
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignal;
+
+/**
+ * Signal notify that the External trace have been started
+ * @since 1.5
+ */
+public class ExternalTraceStartSignal extends TmfSignal{
+
+    private final String sessionName;
+
+    /**
+     * Constructor
+     * @param source input source
+     * @param sessionName external trace
+     */
+    public ExternalTraceStartSignal(Object source, String sessionName) {
+        super(source);
+        this.sessionName = sessionName;
+    }
+
+    /**
+     * Get the name of the external trace
+     * @return External trace name
+     */
+    public String getSessionName() {
+        return sessionName;
+    }
+}

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/ExternalTraceStopSignal.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/ExternalTraceStopSignal.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Renesas Electronics Corp.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Tuan Can - Initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.lttng2.control.ui.views.signals;
+
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignal;
+
+/**
+ * Signal notify that the External trace have been stopped
+ * @since 1.5
+ */
+public class ExternalTraceStopSignal extends TmfSignal{
+
+    private final String sessionName;
+
+    /**
+     * Constructor
+     * @param source input source
+     * @param sessionName external trace
+     */
+    public ExternalTraceStopSignal(Object source, String sessionName) {
+        super(source);
+        this.sessionName = sessionName;
+    }
+
+    /**
+     * Get the name of the external trace
+     * @return External trace name
+     */
+    public String getSessionName() {
+        return sessionName;
+    }
+}

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/LTTngSessionDestroySignal.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/LTTngSessionDestroySignal.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Renesas Electronics Corp.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Tuan Can - Initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.lttng2.control.ui.views.signals;
+
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignal;
+
+/**
+ * Signal notify that the LTTng session have been destroyed
+ * @since 1.5
+ */
+public class LTTngSessionDestroySignal extends TmfSignal{
+
+    private final String sessionName;
+
+    /**
+     * Constructor
+     * @param source input source
+     * @param sessionName LTTng session name
+     */
+    public LTTngSessionDestroySignal(Object source, String sessionName) {
+        super(source);
+        this.sessionName = sessionName;
+    }
+
+    /**
+     * Get the name of the LTTng session
+     * @return LTTng session name
+     */
+    public String getSessionName() {
+        return sessionName;
+    }
+}

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/LTTngSessionStartSignal.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/LTTngSessionStartSignal.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Renesas Electronics Corp.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Tuan Can - Initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.lttng2.control.ui.views.signals;
+
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignal;
+
+/**
+ * Signal notify that the LTTng session have been started
+ * @since 1.5
+ */
+public class LTTngSessionStartSignal extends TmfSignal{
+
+
+    /**
+     * Constructor
+     * @param source input source
+     */
+    public LTTngSessionStartSignal(Object source) {
+        super(source);
+    }
+}

--- a/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/LTTngSessionStopSignal.java
+++ b/lttng/org.eclipse.tracecompass.lttng2.control.ui/src/org/eclipse/tracecompass/lttng2/control/ui/views/signals/LTTngSessionStopSignal.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Renesas Electronics Corp.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Tuan Can - Initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.lttng2.control.ui.views.signals;
+
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignal;
+
+/**
+ * Signal notify that the LTTng session have been stopped
+ * @since 1.5
+ */
+public class LTTngSessionStopSignal extends TmfSignal{
+
+    /**
+     * Constructor
+     * @param source input source
+     */
+    public LTTngSessionStopSignal(Object source) {
+        super(source);
+    }
+}


### PR DESCRIPTION
Synchronize the start/stop LTTng trace in Control view with the external trace

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
I want to synchronize the start/stop action in the Control view with the start/stop action in my 3rd trace view, so I can synchronize the LTTng tracing with my 3rd tool tracing. Therefore, I want to:
+) Create new signals to sync the start/stop actions in the Control view with the other views
+) Update the start/stop handler classes to sync the start/stop LTTng trace action  with the other views

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Test the start/stop action in the Control view: In case using the Trace Compass software, the start/stop action in the Control view still works normally, as it does not contain my 3rd view.
### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal-based session lifecycle for LTTng (start/stop/destroy) to improve coordination and UI responsiveness.
  * External trace start/stop integration so external traces participate in session management workflows; UI handlers now react to these events.

* **Chores**
  * Plugin version bumped to 1.5.0.

* **Tests**
  * UI test timing adjusted to wait for Apply/OK flows to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->