### PR TITLE
releng: Update e4.40 and eStaging targets to 2026-06 release

### DIFF
--- a/doc/org.eclipse.tracecompass.doc.user/doc/User-Guide.mediawiki
+++ b/doc/org.eclipse.tracecompass.doc.user/doc/User-Guide.mediawiki
@@ -4381,7 +4381,7 @@ Alice kills the program, and immediately the server speeds up. She then goes to 
 
 = Trace Compass Incubator =
 
-To install features from the Trace Compass incubator, use the following update site URL: https://download.eclipse.org/tracecompass.incubator/master/repository/.
+To install features from the Trace Compass incubator, use the following update site URL: https://download.eclipse.org/tracecompass.incubator/stable-12.0/repository/.
 
 If you're using the Trace Compass RCP, there's an easy method to install incubator features. See the [https://archive.eclipse.org/tracecompass/doc/stable/org.eclipse.tracecompass.rcp.doc.user/Trace-Compass-Incubator.html Trace Compass RCP documentation]
 

--- a/doc/org.eclipse.tracecompass.rcp.doc.user/doc/User-Guide.mediawiki
+++ b/doc/org.eclipse.tracecompass.rcp.doc.user/doc/User-Guide.mediawiki
@@ -80,7 +80,7 @@ Then click '''Finish'''. It will open Eclipse's main installation wizard. Follow
 
 === From an update site ===
 
-Optionally, one can also install the incubator features using the following update site URL: https://download.eclipse.org/tracecompass.incubator/master/repository/.
+Optionally, one can also install the incubator features using the following update site URL: https://download.eclipse.org/tracecompass.incubator/stable-12.0/repository/.
 
 == Update incubator features ==
 

--- a/rcp/org.eclipse.tracecompass.rcp.incubator.ui/plugin.xml
+++ b/rcp/org.eclipse.tracecompass.rcp.incubator.ui/plugin.xml
@@ -16,7 +16,7 @@
                   style="push">
 	           <parameter
 	               name="org.eclipse.equinox.p2.ui.discovery.commands.RepositoryParameter"
-	               value="https://download.eclipse.org/tracecompass.incubator/master/repository/">
+	               value="https://download.eclipse.org/tracecompass.incubator/stable-12.0/repository/">
 	           </parameter>
             </command>
          </menu>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.40.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.40.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.40" sequenceNumber="4">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.40" sequenceNumber="6">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.11/"/>
@@ -10,7 +10,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc1/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.5/cdt-12.5.0a/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -90,7 +90,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260528-0011/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.40/R-4.40-202606010713/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -100,7 +100,7 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/S-3.42M2-20260429095058/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/R-3.42.0-20260602145033/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="268">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="271">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.11/"/>
@@ -10,7 +10,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc1/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.5/cdt-12.5.0a/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -90,7 +90,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260528-0011/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.40/R-4.40-202606010713/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -100,7 +100,7 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/S-3.42M2-20260429095058/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/R-3.42.0-20260602145033/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>

--- a/tmf/org.eclipse.tracecompass.tmf/p2.inf
+++ b/tmf/org.eclipse.tracecompass.tmf/p2.inf
@@ -1,10 +1,10 @@
 instructions.configure=\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:0,location:http${#58}//download.eclipse.org/tracecompass/master/repository);\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:1,location:http${#58}//download.eclipse.org/tracecompass/master/repository);\
-org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:0,location:http${#58}//download.eclipse.org/tracecompass.incubator/master/repository);\
-org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:1,location:http${#58}//download.eclipse.org/tracecompass.incubator/master/repository);\
+org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:0,location:http${#58}//download.eclipse.org/tracecompass.incubator/stable-12.0/repository);\
+org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:1,location:http${#58}//download.eclipse.org/tracecompass.incubator/stable-12.0/repository);\
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/tracecompass/master/repository,type:0,name:Trace Compass,enabled:false); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/tracecompass/master/repository,type:1,name:Trace Compass,enabled:false); \
-org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/tracecompass.incubator/master/repository,type:0,name:Trace Compass Incubator,enabled:false); \
-org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/tracecompass.incubator/master/repository,type:1,name:Trace Compass Incubator,enabled:false);
+org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/tracecompass.incubator/stable-12.0/repository,type:0,name:Trace Compass Incubator,enabled:false); \
+org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/tracecompass.incubator/stable-12.0/repository,type:1,name:Trace Compass Incubator,enabled:false);
 


### PR DESCRIPTION
### What it does

- Update target for the 2026-06 release

### How to test

Build Trace Compass with e4.40 or staging target.
### Follow-ups
N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
