### PR TITLE
linux.core: fix irq exit handler not finding quark

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IrqExitHandler.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IrqExitHandler.java
@@ -56,6 +56,10 @@ public class IrqExitHandler extends KernelEventHandler {
                 break;
             }
         }
+        if (quark == ITmfStateSystem.INVALID_ATTRIBUTE) {
+            /* No irq entry was found */
+            return;
+        }
         String name = ss.getAttributeName(quark);
         /* Put this IRQ back to inactive in the resource tree */
         long timestamp = KernelEventHandlerUtils.getTimestamp(event);


### PR DESCRIPTION


### What it does

The IRQ exit handler assumes that a quark will always be found. This patch fixes that assumption, and avoid making the whole Linux Analysis fail. Fixes #423.

### How to test

Run with the trace submitted in #423.
### Follow-ups
N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid IRQ state updates when no matching IRQ entry is active.
  * Improved stability by safely skipping processing if no valid IRQ attribute is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->