### PR TITLE
ctf: Support CTF2 empty structs

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/struct/StructParser.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/metadata/tsdl/struct/StructParser.java
@@ -22,6 +22,7 @@ import org.eclipse.tracecompass.ctf.core.trace.CTFTrace;
 import org.eclipse.tracecompass.ctf.parser.CTFParser;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.AbstractScopedCommonTreeParser;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.CTFAntlrMetadataNode;
+import org.eclipse.tracecompass.internal.ctf.core.event.metadata.CTFJsonMetadataNode;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.JsonStructureFieldMemberMetadataNode;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.JsonStructureFieldMetadataNode;
 import org.eclipse.tracecompass.internal.ctf.core.event.metadata.ParseException;
@@ -281,6 +282,9 @@ public final class StructParser extends AbstractScopedCommonTreeParser {
                     throw new ParseException("struct " + structName //$NON-NLS-1$
                             + " is not defined"); //$NON-NLS-1$
                 }
+            } else if (struct instanceof CTFJsonMetadataNode) {
+                /* In CTF2, empty structs should be supported */
+                structDeclaration = new StructDeclaration(structAlign);
             } else {
                 /* !Name and !body */
 


### PR DESCRIPTION
### What it does

Allow empty structs with no names to be read as they are valid ctf2 structs. Fixes #378 
### How to test

Open the attached trace of the issue
### Follow-ups

N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty structs in CTF2 JSON format. Previously, empty structs without a name and body would cause an error. They are now properly processed and supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->