### PR TITLE
ctf: fix bits interpreted as bytes in index creation

### DIFF
--- a/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFTrace.java
+++ b/ctf/org.eclipse.tracecompass.ctf.core/src/org/eclipse/tracecompass/ctf/core/trace/CTFTrace.java
@@ -616,7 +616,7 @@ public class CTFTrace implements IDefinitionScope {
                         // skip packet as the position must be invalid.
                         continue;
                     }
-                    ByteBuffer byteBuffer = SafeMappedByteBuffer.map(fc, MapMode.READ_ONLY, (packetPosition + getPacketHeader().getMaximumSize()) / Byte.SIZE, packetContextDecl.getMaximumSize());
+                    ByteBuffer byteBuffer = SafeMappedByteBuffer.map(fc, MapMode.READ_ONLY, (packetPosition + getPacketHeader().getMaximumSize()) / Byte.SIZE, packetContextDecl.getMaximumSize() / Byte.SIZE);
                     BitBuffer bitBuffer = new BitBuffer(byteBuffer);
                     StructDefinition packetContextFromStream = packetContextDecl.createDefinition(this, ILexicalScope.PACKET_HEADER, bitBuffer);
 


### PR DESCRIPTION
### What it does

Fix how packet contexts are mapped into memory. The packet context size was in bits not bytes, a division was added to fix that issue.

### How to test

Use the following trace:  [the-trace.zip](https://github.com/user-attachments/files/30747066/the-trace.zip)

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed packet context indexing to ensure trace data is mapped using the correct byte-based size.
  * Improved reliability when reading and navigating CTF traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->