### PR TITLE
Add fallback in PieChartViewer refresh to not show empty pie chart viewer

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/piecharts/TmfPieChartViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/piecharts/TmfPieChartViewer.java
@@ -422,8 +422,9 @@ public class TmfPieChartViewer extends Composite {
 
                 // Check if the selection is empty or if
                 // there is enough event types to show in the piecharts
+                // if there aren't enough, show the global pie chart
                 if (nbEventsType < 2) {
-                    getCurrentState().newEmptySelection(this);
+                    getCurrentState().newGlobalEntries(this);
                 } else {
                     getCurrentState().newSelection(this);
                 }


### PR DESCRIPTION
… but not enough event types in the selection, show the global pie chart instead.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
In `org.eclipse.tracecompass.internal.tmf.ui.viewers.piecharts.TmfPieChartViewer.refresh`, instead of making an empty viewer when less than two events types are selected, show  the change shows the global pie chart.

### How to test

In statistics view, select only one event type and see that instead of "No Data" being shown, the global pie chart is left.

### Follow-ups
Addresses #412 
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The pie chart viewer now falls back to showing relevant global data (rather than an empty state) when the current selection has too few non-zero event types, improving visibility and avoiding blank charts for small/insufficient selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->