### PR TITLE
ctf: remove sequence bit length calculation as it cannot be known

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/types/SequenceDeclaration.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/internal/ctf/core/event/types/SequenceDeclaration.java
@@ -116,11 +116,15 @@ public class SequenceDeclaration extends CompoundDeclaration {
         }
 
         long length = lengthDefinition.getValue();
-        long maxBits = length * fElemType.getMaximumSize();
-        if ((length > Integer.MAX_VALUE) || (maxBits > Integer.MAX_VALUE) || (!input.canRead((int) maxBits))) {
+        if (length > Integer.MAX_VALUE ) {
             throw new CTFException("Sequence length too long " + length); //$NON-NLS-1$
         }
-
+        if (fElemType.getMaximumSize() != Integer.MAX_VALUE) {
+            long maxBits = length * fElemType.getMaximumSize();
+            if (maxBits > Integer.MAX_VALUE || !input.canRead((int) maxBits)) {
+                throw new CTFException("Sequence length too long " + length); //$NON-NLS-1$
+            }
+        }
         // Explicitly align to support 0-length sequences
         alignRead(input);
 


### PR DESCRIPTION
### What it does

Remove the check for maximum size, as we do not yet know the size of the member fields at this point, so it is impossible to calculate the maximum number of bits that the sequence will take. Fixes #379 

### How to test

Open the issue attached trace.
### Follow-ups

N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation logic in sequence declarations to more efficiently detect overflow conditions and validate capacity constraints, providing better error detection for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->