### PR TITLE
Add all discovered analyses to map used in getter function used by getDependentAnalyses

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/TmfTrace.java
+++ b/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/trace/TmfTrace.java
@@ -850,6 +850,19 @@ public abstract class TmfTrace extends TmfEventProvider implements ITmfTrace, IT
         Set<String> oldAnalysisModulesKeys = new HashSet<>(previousAnalysisModules.keySet());
         Set<String> keys = new HashSet<>(newAnalysisModules.keySet());
 
+        /* Get all modules in the fAnalysisModules Map to allow 
+        for dependent analysis builds */
+        synchronized(fAnalysisModules){
+          for (String key : keys) {
+              if (!fAnalysisModules.containsKey(key)) {
+                IAnalysisModule module = newAnalysisModules.get(key);
+                  if (module != null) {
+                      fAnalysisModules.put(key, module);
+                  }
+              }
+            }
+        }
+
         for (String key : keys) {
             IAnalysisModule module = newAnalysisModules.remove(key);
             if (!oldAnalysisModulesKeys.contains(key)) {
@@ -861,6 +874,8 @@ public abstract class TmfTrace extends TmfEventProvider implements ITmfTrace, IT
             } else {
                 oldAnalysisModulesKeys.remove(key);
                 if (module != null) {
+                    /* Remove the newly computed analysis module since it already
+                    was done previously*/
                     module.dispose();
                 }
             }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Addresses #415 
<!-- Include relevant issues and describe how they are addressed. -->

### How to test

* Create numerous automatic modules and set them in any order in the plugin.xml
* Inside of any analysis, make one depend on the others
* Observe, with a step debugger, that the dependent analyses are acquired and scheduled before the analysis that depends on them runs
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dependent analysis modules during initialization to ensure proper module registration and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->