### PR TITLE
ctf: fix struct member duplicating issue

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/struct/StructParser.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/struct/StructParser.java
@@ -221,8 +221,8 @@ public final class StructParser extends AbstractScopedCommonTreeParser {
                                 throw new ParseException("Member class requires 'name' and 'field-class' properties"); //$NON-NLS-1$
                             }
                             String name = nameElement.getAsString();
-                            JsonStructureFieldMemberMetadataNode childNode = new JsonStructureFieldMemberMetadataNode(memberNode, "", "", name, fieldClass.getAsJsonObject()); //$NON-NLS-1$ //$NON-NLS-2$
-                            memberNode.addChild(childNode);
+                            // The constructor adds the reference to the parent automatically
+                            new JsonStructureFieldMemberMetadataNode(memberNode, "", "", name, fieldClass.getAsJsonObject()); //$NON-NLS-1$ //$NON-NLS-2$
                         }
                     }
                     structBody = memberNode;


### PR DESCRIPTION
### What it does

Constructing the member field only as the constructor already adds the member to its parent. Previously the struct member was added twice causing an error. Fixes #375 
### How to test

Opening the trace that it provided in the issue.
### Follow-ups

N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal metadata parsing to simplify how structural metadata elements are created and attached during JSON processing, reducing code complexity and improving maintainability without changing outward behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->