### PR TITLE
releng: 12.0.0 release

### DIFF
--- a/TraceCompass.setup
+++ b/TraceCompass.setup
@@ -75,7 +75,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="tracecompass-e4.39"
+      defaultValue="tracecompass-e4.40"
       storageURI="scope://Workspace"
       label="Target Platform">
     <choice
@@ -139,6 +139,9 @@
         value="tracecompass-e4.39"
         label="Trace Compass Eclipse 2026-03 - 4.39"/>
     <choice
+        value="tracecompass-e4.40"
+        label="Trace Compass Eclipse 2026-06 - 4.40"/>
+    <choice
         value="tracecompass-eStaging"
         label="Trace Compass Eclipse Latest"/>
     <description>Choose the compatibly level of the target platform</description>
@@ -175,15 +178,15 @@
     <setupTask
         xsi:type="pde:TargetPlatformTask"
         id="tracecompass-baseline-resolve"
-        name="tracecompass-baseline-11.3.0"
+        name="tracecompass-baseline-12.0.0"
         activate="false">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask
         xsi:type="pde:APIBaselineFromTargetTask"
-        id="tracecompass-baseline-11.3.0"
+        id="tracecompass-baseline-12.0.0"
         name="Trace Compass Baseline"
-        targetName="tracecompass-baseline-11.3.0">
+        targetName="tracecompass-baseline-12.0.0">
       <description>Trace Compass Baseline</description>
     </setupTask>
     <setupTask

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho-use-project-settings>true</tycho-use-project-settings>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-tracecompass/org.eclipse.tracecompass</tycho.scmUrl>
     <cbi-plugins.version>1.5.4</cbi-plugins.version>
-    <target-platform>tracecompass-e4.39</target-platform>
+    <target-platform>tracecompass-e4.40</target-platform>
 
     <rcptt-version>2.8.1</rcptt-version>
     <!-- Disable GTK3 because it's not quite usable yet and it can make the tests hang (bug in IcedTea http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1736) -->

--- a/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-12.0.0.target
+++ b/releng/org.eclipse.tracecompass.target/baseline/tracecompass-baseline-12.0.0.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="tracecompass-baseline-11.3.0" sequenceNumber="1">
+<?pde version="3.8"?><target name="tracecompass-baseline-12.0.0" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.analysis.counters.core" version="0.0.0"/>
@@ -46,11 +46,11 @@
 <unit id="org.eclipse.tracecompass.tmf.remote.core" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tracecompass/releases/11.3.0/repository/"/>
+<repository location="https://download.eclipse.org/tracecompass/releases/12.0.0/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.core.runtime" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2026-03"/>
+<repository location="https://download.eclipse.org/releases/2026-06"/>
 </location>
 </locations>
 </target>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-e4.40.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-e4.40.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.40" sequenceNumber="5">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-e4.40" sequenceNumber="6">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.11/"/>
@@ -10,7 +10,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc2/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.5/cdt-12.5.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -90,7 +90,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260601-0713/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.40/R-4.40-202606010713/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -100,7 +100,7 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/S-3.42RC1-20260602145033/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/R-3.42.0-20260602145033/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
+++ b/releng/org.eclipse.tracecompass.target/tracecompass-eStaging.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="270">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="tracecompass-eStaging" sequenceNumber="271">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.11/"/>
@@ -10,7 +10,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc2/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.5/cdt-12.5.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -90,7 +90,7 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260601-0713/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.40/R-4.40-202606010713/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tracecompass.testtraces.tracecompass-test-traces-ctf" version="1.7.2"/>
@@ -100,7 +100,7 @@
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/S-3.42RC1-20260602145033/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.42.0/R-3.42.0-20260602145033/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>


### PR DESCRIPTION
### What it does

- releng: build with tracecompass-e4.40 target by default
- releng: Update e4.40 and eStaging targets to 2026-06 release
- releng: add Trace Compass 12.0.0 baseline
- releng: Update OOMPH setup file for 12.0.0

### How to test

Build Trace Compass
### Follow-ups

N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded default Eclipse target platform from 4.39 to 4.40.
  * Updated PDE API baseline to version 12.0.0.
  * Updated build/repository definitions for CDT, Eclipse 4.40 and WebTools to align with the latest release artifacts and build lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->